### PR TITLE
fix(pglite): Fix Windows path resolution

### DIFF
--- a/packages/pglite/src/initdb.ts
+++ b/packages/pglite/src/initdb.ts
@@ -1,7 +1,7 @@
 import { PGDATA } from "./fs/index.js";
 import EmPostgresFactory, { type EmPostgres } from "../release/postgres.js";
 import loadPgShare from "../release/share.js";
-import { locatePostgresFile, nodeValues } from "./utils.js";
+import { makeLocateFile, nodeValues } from "./utils.js";
 import { DebugLevel } from "./index.js";
 
 export const DIRS = [
@@ -58,7 +58,7 @@ export async function initDb(dataDir?: string, debug?: DebugLevel) {
         mod.FS.writeFile(PGDATA + "/base/1/PG_VERSION", "15devel");
       },
     ],
-    locateFile: locatePostgresFile,
+    locateFile: await makeLocateFile(),
     ...(debugMode
       ? { print: console.info, printErr: console.error }
       : { print: () => { }, printErr: () => { } }),

--- a/packages/pglite/src/initdb.ts
+++ b/packages/pglite/src/initdb.ts
@@ -1,11 +1,8 @@
 import { PGDATA } from "./fs/index.js";
 import EmPostgresFactory, { type EmPostgres } from "../release/postgres.js";
 import loadPgShare from "../release/share.js";
-import { nodeValues } from "./utils.js";
+import { locatePostgresFile, nodeValues } from "./utils.js";
 import { DebugLevel } from "./index.js";
-
-const PGWASM_URL = new URL("../release/postgres.wasm", import.meta.url);
-const PGSHARE_URL = new URL("../release/share.data", import.meta.url);
 
 export const DIRS = [
   "global",
@@ -61,21 +58,10 @@ export async function initDb(dataDir?: string, debug?: DebugLevel) {
         mod.FS.writeFile(PGDATA + "/base/1/PG_VERSION", "15devel");
       },
     ],
