### PR TITLE
docs: Add git submodule initialization as build prerequirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,12 +87,14 @@ Parameterized queries are not currently supported, but this will be added soon.
 
 There are a couple of prerequisites:
 
-- the Postgres build toolchain
-- emscripten version 3.1.25
+- the Postgres build toolchain - https://www.postgresql.org/download/
+- emscripten version 3.1.25 - https://emscripten.org/docs/getting_started/downloads.html
 
 To build, checkout the repo, then:
 
 ```
+git submodule init
+git submodule update
 cd ./pglite/packages/pglite
 emsdk install 3.1.25
 emsdk activate 3.1.25

--- a/README.md
+++ b/README.md
@@ -93,8 +93,7 @@ There are a couple of prerequisites:
 To build, checkout the repo, then:
 
 ```
-git submodule init
-git submodule update
+git submodule update --init
 cd ./pglite/packages/pglite
 emsdk install 3.1.25
 emsdk activate 3.1.25


### PR DESCRIPTION
Git submodule need to be initialized and updated before running build, as local `postgres` source code is required.