### PR TITLE
feature: PL/PGSQL Support via static linking

### DIFF
--- a/packages/pglite/Makefile
+++ b/packages/pglite/Makefile
@@ -1,15 +1,22 @@
 .PHONY: debug-build debug-datadir build datadir
 
-build:
+build-configure:
 	EMCC_CFLAGS="-Wl,--allow-undefined" \
-	emconfigure ./configure CFLAGS='-O3' \
+	emconfigure ./configure CFLAGS='-O2' \
 		--without-readline \
 		--without-zlib \
 		--disable-thread-safety \
 		--disable-spinlocks \
 		--with-system-tzdata=/usr/share/zoneinfo
-	EMCC_CFLAGS="-sALLOW_MEMORY_GROWTH=1 -sERROR_ON_UNDEFINED_SYMBOLS=0 -sWARN_ON_UNDEFINED_SYMBOLS=0 -sTOTAL_MEMORY=65536000 -sEMULATE_FUNCTION_POINTER_CASTS=1 -sMODULARIZE=1 -sEXPORT_ES6=1 -sEXPORTED_FUNCTIONS=_main,_ExecProtocolMsg,_malloc,_free -sEXPORTED_RUNTIME_METHODS=ccall,cwrap,FS" \
+		--with-system-tzdata=/usr/share/zoneinfo
+
+build:
+	EMCC_CFLAGS="--profiling -s SIDE_MODULE=1 -sERROR_ON_UNDEFINED_SYMBOLS=0 -sWARN_ON_UNDEFINED_SYMBOLS=0 -sTOTAL_MEMORY=65536000 -sMODULARIZE=1 -sEXPORT_ES6=1 -sEXPORTED_RUNTIME_METHODS='FS'" \
+		emmake make -C src/pl/plpgsql MAKELEVEL=0
+
+	EMCC_CFLAGS="--profiling -sALLOW_MEMORY_GROWTH=1 -sERROR_ON_UNDEFINED_SYMBOLS=0 -sWARN_ON_UNDEFINED_SYMBOLS=0 -sTOTAL_MEMORY=65536000 -sEMULATE_FUNCTION_POINTER_CASTS=1 -sMODULARIZE=1 -sEXPORT_ES6=1 -sEXPORTED_FUNCTIONS=_main,_ExecProtocolMsg,_malloc,_free -sEXPORTED_RUNTIME_METHODS=ccall,cwrap,FS" \
 		emmake make -C src/backend MAKELEVEL=0
+
 	mkdir -p ../packages/pglite/release
 	cp src/backend/postgres ../packages/pglite/release/postgres.js
 	cp src/backend/postgres.wasm ../packages/pglite/release/postgres.wasm
@@ -17,34 +24,17 @@ build:
 
 sharedir:
 	mkdir -p tmp_install
+	
 	DESTDIR="$(abspath tmp_install)" \
 	EMCC_CFLAGS="-sERROR_ON_UNDEFINED_SYMBOLS=0 -sWARN_ON_UNDEFINED_SYMBOLS=0 -sTOTAL_MEMORY=65536000 -sEMULATE_FUNCTION_POINTER_CASTS=1 -sMODULARIZE=1 -sEXPORT_ES6=1 -sEXPORTED_RUNTIME_METHODS='FS'" \
 		emmake make MAKELEVEL=0 -C src/backend/ install
-	node ../packages/pglite/scripts/modify-share.js
-	cd ../packages/pglite/release && \
-	`em-config EMSCRIPTEN_ROOT`/tools/file_packager share.data --preload ../../../postgres/tmp_install/usr/local/pgsql/share@/usr/local/pgsql/share --js-output=share.js --export-name=ModuleBase
-	cd ../packages/pglite/ && node scripts/modify-share-js.js
 