-    locateFile: (base: string, _path: any) => {
-      let path = "";
-      if (base === "share.data") {
-        path = PGSHARE_URL.toString();
-      } else if (base === "postgres.wasm") {
-        path = PGWASM_URL.toString();
-      }
-      if (path?.startsWith("file://")) {
-        path = path.slice(7);
-      }
-      return path;
-    },
+    locateFile: locatePostgresFile,
     ...(debugMode
       ? { print: console.info, printErr: console.error }
-      : { print: () => {}, printErr: () => {} }),
+      : { print: () => { }, printErr: () => { } }),
     arguments: [
       "--boot",
       "-x1",

--- a/packages/pglite/src/pglite.ts
+++ b/packages/pglite/src/pglite.ts
@@ -1,7 +1,7 @@
 import { Mutex } from "async-mutex";
 import EmPostgresFactory, { type EmPostgres } from "../release/postgres.js";
 import { type Filesystem, parseDataDir, loadFs } from "./fs/index.js";
-import { nodeValues } from "./utils.js";
+import { locatePostgresFile, nodeValues } from "./utils.js";
 import { PGEvent } from "./event.js";
 import { parseResults } from "./parse.js";
 import { serializeType } from "./types.js";
@@ -23,9 +23,6 @@ import {
   DatabaseError,
   NoticeMessage,
 } from "pg-protocol/dist/messages.js";
-
-const PGWASM_URL = new URL("../release/postgres.wasm", import.meta.url);
-const PGSHARE_URL = new URL("../release/share.data", import.meta.url);
 
 export class PGlite implements PGliteInterface {
   readonly dataDir?: string;
@@ -119,18 +116,7 @@ export class PGlite implements PGliteInterface {
           "/pgdata",
           "template1",
         ],
-        locateFile: (base: string, _path: any) => {
-          let path = "";
-          if (base === "share.data") {
-            path = PGSHARE_URL.toString();
-          } else if (base === "postgres.wasm") {
-            path = PGWASM_URL.toString();
-          }
-          if (path?.startsWith("file://")) {
-            path = path.slice(7);
-          }
-          return path;
-        },
+        locateFile: locatePostgresFile,
         ...(this.debug > 0
           ? { print: console.info, printErr: console.error }
           : { print: () => {}, printErr: () => {} }),

--- a/packages/pglite/src/pglite.ts
+++ b/packages/pglite/src/pglite.ts
@@ -1,7 +1,7 @@
 import { Mutex } from "async-mutex";
 import EmPostgresFactory, { type EmPostgres } from "../release/postgres.js";
 import { type Filesystem, parseDataDir, loadFs } from "./fs/index.js";
-import { locatePostgresFile, nodeValues } from "./utils.js";
+import { makeLocateFile } from "./utils.js";
 import { PGEvent } from "./event.js";
 import { parseResults } from "./parse.js";
 import { serializeType } from "./types.js";
@@ -116,7 +116,7 @@ export class PGlite implements PGliteInterface {
           "/pgdata",
           "template1",
         ],
-        locateFile: locatePostgresFile,
+        locateFile: await makeLocateFile(),
         ...(this.debug > 0
           ? { print: console.info, printErr: console.error }
           : { print: () => {}, printErr: () => {} }),

--- a/packages/pglite/src/utils.ts
+++ b/packages/pglite/src/utils.ts
@@ -1,5 +1,3 @@
-import { fileURLToPath } from "url";
-
 export const IN_NODE =
   typeof process === "object" &&
   typeof process.versions === "object" &&
@@ -16,22 +14,28 @@ export async function nodeValues() {
 }
 
 
-const PGWASM_URL = new URL("../release/postgres.wasm", import.meta.url);
-const PGSHARE_URL = new URL("../release/share.data", import.meta.url);
-export function locatePostgresFile(base: string) {
-  let url: URL | null = null;
-  switch (base) {
-    case "share.data":
-      url = PGSHARE_URL;
-      break;
-    case "postgres.wasm":
-      url = PGWASM_URL;
-      break;
-    default:
+export async function makeLocateFile() {
+  const PGWASM_URL = new URL("../release/postgres.wasm", import.meta.url);
+  const PGSHARE_URL = new URL("../release/share.data", import.meta.url);
+  let fileURLToPath = (fileUrl: URL) => fileUrl.pathname
+  if (IN_NODE) {
+    fileURLToPath = (await import("url")).fileURLToPath
   }
-
-  if (url?.protocol === "file:") {
-    return fileURLToPath(url);
+  return (base: string) => {
+    let url: URL | null = null;
+    switch (base) {
+      case "share.data":
+        url = PGSHARE_URL;
+        break;
+      case "postgres.wasm":
+        url = PGWASM_URL;
+        break;
+      default:
+    }
+  
+    if (url?.protocol === "file:") {
+      return fileURLToPath(url);
+    }
+    return url?.toString() ?? '';
   }
-  return url?.toString() ?? '';
 }

--- a/packages/pglite/src/utils.ts
+++ b/packages/pglite/src/utils.ts
@@ -1,3 +1,5 @@
+import { fileURLToPath } from "url";
+
 export const IN_NODE =
   typeof process === "object" &&
   typeof process.versions === "object" &&
@@ -11,4 +13,25 @@ export async function nodeValues() {
     require = (await import("module")).default.createRequire(import.meta.url);
   }
   return { dirname, require };
+}
+
+
+const PGWASM_URL = new URL("../release/postgres.wasm", import.meta.url);
+const PGSHARE_URL = new URL("../release/share.data", import.meta.url);
+export function locatePostgresFile(base: string) {
+  let url: URL | null = null;
+  switch (base) {
+    case "share.data":
+      url = PGSHARE_URL;
+      break;
+    case "postgres.wasm":
+      url = PGWASM_URL;
+      break;
+    default:
+  }
+
+  if (url?.protocol === "file:") {
+    return fileURLToPath(url);
+  }
+  return url?.toString() ?? '';
 }

--- a/packages/pglite/tsup.config.ts
+++ b/packages/pglite/tsup.config.ts
@@ -1,7 +1,8 @@
 import { defineConfig } from 'tsup'
 import path from 'path'
+import { fileURLToPath } from 'url'
 
-const thisFile = new URL(import.meta.url).pathname
+const thisFile = fileURLToPath(new URL(import.meta.url))
 const root = path.dirname(thisFile)
 
 let replaceAssertPlugin = {


### PR DESCRIPTION
Fixes https://github.com/electric-sql/pglite/issues/34

The `import.meta.url` call resolves to a path that starts with a forward slash, that Windows cannot handle. (see https://github.com/nodejs/node/issues/37845)

Using the Node URL API to resolve a file URL to a path works, but I understand that the PGLite code works across multiple environments so either we need to polyfill this API or write our own implementation of something that works around this issue (like a very ugly regex?)