### PR TITLE
Polyfill CustomEvent in Node.js

### DIFF
--- a/packages/pglite/src/index.ts
+++ b/packages/pglite/src/index.ts
@@ -3,9 +3,24 @@ import EmPostgresFactory, { type EmPostgres } from "../release/postgres.js";
 import type { Filesystem } from "./fs.js";
 import { MemoryFS } from "./memoryfs.js";
 import { IdbFs } from "./idbfs.js";
-import { nodeValues } from "./utils.js";
+import { IN_NODE, nodeValues } from "./utils.js";
 
 type FilesystemType = "nodefs" | "idbfs" | "memoryfs";
+
+if (IN_NODE && typeof CustomEvent === 'undefined') {
+  (globalThis as any).CustomEvent = class CustomEvent<T> extends Event {
+    #detail: T | null;
+
+    constructor(type: string, options?: EventInit & { detail: T }) {
+      super(type, options);
+      this.#detail = options?.detail ?? null;
+    }
+
+    get detail() {
+      return this.#detail;
+    }
+  }
+}
 
 export class PGlite {
   readonly dataDir?: string;


### PR DESCRIPTION
I noticed that it fails to run in Node.js because it relied on `CustomEvent` as a global which isn't exposed in Node.js unless you pass `--experimental-global-customevent`.

This PR adds a polyfill for `CustomEvent` when in Node.js. I tested this and it now works both on local Node.js as well as in WebContainer (which you could test once a new version is released). If you wanna try it yourself, you can fork [this project](https://stackblitz.com/edit/node-oqtitn?file=index.js) and update the version once there's a new one that includes the fix.