### PR TITLE
Fix invalid storage in webworker

### DIFF
--- a/packages/pglite/src/worker/index.ts
+++ b/packages/pglite/src/worker/index.ts
@@ -32,11 +32,12 @@ export class PGliteWorker implements PGliteInterface {
 
     this.#worker = Comlink.wrap(new Worker(WORKER_URL, { type: "module" }));
 
-    this.waitReady = this.#init();
+    // pass unparsed dataDir value
+    this.waitReady = this.#init(dataDir);
   }
 
-  async #init() {
-    await this.#worker.init(this.dataDir, { debug: this.debug });
+  async #init(dataDir: string) {
+    await this.#worker.init(dataDir, { debug: this.debug });
     this.#ready = true;
   }
 


### PR DESCRIPTION
I found bug when using storage in web worker, it always fallback to `nodefs` no matter what storage we use. turns out, when we initialize `PGLiteWorker`, we parse `dataDir`

```ts
const { dataDir: dir, fsType } = parseDataDir(dataDir);
this.dataDir = dir;
```

now `dataDir` is the parsed value, for example from `idb://my-database` to only `/my-database` without `idb://`. then when we initialize the worker, we are using parsed value instead the the raw value, and this value will be parsed again in `PGLite`

```ts
async #init() {
    await this.#worker.init(this.dataDir, { debug: this.debug });
    this.#ready = true;
}
```

so no mattter what storage used in web worker, it's always using `nodefs`, because we always parsing the parsed value to `PGLite`