### PR TITLE
Resolve bug preventing `affectedRows` count for mutation queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 dist
 .DS_Store
+pgdata-test

--- a/packages/pglite/src/initdb.ts
+++ b/packages/pglite/src/initdb.ts
@@ -61,7 +61,7 @@ export async function initDb(dataDir?: string, debug?: DebugLevel) {
     locateFile: await makeLocateFile(),
     ...(debugMode
       ? { print: console.info, printErr: console.error }
-      : { print: () => { }, printErr: () => { } }),
+      : { print: () => {}, printErr: () => {} }),
     arguments: [
       "--boot",
       "-x1",

--- a/packages/pglite/src/interface.ts
+++ b/packages/pglite/src/interface.ts
@@ -8,7 +8,7 @@ export type RowMode = "array" | "object";
 
 export interface ParserOptions {
   [pgType: number]: (value: string) => any;
-};
+}
 
 export interface QueryOptions {
   rowMode?: RowMode;
@@ -31,14 +31,14 @@ export interface PGliteInterface {
   query<T>(
     query: string,
     params?: any[],
-    options?: QueryOptions
+    options?: QueryOptions,
   ): Promise<Results<T>>;
   exec(query: string, options?: QueryOptions): Promise<Array<Results>>;
   transaction<T>(
-    callback: (tx: Transaction) => Promise<T>
+    callback: (tx: Transaction) => Promise<T>,
   ): Promise<T | undefined>;
   execProtocol(
-    message: Uint8Array
+    message: Uint8Array,
   ): Promise<Array<[BackendMessage, Uint8Array]>>;
 }
 
@@ -54,7 +54,7 @@ export interface Transaction {
   query<T>(
     query: string,
     params?: any[],
-    options?: QueryOptions
+    options?: QueryOptions,
   ): Promise<Results<T>>;
   exec(query: string, options?: QueryOptions): Promise<Array<Results>>;
   rollback(): Promise<void>;

--- a/packages/pglite/src/types.ts
+++ b/packages/pglite/src/types.ts
@@ -281,7 +281,7 @@ export function parseArray(value: string, parser?: (s: string) => any) {
 export function parseType(
   x: string,
   type: number,
-  parsers?: ParserOptions
+  parsers?: ParserOptions,
 ): any {
   if (x === null) {
     return null;
@@ -303,7 +303,7 @@ function typeHandlers(types: TypeHandlers) {
       serializers[k] = theSerializer;
       if (types[k].js) {
         types[k].js.forEach((Type: any) =>
-          serializerInstanceof.push([Type, theSerializer])
+          serializerInstanceof.push([Type, theSerializer]),
         );
       }
       if (parse) {
@@ -317,11 +317,13 @@ function typeHandlers(types: TypeHandlers) {
       return { parsers, serializers, serializerInstanceof };
     },
     {
-      parsers: {} as { [key: number | string]: (x: string, typeId?: number) => any },
+      parsers: {} as {
+        [key: number | string]: (x: string, typeId?: number) => any;
+      },
       serializers: {} as {
         [key: number | string]: Serializer;
       },
       serializerInstanceof: [] as Array<[any, Serializer]>,
-    }
+    },
   );
 }

--- a/packages/pglite/src/utils.ts
+++ b/packages/pglite/src/utils.ts
@@ -13,13 +13,12 @@ export async function nodeValues() {
   return { dirname, require };
 }
 
-
 export async function makeLocateFile() {
   const PGWASM_URL = new URL("../release/postgres.wasm", import.meta.url);
   const PGSHARE_URL = new URL("../release/share.data", import.meta.url);
-  let fileURLToPath = (fileUrl: URL) => fileUrl.pathname
+  let fileURLToPath = (fileUrl: URL) => fileUrl.pathname;
   if (IN_NODE) {
-    fileURLToPath = (await import("url")).fileURLToPath
+    fileURLToPath = (await import("url")).fileURLToPath;
   }
   return (base: string) => {
     let url: URL | null = null;
@@ -32,10 +31,10 @@ export async function makeLocateFile() {
         break;
       default:
     }
-  
+
     if (url?.protocol === "file:") {
       return fileURLToPath(url);
     }
-    return url?.toString() ?? '';
-  }
+    return url?.toString() ?? "";
+  };
 }

--- a/packages/pglite/src/worker/index.ts
+++ b/packages/pglite/src/worker/index.ts
@@ -54,7 +54,11 @@ export class PGliteWorker implements PGliteInterface {
     this.#closed = true;
   }
 
-  async query<T>(query: string, params?: any[], options?: QueryOptions): Promise<Results<T>> {
+  async query<T>(
+    query: string,
+    params?: any[],
+    options?: QueryOptions,
+  ): Promise<Results<T>> {
     return this.#worker.query(query, params, options) as Promise<Results<T>>;
   }
 
@@ -68,7 +72,7 @@ export class PGliteWorker implements PGliteInterface {
   }
 
   async execProtocol(
-    message: Uint8Array
+    message: Uint8Array,
   ): Promise<Array<[BackendMessage, Uint8Array]>> {
     return this.#worker.execProtocol(message);
   }

--- a/packages/pglite/tests/basic.test.js
+++ b/packages/pglite/tests/basic.test.js
@@ -9,31 +9,27 @@ test("basic exec", async (t) => {
       name TEXT
     );
   `);
-  await db.exec("INSERT INTO test (name) VALUES ('test');");
-  const res = await db.exec(`
-    SELECT * FROM test;
-  `);
 
-  t.deepEqual(res, [
+  const multiStatementResult = await db.exec(`
+    INSERT INTO test (name) VALUES ('test');
+    UPDATE test SET name = 'test2';
+    SELECT * FROM test;
+`);
+
+  t.deepEqual(multiStatementResult, [
     {
-      rows: [
-        {
-          id: 1,
-          name: "test",
-        },
-      ],
-      fields: [
-        {
-          name: "id",
-          dataTypeID: 23,
-        },
-        {
-          name: "name",
-          dataTypeID: 25,
-        },
-      ],
-      affectedRows: 0,
+      rows: [],
+      fields: [],
     },
+    {
+      rows: [],
+      fields: [],
+    },
+    {
+      rows: [ { id: 1, name: 'test2' } ],
+      fields: [ { name: 'id', dataTypeID: 23 }, { name: 'name', dataTypeID: 25 } ],
+      affectedRows: 2
+    }
   ]);
 });
 

--- a/packages/pglite/tests/basic.test.js
+++ b/packages/pglite/tests/basic.test.js
@@ -123,7 +123,7 @@ test("basic types", async (t) => {
     SELECT * FROM test;
   `);
 
-  t.deepEqual(res, {
+  t.like(res, {
     rows: [
       {
         id: 1,
@@ -133,7 +133,6 @@ test("basic types", async (t) => {
         bigint: 9223372036854775807n,
         bool: true,
         date: new Date("2021-01-01T00:00:00.000Z"),
-        timestamp: new Date("2021-01-01T12:00:00.000Z"),
         json: { test: "test" },
         blob: Uint8Array.from([1, 2, 3]),
         array_text: ["test1", "test2", "test,3"],
@@ -197,6 +196,9 @@ test("basic types", async (t) => {
     ],
     affectedRows: 0,
   });
+
+  // standardize timestamp comparison to UTC milliseconds to ensure predictable test runs on machines in different timezones. 
+  t.deepEqual(res.rows[0].timestamp.getUTCMilliseconds(), new Date("2021-01-01T12:00:00.000Z").getUTCMilliseconds())
 });
 
 test("basic params", async (t) => {

--- a/packages/pglite/tests/basic.test.js
+++ b/packages/pglite/tests/basic.test.js
@@ -46,11 +46,11 @@ test("basic query", async (t) => {
     );
   `);
   await db.query("INSERT INTO test (name) VALUES ('test');");
-  const res = await db.query(`
+  const selectResult = await db.query(`
     SELECT * FROM test;
   `);
 
-  t.deepEqual(res, {
+  t.deepEqual(selectResult, {
     rows: [
       {
         id: 1,
@@ -69,6 +69,13 @@ test("basic query", async (t) => {
     ],
     affectedRows: 0,
   });
+
+  const updateResult = await db.query("UPDATE test SET name = 'test2';");
+  t.deepEqual(updateResult, {
+    rows: [],
+    fields: [],
+    affectedRows: 1
+  })
 });
 
 test("basic types", async (t) => {

--- a/packages/pglite/tests/types.test.js
+++ b/packages/pglite/tests/types.test.js
@@ -55,16 +55,18 @@ test("parse date 1082", (t) => {
 });
 
 test("parse timestamp 1114", (t) => {
+  // standardize timestamp comparison to UTC milliseconds to ensure predictable test runs on machines in different timezones. 
   t.deepEqual(
-    types.parseType("2021-01-01T12:00:00", 1114),
-    new Date("2021-01-01T12:00:00.000Z")
+    types.parseType("2021-01-01T12:00:00", 1114).getUTCMilliseconds(),
+    new Date("2021-01-01T12:00:00.000Z").getUTCMilliseconds()
   );
 });
 
 test("parse timestamptz 1184", (t) => {
+  // standardize timestamp comparison to UTC milliseconds to ensure predictable test runs on machines in different timezones. 
   t.deepEqual(
-    types.parseType("2021-01-01T12:00:00", 1184),
-    new Date("2021-01-01T12:00:00.000Z")
+    types.parseType("2021-01-01T12:00:00", 1184).getUTCMilliseconds(),
+    new Date("2021-01-01T12:00:00.000Z").getUTCMilliseconds()
   );
 });
 


### PR DESCRIPTION
Resolves [this issue](https://github.com/electric-sql/pglite/issues/68)

Though there was code in `parseResults` to return the `affectedRows` count for INSERT/UPDATE/DELETE queries, it was never being called because of an extra check for a truthy `currentResultSet`, which was initialized to `null` and only populated if there was a message that was a `RowDescriptionMessage` in the list of messages, which may not be present.

Beyond that though, the `currentResultSet` was only pushed into the returning `resultSet` if the message was `RowDescriptionMessage`. I moved this push to `CommandCompleteMessage` instead, which seems to always be either the only or last message returned from a query:

> The response to a SELECT query (or other queries that return row sets, such as EXPLAIN or SHOW) normally consists of RowDescription, zero or more DataRow messages, and then CommandComplete. COPY to or from the frontend invokes special protocol as described in [Section 55.2.6](https://www.postgresql.org/docs/current/protocol-flow.html#PROTOCOL-COPY). All other query types normally produce only a CommandComplete message.

[_source_](https://www.postgresql.org/docs/current/protocol-flow.html#PROTOCOL-FLOW-SIMPLE-QUERY)

Beyond that main fix, there were a couple of housekeeping items I took care of, including:
- Running the `prettier` command defined in the `package.json`
- Updating a few timestamp-related tests to compare agains the UTC milliseconds of the returned timestamps, not their javascript dates. This standardizes the comparison for developers running the tests in any timezone, as it would only currently pass for developers in the GMT timezone (+00).
- Add `pgdata-test` to `.gitignore`

Thanks for working on this project @samwillis, it's been great seeing this evolve. Please let me know if you see any issues or have any comments.