-build-debug:
-	EMCC_CFLAGS="-Wl,--allow-undefined" \
-	emconfigure ./configure CFLAGS='-Oz' \
-		--without-readline \
-		--without-zlib \
-		--disable-thread-safety \
-		--disable-spinlocks \
-		--with-system-tzdata=/usr/share/zoneinfo
-	EMCC_CFLAGS="-sERROR_ON_UNDEFINED_SYMBOLS=0 -sWARN_ON_UNDEFINED_SYMBOLS=0 -sTOTAL_MEMORY=65536000 -sEMULATE_FUNCTION_POINTER_CASTS=1 -sMODULARIZE=1 -sEXPORT_ES6=1 -sEXPORTED_RUNTIME_METHODS='FS' -sASSERTIONS=2 -sSAFE_HEAP=1" \
-		emmake make -C src/backend MAKELEVEL=0
-	mkdir -p ../packages/pglite/release
-	cp src/backend/postgres ../packages/pglite/release/postgres.js
-	cp src/backend/postgres.wasm ../packages/pglite/release/postgres.wasm
-	cd ../packages/pglite/ && node scripts/modify-postgres-js.js
-
-sharedir-debug:
-	mkdir -p tmp_install
 	DESTDIR="$(abspath tmp_install)" \
-	EMCC_CFLAGS="-sERROR_ON_UNDEFINED_SYMBOLS=0 -sWARN_ON_UNDEFINED_SYMBOLS=0 -sTOTAL_MEMORY=65536000 -sEMULATE_FUNCTION_POINTER_CASTS=1 -sMODULARIZE=1 -sEXPORT_ES6=1 -sEXPORTED_RUNTIME_METHODS='FS' -sASSERTIONS=2 -sSAFE_HEAP=1" \
-		emmake make MAKELEVEL=0 -C src/backend/ install
+	EMCC_CFLAGS="-sERROR_ON_UNDEFINED_SYMBOLS=0 -sWARN_ON_UNDEFINED_SYMBOLS=0 -sTOTAL_MEMORY=65536000 -sEMULATE_FUNCTION_POINTER_CASTS=1 -sMODULARIZE=1 -sEXPORT_ES6=1 -sEXPORTED_RUNTIME_METHODS='FS'" \
+		emmake make MAKELEVEL=0 -C src/pl/plpgsql install
+
+	rm tmp_install/usr/local/pgsql/share/*.sample
+	rm tmp_install/usr/local/pgsql/share/timezonesets/*.txt
 	node ../packages/pglite/scripts/modify-share.js
 	cd ../packages/pglite/release && \
 	`em-config EMSCRIPTEN_ROOT`/tools/file_packager share.data --preload ../../../postgres/tmp_install/usr/local/pgsql/share@/usr/local/pgsql/share --js-output=share.js --export-name=ModuleBase

--- a/packages/pglite/README.md
+++ b/packages/pglite/README.md
@@ -237,6 +237,12 @@ Rows objects are a key / value mapping for each row returned by the query.
 
 The `.query<T>()` method can take a TypeScript type describing the expected shape of the returned rows. *(Note: this is not validated at run time, the result only cast to the provided type)*
 
+## Extensions
+
+PGlite supports the pl/pgsql procedural langue extension, this is included and enabled by default.
+
+In future we plan to support additional extensions, see the [roadmap](#roadmap).
+
 ## How it works
 
 PostgreSQL typically operates using a process forking model; whenever a client initiates a connection, a new process is forked to manage that connection. However, programs compiled with Emscripten - a C to WebAssembly (WASM) compiler - cannot fork new processes, and operates strictly in a single-process mode. As a result, PostgreSQL cannot be directly compiled to WASM for conventional operation.
@@ -253,7 +259,6 @@ PGlite is *Alpha* and under active development, the current roadmap is:
 
 - CI builds [#19](https://github.com/electric-sql/pglite/issues/19)
 - Support Postgres extensions, starting with:
-  - pl_pgsql [#35](https://github.com/electric-sql/pglite/issues/36)
   - pgvector [#18](https://github.com/electric-sql/pglite/issues/18)
   - PostGIS [#11](https://github.com/electric-sql/pglite/issues/11)
 - OPFS support in browser [#9](https://github.com/electric-sql/pglite/issues/9)

--- a/packages/pglite/examples/plpgsql.html
+++ b/packages/pglite/examples/plpgsql.html
@@ -1,0 +1,41 @@
+<script type="module">
+  import { PGlite } from "../dist/index.js";
+
+  console.log("Starting...");
+  const pg = new PGlite(undefined, {
+    // debug: 1,
+  });
+
+  console.log("Waiting for ready...");
+  await pg.waitReady;
+
+  let ret = await pg.exec(`
+    CREATE EXTENSION IF NOT EXISTS plpgsql;
+  `);
+  console.log(ret);
+  
+  await pg.exec(`
+    CREATE OR REPLACE FUNCTION calculate_factorial(n INT) RETURNS INT AS $$
+    DECLARE
+        result INT := 1;
+    BEGIN
+        IF n < 0 THEN
+            RAISE EXCEPTION 'The input cannot be negative.';
+        ELSIF n = 0 OR n = 1 THEN
+            RETURN result;
+        ELSE
+            FOR i IN 2..n LOOP
+                result := result * i;
+            END LOOP;
+            RETURN result;
+        END IF;
+    END;
+    $$ LANGUAGE plpgsql;
+  `);
+
+  ret = await pg.exec(`
+    SELECT calculate_factorial(5) AS result;
+  `);
+  console.log(ret);
+
+</script>

--- a/packages/pglite/package.json
+++ b/packages/pglite/package.json
@@ -29,13 +29,13 @@
   },
   "scripts": {
     "test": "rm -rf ./pgdata-test && concurrently --hide 0 --prefix none -k \"npx http-server --port 3334 ./\" \"sleep 2 && ava tests/*.test.js tests/**/*.test.js\"",
