### PR TITLE
Fix web worker syntax for webpack static analysis

### DIFF
--- a/packages/pglite/src/worker/index.ts
+++ b/packages/pglite/src/worker/index.ts
@@ -11,8 +11,6 @@ import type { BackendMessage } from "pg-protocol/dist/messages.js";
 import { parseDataDir } from "../fs/index.js";
 import type { Worker as WorkerInterface } from "./process.js";
 
-const WORKER_URL = new URL("./process.js", import.meta.url);
-
 export class PGliteWorker implements PGliteInterface {
   readonly dataDir?: string;
   readonly fsType: FilesystemType;
@@ -32,7 +30,12 @@ export class PGliteWorker implements PGliteInterface {
     this.#options = options ?? {};
     this.debug = options?.debug ?? 0;
 
-    this.#worker = Comlink.wrap(new Worker(WORKER_URL, { type: "module" }));
+    this.#worker = Comlink.wrap(
+      // the below syntax is required by webpack in order to
+      // identify the worker properly during static analysis
+      // see: https://webpack.js.org/guides/web-workers/
+      new Worker(new URL("./process.js", import.meta.url), { type: "module" }),
+    );
 
     // pass unparsed dataDir value
     this.waitReady = this.#init(dataDir);


### PR DESCRIPTION
`PGliteWorker` doesn't currently work with webpack 5 (and Next.js) because webpack requires the worker to be loaded in a [specific way](https://webpack.js.org/guides/web-workers/). Instead of:
```ts
const WORKER_URL = new URL("./process.js", import.meta.url);
new Worker(WORKER_URL, { type: "module" });
```
webpack needs you to combine them into one line:
```ts
new Worker(new URL("./process.js", import.meta.url), { type: "module" });
```

I suspect this is because `WORKER_URL` could be dynamically created at runtime which breaks webpack's static analysis. And webpack needs to statically identify this at build time in order to perform special bundling on the worker script.

Created a quick fork `@gregnr/pglite` to test this and all appears to work now in Next 14:
```ts
import { PGliteWorker } from '@gregnr/pglite/worker'

const db = new PGliteWorker()

const result = await db.query('select 1');
// { rows: [...], fields: [...], affectedRows: 0 }
```