### PR TITLE
Support for adding or receiving a blob for with with COPY FROM/TO

### DIFF
--- a/packages/pglite/examples/copy.html
+++ b/packages/pglite/examples/copy.html
@@ -1,0 +1,48 @@
+<script type="module">
+  import { PGlite } from "../dist/index.js";
+  
+  const pg = new PGlite();
+  
+  await pg.exec(`
+    CREATE TABLE IF NOT EXISTS test (
+      id SERIAL PRIMARY KEY,
+      name TEXT
+    );
+  `);
+
+  // add 1000 rows:
+  await pg.exec("INSERT INTO test (name) SELECT 'name' || i FROM generate_series(1, 1000) i;");
+
+  // Copy the date to a file:
+  console.log('Copying data to file...') // 'test.csv
+  const ret = await pg.query("COPY test TO '/dev/blob' WITH (FORMAT binary);");
+
+  console.log('Data copied to blob:')
+  const blob = ret.blob;
+  console.log(blob);
+
+  // Download the file:
+  const a = document.createElement('a');
+  a.href = URL.createObjectURL(new File([blob], 'test.csv', { type: 'text/csv' }));
+  a.download = 'test.csv';
+  a.click();
+
+  // Other table
+  await pg.exec(`
+    CREATE TABLE IF NOT EXISTS test2 (
+      id SERIAL PRIMARY KEY,
+      name TEXT
+    );
+  `);
+
+  // import the data from the file:
+  console.log('Importing data from file...')
+  const ret2 = await pg.query("COPY test2 FROM '/dev/blob' WITH (FORMAT binary);", [], {
+    blob: blob
+  });
+
+  console.log('Data imported from file:')
+  const ret3 = await pg.query("SELECT * FROM test2;", []);
+  console.log(ret3.rows);
+
+</script>

--- a/packages/pglite/src/fs/idbfs.ts
+++ b/packages/pglite/src/fs/idbfs.ts
@@ -45,6 +45,7 @@ export class IdbFs extends FilesystemBase {
     const options: Partial<EmPostgres> = {
       ...opts,
       preRun: [
+        ...(opts.preRun || []),
         (mod: any) => {
           const idbfs = mod.FS.filesystems.IDBFS;
           // Mount the idbfs to the users dataDir

--- a/packages/pglite/src/fs/memoryfs.ts
+++ b/packages/pglite/src/fs/memoryfs.ts
@@ -19,6 +19,7 @@ export class MemoryFS extends FilesystemBase {
     const options: Partial<EmPostgres> = {
       ...opts,
       preRun: [
+        ...(opts.preRun || []),
         (mod: any) => {
           /**
            * There is an issue with just mounting the filesystem, Postgres stalls...

--- a/packages/pglite/src/fs/nodefs.ts
+++ b/packages/pglite/src/fs/nodefs.ts
@@ -32,6 +32,7 @@ export class NodeFS extends FilesystemBase {
     const options: Partial<EmPostgres> = {
       ...opts,
       preRun: [
+        ...(opts.preRun || []),
         (mod: any) => {
           const nodefs = mod.FS.filesystems.NODEFS;
           mod.FS.mkdir(PGDATA);

--- a/packages/pglite/src/interface.ts
+++ b/packages/pglite/src/interface.ts
@@ -13,6 +13,7 @@ export interface ParserOptions {
 export interface QueryOptions {
   rowMode?: RowMode;
   parsers?: ParserOptions;
+  blob?: Blob | File;
 }
 
 export interface ExecProtocolOptions {
@@ -54,6 +55,7 @@ export type Results<T = { [key: string]: any }> = {
   rows: Row<T>[];
   affectedRows?: number;
   fields: { name: string; dataTypeID: number }[];
+  blob?: Blob; // Only set when a file is returned, such as from a COPY command
 };
 
 export interface Transaction {

--- a/packages/pglite/src/parse.ts
+++ b/packages/pglite/src/parse.ts
@@ -14,6 +14,7 @@ import { parseType } from "./types.js";
 export function parseResults(
   messages: Array<BackendMessage>,
   options?: QueryOptions,
+  blob?: Blob,
 ): Array<Results> {
   const resultSets: Results[] = [];
   let currentResultSet: Results = { rows: [], fields: [] };
@@ -62,7 +63,7 @@ export function parseResults(
       affectedRows += retrieveRowCount(msg);
 
       if (index === filteredMessages.length - 1)
-        resultSets.push({ ...currentResultSet, affectedRows });
+        resultSets.push({ ...currentResultSet, affectedRows, blob });
       else resultSets.push(currentResultSet);
 
       currentResultSet = { rows: [], fields: [] };


### PR DESCRIPTION
This adds an additional `blob` property to the `options` passed to the `.query` and `.exec` methods. This can be a Blob or File that will then be made available on the `/dev/blob` device in the VFS. This can be used with a `COPY` for importing data:

```sql
const myBlob = new Blob(/*...*/);
await pg.query("COPY test FROM '/dev/blob' WITH (FORMAT binary);", [], {
  blob: blob
});
```

It also add support for copying to a  new blob, again via the `/dev/blob` device. When data is written to the blob device during a query the returned result will include a `blob` property contains the new blob:

```sql
COPY test TO '/dev/blob' WITH (FORMAT binary);
```
Returned data:
```js
{
  fields: [(/*...*/],
  rows: [(/*...*/],
  blob: Blob()
}
```