+    "build:configure": "cd ../../postgres/ && make -f ../packages/pglite/Makefile build-configure",
     "build:wasm": "cd ../../postgres/ && make -f ../packages/pglite/Makefile build",
-    "build:wasm:debug": "cd ../../postgres/ && make -f ../packages/pglite/Makefile build-debug",
     "build:sharedir": "cd ../../postgres/ && make -f ../packages/pglite/Makefile sharedir",
-    "build:sharedir:debug": "cd ../../postgres/ && make -f ../packages/pglite/Makefile sharedir-debug",
+    "build:clean": "cd ../../postgres/ && make clean",
     "build:js": "tsup && tsx scripts/bundle-wasm.ts",
-    "build": "npm run build:wasm && npm run build:sharedir && npm run build:js",
-    "build:debug": "npm run build:wasm:debug && npm run build:sharedir:debug && npm run build:js",
+    "build:all": "npm run build:wasm && npm run build:sharedir && npm run build:js",
+    "build": "npm run build:configure && npm run build:all",
     "format": "prettier --write ./src"
   },
   "devDependencies": {

--- a/packages/pglite/src/pglite.ts
+++ b/packages/pglite/src/pglite.ts
@@ -151,7 +151,10 @@ export class PGlite {
     if (firstRun) {
       await this.#firstRun();
     }
-    await this.#runExec("SET search_path TO public;");
+    await this.#runExec(`
+      SET search_path TO public;
+      CREATE EXTENSION IF NOT EXISTS plpgsql;
+    `);
   }
 
   /**

--- a/packages/pglite/tsup.config.ts
+++ b/packages/pglite/tsup.config.ts
@@ -29,4 +29,5 @@ export default defineConfig({
   esbuildPlugins: [
     replaceAssertPlugin,
   ],
+  minify: true,
 })


### PR DESCRIPTION
Replaces #42 

See also https://github.com/electric-sql/postgres-wasm/pull/7

Closes #36 

Dev build: [electric-sql-pglite-0.0.2.tgz](https://github.com/electric-sql/pglite/files/14731639/electric-sql-pglite-0.0.2.tgz)

Install with:

```
npm install ./path/to/electric-sql-pglite-0.0.2.tgz
```