### PR TITLE
Support for pg_notify

### DIFF
--- a/packages/pglite/README.md
+++ b/packages/pglite/README.md
@@ -265,6 +265,35 @@ await pg.transaction(async (tx) => {
 
 Close the database, ensuring it is shut down cleanly.
 
+#### `.listen(channel: string, callback: (payload: string) => void): Promise<void>`
+
+Subscribe to a [pg_notify](https://www.postgresql.org/docs/current/sql-notify.html) channel. The callback will receive the payload from the notification.
+
+Returns an unsubscribe function to unsubscribe from the channel.
+
+##### Example:
+
+```ts
+const unsub = await pg.listen('test', (payload) => {
+  console.log('Received:', payload);
+});
+await pg.query("NOTIFY test, 'Hello, world!'");
+```
+
+#### `.unlisten(channel: string, callback?: (payload: string) => void): Promise<void>`
+
+Unsubscribe from the channel. If a callback is provided it removes only that callback from the subscription, when no callback is provided is unsubscribes all callbacks for the channel.
+
+#### `onNotification(callback: (channel: string, payload: string) => void): () => void`
+
+Add an event handler for all notifications received from Postgres.
+
+**Note:** This does not subscribe to the notification, you will have to manually subscribe with `LISTEN channel_name`.
+
+#### `offNotification(callback: (channel: string, payload: string) => void): void`
+
+Remove an event handler for all notifications received from Postgres.
+
 ### Properties:
 
 - `.ready` *boolean (read only)*: Whether the database is ready to accept queries.

--- a/packages/pglite/examples/notify-worker.html
+++ b/packages/pglite/examples/notify-worker.html
@@ -1,0 +1,22 @@
+<script type="module">
+  import { PGliteWorker } from "../dist/worker/index.js";
+
+  const pg = new PGliteWorker();
+  
+  const unsub = await pg.listen('test', (payload) => {
+    console.log('Received:', payload);
+  });
+  
+  await new Promise((resolve) => setTimeout(resolve, 500));
+  
+  await pg.query('NOTIFY test, \'Hello, world!\'');
+  
+  await new Promise((resolve) => setTimeout(resolve, 500));
+  
+  await pg.query('NOTIFY test, \'Hello, world again!\'');
+
+  await unsub();
+
+  await pg.query('NOTIFY test, \'Will not be received!\'');
+
+</script>

--- a/packages/pglite/examples/notify.html
+++ b/packages/pglite/examples/notify.html
@@ -1,0 +1,22 @@
+<script type="module">
+  import { PGlite } from "../dist/index.js";
+
+  const pg = new PGlite();
+  
+  const unsub = await pg.listen('test', (payload) => {
+    console.log('Received:', payload);
+  });
+  
+  await new Promise((resolve) => setTimeout(resolve, 500));
+  
+  await pg.query('NOTIFY test, \'Hello, world!\'');
+  
+  await new Promise((resolve) => setTimeout(resolve, 500));
+  
+  await pg.query('NOTIFY test, \'Hello, world again!\'');
+
+  await unsub();
+
+  await pg.query('NOTIFY test, \'Will not be received!\'');
+
+</script>

--- a/packages/pglite/src/interface.ts
+++ b/packages/pglite/src/interface.ts
@@ -1,5 +1,4 @@
 import type { BackendMessage } from "pg-protocol/dist/messages.js";
-import { off } from "process";
 
 export type FilesystemType = "nodefs" | "idbfs" | "memoryfs";
 

--- a/packages/pglite/src/interface.ts
+++ b/packages/pglite/src/interface.ts
@@ -1,4 +1,5 @@
 import type { BackendMessage } from "pg-protocol/dist/messages.js";
+import { off } from "process";
 
 export type FilesystemType = "nodefs" | "idbfs" | "memoryfs";
 
@@ -47,6 +48,18 @@ export interface PGliteInterface {
     message: Uint8Array,
     options?: ExecProtocolOptions,
   ): Promise<Array<[BackendMessage, Uint8Array]>>;
+  listen(
+    channel: string,
+    callback: (payload: string) => void,
+  ): Promise<() => Promise<void>>;
+  unlisten(
+    channel: string,
+    callback?: (payload: string) => void,
+  ): Promise<void>;
+  onNotification(
+    callback: (channel: string, payload: string) => void,
+  ): () => void;
+  offNotification(callback: (channel: string, payload: string) => void): void;
 }
 
 export type Row<T = { [key: string]: any }> = T;

--- a/packages/pglite/src/pglite.ts
+++ b/packages/pglite/src/pglite.ts
@@ -634,13 +634,14 @@ export class PGlite implements PGliteInterface {
    * @param callback The callback to remove
    */
   async unlisten(channel: string, callback?: (payload: string) => void) {
-    await this.exec(`UNLISTEN ${channel}`);
     if (callback) {
       this.#notifyListeners.get(channel)?.delete(callback);
       if (this.#notifyListeners.get(channel)!.size === 0) {
+        await this.exec(`UNLISTEN ${channel}`);
         this.#notifyListeners.delete(channel);
       }
     } else {
+      await this.exec(`UNLISTEN ${channel}`);
       this.#notifyListeners.delete(channel);
     }
   }

--- a/packages/pglite/src/worker/process.ts
+++ b/packages/pglite/src/worker/process.ts
@@ -5,9 +5,16 @@ import type { PGliteOptions, QueryOptions } from "../interface.js";
 let db: PGlite;
 
 const worker = {
-  async init(dataDir?: string, options?: PGliteOptions) {
+  async init(
+    dataDir?: string,
+    options?: PGliteOptions,
+    onNotification?: (channel: string, payload: string) => void,
+  ) {
     db = new PGlite(dataDir, options);
     await db.waitReady;
+    if (onNotification) {
+      db.onNotification(onNotification);
+    }
     return true;
   },
   async close() {

--- a/packages/pglite/tests/notify.test.js
+++ b/packages/pglite/tests/notify.test.js
@@ -1,0 +1,43 @@
+import test from "ava";
+import { PGlite } from "../dist/index.js";
+
+test("notify", async (t) => {
+  const db = new PGlite();
+  
+  await db.listen("test", (payload) => {
+    t.is(payload, '321');
+  });
+
+  await db.query("NOTIFY test, '321'");
+
+  await new Promise((resolve) => setTimeout(resolve, 1000));
+});
+
+test("unlisten", async (t) => {
+  const db = new PGlite();
+  
+  const unsub = await db.listen("test", () => {
+    t.fail();
+  });
+
+  await unsub();
+
+  await db.query("NOTIFY test");
+
+  await new Promise((resolve) => setTimeout(resolve, 1000));
+  t.pass();
+});
+
+test('onNotification', async (t) => {
+  const db = new PGlite();
+
+  db.onNotification((chan, payload) => {
+    t.is(chan, 'test');
+    t.is(payload, '123');
+  });
+
+  await db.query("LISTEN test");
+  await db.query("NOTIFY test, '123'");
+
+  await new Promise((resolve) => setTimeout(resolve, 1000));
+});


### PR DESCRIPTION
This adds support for subscribing to notification using `pg_notify`, the built in postgres async notification system.

To subscribe to a notification:

```js
const unsub = await pg.listen('test', (payload: string) => {
  // do something with the payload
});
```

The first arg is the channel to subscribe to, the second the callback that receives the payload.

Calling `.listen` creates the JS side event callback *and* calls `LISTEN channel_name` on the database connection to subscribe to the channel.

To unsubscribe call the function returned by the subscribe call, with unregisters the callback and calls `UNSUBSCRIBE channel_name` on the database connection.

If you want to listen to all notifications the connection receives you can subscribe with the `onNotification(callback)` api, or unsubscribe with the returned unsubscribe function or the matching `offNotification(callback)` with the same callback.

To do:

- [x] Docs
- [x] Tests

Related Postgres WASM PR: https://github.com/electric-sql/postgres-wasm/pull/11, required modification to skip the system interrupts that Postgres normally uses.