### PR TITLE
Dump and load tarball of a database

### DIFF
--- a/packages/pglite/examples/dumpDataDir.html
+++ b/packages/pglite/examples/dumpDataDir.html
@@ -1,0 +1,1 @@
+<script type="module" src="./dumpDataDir.js"></script>

--- a/packages/pglite/examples/dumpDataDir.js
+++ b/packages/pglite/examples/dumpDataDir.js
@@ -1,0 +1,26 @@
+import { PGlite } from "../dist/index.js";
+
+const pg = new PGlite();
+await pg.exec(`
+  CREATE TABLE IF NOT EXISTS test (
+    id SERIAL PRIMARY KEY,
+    name TEXT
+  );
+`);
+await pg.exec("INSERT INTO test (name) VALUES ('test');");
+
+const { tarball, filename } = await pg.dumpDataDir();
+
+if (typeof window !== 'undefined') {
+  // Download the dump
+  const blob = new Blob([tarball], { type: "application/octet-stream" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  a.click();
+} else {
+  // Save the dump to a file using node fs
+  const fs = await import("fs");
+  fs.writeFileSync(filename, tarball);
+}

--- a/packages/pglite/examples/dumpDataDir.js
+++ b/packages/pglite/examples/dumpDataDir.js
@@ -9,25 +9,23 @@ await pg.exec(`
 `);
 await pg.exec("INSERT INTO test (name) VALUES ('test');");
 
-const { tarball, filename, extension } = await pg.dumpDataDir();
+const file = await pg.dumpDataDir();
 
 if (typeof window !== "undefined") {
   // Download the dump
-  const blob = new Blob([tarball], { type: "application/octet-stream" });
-  const url = URL.createObjectURL(blob);
+  const url = URL.createObjectURL(file);
   const a = document.createElement("a");
   a.href = url;
-  a.download = filename;
+  a.download = file.name;
   a.click();
 } else {
   // Save the dump to a file using node fs
   const fs = await import("fs");
-  fs.writeFileSync(filename, tarball);
+  fs.writeFileSync(file.name, await file.arrayBuffer());
 }
 
 const pg2 = new PGlite({
-  // debug: 1,
-  loadDataDir: { tarball, extension },
+  loadDataDir: file,
 });
 
 const rows = await pg2.query("SELECT * FROM test;");

--- a/packages/pglite/examples/dumpDataDir.js
+++ b/packages/pglite/examples/dumpDataDir.js
@@ -9,9 +9,9 @@ await pg.exec(`
 `);
 await pg.exec("INSERT INTO test (name) VALUES ('test');");
 
-const { tarball, filename } = await pg.dumpDataDir();
+const { tarball, filename, extension } = await pg.dumpDataDir();
 
-if (typeof window !== 'undefined') {
+if (typeof window !== "undefined") {
   // Download the dump
   const blob = new Blob([tarball], { type: "application/octet-stream" });
   const url = URL.createObjectURL(blob);
@@ -24,3 +24,11 @@ if (typeof window !== 'undefined') {
   const fs = await import("fs");
   fs.writeFileSync(filename, tarball);
 }
+
+const pg2 = new PGlite({
+  // debug: 1,
+  loadDataDir: { tarball, extension },
+});
+
+const rows = await pg2.query("SELECT * FROM test;");
+console.log(rows);

--- a/packages/pglite/src/definitions/tinytar.d.ts
+++ b/packages/pglite/src/definitions/tinytar.d.ts
@@ -34,6 +34,8 @@ declare module "tinytar" {
   const NULL_CHAR: string;
   const TMAGIC: string;
   const OLDGNU_MAGIC: string;
+
+  // Values used in typeflag field
   const REGTYPE: number;
   const LNKTYPE: number;
   const SYMTYPE: number;
@@ -42,6 +44,8 @@ declare module "tinytar" {
   const DIRTYPE: number;
   const FIFOTYPE: number;
   const CONTTYPE: number;
+
+  // Bits used in the mode field, values in octal
   const TSUID: number;
   const TSGID: number;
   const TSVTX: number;
@@ -54,6 +58,7 @@ declare module "tinytar" {
   const TOREAD: number;
   const TOWRITE: number;
   const TOEXEC: number;
+
   const TPERMALL: number;
   const TPERMMASK: number;
 }

--- a/packages/pglite/src/fs/idbfs.ts
+++ b/packages/pglite/src/fs/idbfs.ts
@@ -1,6 +1,7 @@
 import { FilesystemBase } from "./types.js";
 import type { FS, PostgresMod } from "../postgres.js";
 import { PGDATA } from "./index.js";
+import { dumpTar } from "./tarUtils.js";
 
 export class IdbFs extends FilesystemBase {
   async emscriptenOpts(opts: Partial<PostgresMod>) {
@@ -47,5 +48,9 @@ export class IdbFs extends FilesystemBase {
         }
       });
     });
+  }
+
+  async dumpTar(mod: FS) {
+    return dumpTar(mod);
   }
 }

--- a/packages/pglite/src/fs/idbfs.ts
+++ b/packages/pglite/src/fs/idbfs.ts
@@ -50,7 +50,7 @@ export class IdbFs extends FilesystemBase {
     });
   }
 
-  async dumpTar(mod: FS) {
-    return dumpTar(mod);
+  async dumpTar(mod: FS, dbname: string) {
+    return dumpTar(mod, dbname);
   }
 }

--- a/packages/pglite/src/fs/memoryfs.ts
+++ b/packages/pglite/src/fs/memoryfs.ts
@@ -8,7 +8,7 @@ export class MemoryFS extends FilesystemBase {
     return opts;
   }
 
-  async dumpTar(mod: FS) {
-    return dumpTar(mod);
+  async dumpTar(mod: FS, dbname: string) {
+    return dumpTar(mod, dbname);
   }
 }

--- a/packages/pglite/src/fs/memoryfs.ts
+++ b/packages/pglite/src/fs/memoryfs.ts
@@ -1,9 +1,14 @@
 import { FilesystemBase } from "./types.js";
-import type { PostgresMod } from "../postgres.js";
+import type { PostgresMod, FS } from "../postgres.js";
+import { dumpTar } from "./tarUtils.js";
 
 export class MemoryFS extends FilesystemBase {
   async emscriptenOpts(opts: Partial<PostgresMod>) {
     // Nothing to do for memoryfs
     return opts;
+  }
+
+  async dumpTar(mod: FS) {
+    return dumpTar(mod);
   }
 }

--- a/packages/pglite/src/fs/nodefs.ts
+++ b/packages/pglite/src/fs/nodefs.ts
@@ -31,7 +31,7 @@ export class NodeFS extends FilesystemBase {
     return options;
   }
 
-  async dumpTar(mod: FS) {
-    return dumpTar(mod);
+  async dumpTar(mod: FS, dbname: string) {
+    return dumpTar(mod, dbname);
   }
 }

--- a/packages/pglite/src/fs/nodefs.ts
+++ b/packages/pglite/src/fs/nodefs.ts
@@ -2,7 +2,8 @@ import * as fs from "fs";
 import * as path from "path";
 import { FilesystemBase } from "./types.js";
 import { PGDATA } from "./index.js";
-import type { PostgresMod } from "../postgres.js";
+import type { PostgresMod, FS } from "../postgres.js";
+import { dumpTar } from "./tarUtils.js";
 
 export class NodeFS extends FilesystemBase {
   protected rootDir: string;
@@ -28,5 +29,9 @@ export class NodeFS extends FilesystemBase {
       ],
     };
     return options;
+  }
+
+  async dumpTar(mod: FS) {
+    return dumpTar(mod);
   }
 }

--- a/packages/pglite/src/fs/tarUtils.ts
+++ b/packages/pglite/src/fs/tarUtils.ts
@@ -1,0 +1,104 @@
+import { tar, type TarFile } from "tinytar";
+import { FS } from "../postgres.js";
+import { PGDATA } from "./index.js";
+
+export interface DumpTarResult {
+  tarball: Uint8Array;
+  extension: ".tar" | ".tgz";
+}
+
+export async function dumpTar(FS: FS): Promise<DumpTarResult> {
+  const tarball = createTarball(FS, PGDATA);
+  const [compressed, zipped] = await maybeZip(tarball);
+  return {
+    tarball: compressed,
+    extension: zipped ? ".tgz" : ".tar",
+  };
+}
+
+function readDirectory(FS: FS, path: string) {
+  let files: TarFile[] = [];
+
+  const traverseDirectory = (currentPath: string) => {
+    const entries = FS.readdir(currentPath);
+    entries.forEach((entry) => {
+      if (entry === "." || entry === "..") {
+        return;
+      }
+      const fullPath = currentPath + "/" + entry;
+      const stats = FS.stat(fullPath);
+      if (FS.isDir(stats.mode)) {
+        traverseDirectory(fullPath);
+      } else if (FS.isFile(stats.mode)) {
+        const data = FS.readFile(fullPath, { encoding: "binary" });
+        files.push({
+          name: fullPath.substring(path.length), // remove the root path
+          mode: stats.mode,
+          size: stats.size,
+          modifyTime: stats.mtime,
+          data: new Uint8Array(data),
+        });
+      }
+    });
+  };
+
+  traverseDirectory(path);
+  return files;
+}
+
+export function createTarball(FS: FS, directoryPath: string) {
+  const files = readDirectory(FS, directoryPath);
+  const tarball = tar(files);
+  return tarball;
+}
+
+export async function maybeZip(
+  file: Uint8Array,
+): Promise<[Uint8Array, boolean]> {
+  if (typeof window !== "undefined" && "CompressionStream" in window) {
+    return [await zipBrowser(file), true];
+  } else if (
+    typeof process !== "undefined" &&
+    process.versions &&
+    process.versions.node
+  ) {
+    return [await zipNode(file), true];
+  } else {
+    return [file, false];
+  }
+}
+
+export async function zipBrowser(file: Uint8Array): Promise<Uint8Array> {
+  const cs = new CompressionStream("gzip");
+  const writer = cs.writable.getWriter();
+  const reader = cs.readable.getReader();
+
+  writer.write(file);
+  writer.close();
+
+  const chunks: Uint8Array[] = [];
+
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    if (value) chunks.push(value);
+  }
+
+  const compressed = new Uint8Array(
+    chunks.reduce((acc, chunk) => acc + chunk.length, 0),
+  );
+  let offset = 0;
+  chunks.forEach((chunk) => {
+    compressed.set(chunk, offset);
+    offset += chunk.length;
+  });
+
+  return compressed;
+}
+
+export async function zipNode(file: Uint8Array): Promise<Uint8Array> {
+  const { promisify } = await import("util");
+  const { gzip } = await import("zlib");
+  const gzipPromise = promisify(gzip);
+  return await gzipPromise(file);
+}

--- a/packages/pglite/src/fs/tarUtils.ts
+++ b/packages/pglite/src/fs/tarUtils.ts
@@ -1,19 +1,53 @@
-import { tar, type TarFile } from "tinytar";
+import { tar, untar, type TarFile, REGTYPE, DIRTYPE } from "tinytar";
 import { FS } from "../postgres.js";
 import { PGDATA } from "./index.js";
 
-export interface DumpTarResult {
+export interface DumpedTar {
   tarball: Uint8Array;
   extension: ".tar" | ".tgz";
 }
 
-export async function dumpTar(FS: FS): Promise<DumpTarResult> {
+export async function dumpTar(FS: FS): Promise<DumpedTar> {
   const tarball = createTarball(FS, PGDATA);
   const [compressed, zipped] = await maybeZip(tarball);
   return {
     tarball: compressed,
     extension: zipped ? ".tgz" : ".tar",
   };
+}
+
+export async function loadTar(FS: FS, dump: DumpedTar): Promise<void> {
+  let tarball = dump.tarball;
+  console.log("loading tarball");
+  if (dump.extension === ".tgz") {
+    tarball = await unzip(tarball);
+  }
+
+  const files = untar(tarball);
+  for (const file of files) {
+    const filePath = PGDATA + file.name;
+
+    // Ensure the directory structure exists
+    const dirPath = filePath.split("/").slice(0, -1);
+    for (let i = 1; i <= dirPath.length; i++) {
+      const dir = dirPath.slice(0, i).join("/");
+      if (!FS.analyzePath(dir).exists) {
+        FS.mkdir(dir);
+      }
+    }
+
+    // Write the file or directory
+    if (file.type == REGTYPE) {
+      FS.writeFile(filePath, file.data);
+      FS.utime(
+        filePath,
+        dateToUnixTimestamp(file.modifyTime),
+        dateToUnixTimestamp(file.modifyTime),
+      );
+    } else if (file.type == DIRTYPE) {
+      FS.mkdir(filePath);
+    }
+  }
 }
 
 function readDirectory(FS: FS, path: string) {
@@ -27,17 +61,19 @@ function readDirectory(FS: FS, path: string) {
       }
       const fullPath = currentPath + "/" + entry;
       const stats = FS.stat(fullPath);
+      const data = FS.isFile(stats.mode)
+        ? FS.readFile(fullPath, { encoding: "binary" })
+        : new Uint8Array(0);
+      files.push({
+        name: fullPath.substring(path.length), // remove the root path
+        mode: stats.mode,
+        size: stats.size,
+        type: FS.isFile(stats.mode) ? REGTYPE : DIRTYPE,
+        modifyTime: stats.mtime,
+        data,
+      });
       if (FS.isDir(stats.mode)) {
         traverseDirectory(fullPath);
-      } else if (FS.isFile(stats.mode)) {
-        const data = FS.readFile(fullPath, { encoding: "binary" });
-        files.push({
-          name: fullPath.substring(path.length), // remove the root path
-          mode: stats.mode,
-          size: stats.size,
-          modifyTime: stats.mtime,
-          data: new Uint8Array(data),
-        });
       }
     });
   };
@@ -101,4 +137,61 @@ export async function zipNode(file: Uint8Array): Promise<Uint8Array> {
   const { gzip } = await import("zlib");
   const gzipPromise = promisify(gzip);
   return await gzipPromise(file);
+}
+
+export async function unzip(file: Uint8Array): Promise<Uint8Array> {
+  if (typeof window !== "undefined" && "DecompressionStream" in window) {
+    return await unzipBrowser(file);
+  } else if (
+    typeof process !== "undefined" &&
+    process.versions &&
+    process.versions.node
+  ) {
+    return await unzipNode(file);
+  } else {
+    throw new Error("Unsupported environment for decompression");
+  }
+}
+
+export async function unzipBrowser(file: Uint8Array): Promise<Uint8Array> {
+  const ds = new DecompressionStream("gzip");
+  const writer = ds.writable.getWriter();
+  const reader = ds.readable.getReader();
+
+  writer.write(file);
+  writer.close();
+
+  const chunks: Uint8Array[] = [];
+
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    if (value) chunks.push(value);
+  }
+
+  const decompressed = new Uint8Array(
+    chunks.reduce((acc, chunk) => acc + chunk.length, 0),
+  );
+  let offset = 0;
+  chunks.forEach((chunk) => {
+    decompressed.set(chunk, offset);
+    offset += chunk.length;
+  });
+
+  return decompressed;
+}
+
+export async function unzipNode(file: Uint8Array): Promise<Uint8Array> {
+  const { promisify } = await import("util");
+  const { gunzip } = await import("zlib");
+  const gunzipPromise = promisify(gunzip);
+  return await gunzipPromise(file);
+}
+
+function dateToUnixTimestamp(date: Date | number | undefined): number {
+  if (!date) {
+    return Math.floor(Date.now() / 1000);
+  } else {
+    return typeof date === "number" ? date : Math.floor(date.getTime() / 1000);
+  }
 }

--- a/packages/pglite/src/fs/types.ts
+++ b/packages/pglite/src/fs/types.ts
@@ -1,4 +1,5 @@
 import type { PostgresMod, FS } from "../postgres.js";
+import type { DumpTarResult } from "./tarUtils.js";
 
 export type FsType = "nodefs" | "idbfs" | "memoryfs";
 
@@ -15,15 +16,17 @@ export interface Filesystem {
   /**
    * Sync the filesystem to the emscripten filesystem.
    */
-  syncToFs(mod: FS): Promise<void>;
+  syncToFs(FS: FS): Promise<void>;
 
   /**
    * Sync the emscripten filesystem to the filesystem.
    */
-  initialSyncFs(mod: FS): Promise<void>;
+  initialSyncFs(FS: FS): Promise<void>;
 
-  //  on_mount(): Function<void>;
-  // load_extension(ext: string): Promise<void>;
+  /**
+   * Dump the PGDATA dir from the filesystem to a gziped tarball.
+   */
+  dumpTar(FS: FS): Promise<DumpTarResult>;
 }
 
 export abstract class FilesystemBase implements Filesystem {
@@ -34,6 +37,7 @@ export abstract class FilesystemBase implements Filesystem {
   abstract emscriptenOpts(
     opts: Partial<PostgresMod>,
   ): Promise<Partial<PostgresMod>>;
-  async syncToFs(mod: FS) {}
+  async syncToFs(FS: FS) {}
   async initialSyncFs(mod: FS) {}
+  abstract dumpTar(mod: FS): Promise<DumpTarResult>;
 }

--- a/packages/pglite/src/fs/types.ts
+++ b/packages/pglite/src/fs/types.ts
@@ -1,5 +1,5 @@
 import type { PostgresMod, FS } from "../postgres.js";
-import type { DumpTarResult } from "./tarUtils.js";
+import type { DumpedTar } from "./tarUtils.js";
 
 export type FsType = "nodefs" | "idbfs" | "memoryfs";
 
@@ -26,7 +26,7 @@ export interface Filesystem {
   /**
    * Dump the PGDATA dir from the filesystem to a gziped tarball.
    */
-  dumpTar(FS: FS): Promise<DumpTarResult>;
+  dumpTar(FS: FS): Promise<DumpedTar>;
 }
 
 export abstract class FilesystemBase implements Filesystem {
@@ -39,5 +39,5 @@ export abstract class FilesystemBase implements Filesystem {
   ): Promise<Partial<PostgresMod>>;
   async syncToFs(FS: FS) {}
   async initialSyncFs(mod: FS) {}
-  abstract dumpTar(mod: FS): Promise<DumpTarResult>;
+  abstract dumpTar(mod: FS): Promise<DumpedTar>;
 }

--- a/packages/pglite/src/fs/types.ts
+++ b/packages/pglite/src/fs/types.ts
@@ -1,5 +1,4 @@
 import type { PostgresMod, FS } from "../postgres.js";
-import type { DumpedTar } from "./tarUtils.js";
 
 export type FsType = "nodefs" | "idbfs" | "memoryfs";
 
@@ -26,7 +25,7 @@ export interface Filesystem {
   /**
    * Dump the PGDATA dir from the filesystem to a gziped tarball.
    */
-  dumpTar(FS: FS): Promise<DumpedTar>;
+  dumpTar(FS: FS, dbname: string): Promise<File>;
 }
 
 export abstract class FilesystemBase implements Filesystem {
@@ -39,5 +38,5 @@ export abstract class FilesystemBase implements Filesystem {
   ): Promise<Partial<PostgresMod>>;
   async syncToFs(FS: FS) {}
   async initialSyncFs(mod: FS) {}
-  abstract dumpTar(mod: FS): Promise<DumpedTar>;
+  abstract dumpTar(mod: FS, dbname: string): Promise<File>;
 }

--- a/packages/pglite/src/interface.ts
+++ b/packages/pglite/src/interface.ts
@@ -49,19 +49,13 @@ export interface DumpDataDirResult {
   filename: string;
 }
 
-export interface LoadDataDir {
-  tarball: Uint8Array;
-  extension: ".tar" | ".tgz" | ".tar.gz";
-  filename?: string;
-}
-
 export interface PGliteOptions {
   dataDir?: string;
   fs?: Filesystem;
   debug?: DebugLevel;
   relaxedDurability?: boolean;
   extensions?: Extensions;
-  loadDataDir?: LoadDataDir;
+  loadDataDir?: Blob | File;
 }
 
 export type PGliteInterface = {
@@ -96,7 +90,7 @@ export type PGliteInterface = {
     callback: (channel: string, payload: string) => void,
   ): () => void;
   offNotification(callback: (channel: string, payload: string) => void): void;
-  dumpDataDir(): Promise<DumpDataDirResult>;
+  dumpDataDir(): Promise<File>;
 };
 
 export type PGliteInterfaceExtensions<E> = E extends Extensions

--- a/packages/pglite/src/interface.ts
+++ b/packages/pglite/src/interface.ts
@@ -49,12 +49,19 @@ export interface DumpDataDirResult {
   filename: string;
 }
 
+export interface LoadDataDir {
+  tarball: Uint8Array;
+  extension: ".tar" | ".tgz" | ".tar.gz";
+  filename?: string;
+}
+
 export interface PGliteOptions {
   dataDir?: string;
   fs?: Filesystem;
   debug?: DebugLevel;
   relaxedDurability?: boolean;
   extensions?: Extensions;
+  loadDataDir?: LoadDataDir;
 }
 
 export type PGliteInterface = {

--- a/packages/pglite/src/interface.ts
+++ b/packages/pglite/src/interface.ts
@@ -43,6 +43,12 @@ export type Extensions = {
   [namespace: string]: Extension | URL;
 };
 
+export interface DumpDataDirResult {
+  tarball: Uint8Array;
+  extension: ".tar" | ".tgz";
+  filename: string;
+}
+
 export interface PGliteOptions {
   dataDir?: string;
   fs?: Filesystem;
@@ -83,6 +89,7 @@ export type PGliteInterface = {
     callback: (channel: string, payload: string) => void,
   ): () => void;
   offNotification(callback: (channel: string, payload: string) => void): void;
+  dumpDataDir(): Promise<DumpDataDirResult>;
 };
 
 export type PGliteInterfaceExtensions<E> = E extends Extensions

--- a/packages/pglite/src/pglite.ts
+++ b/packages/pglite/src/pglite.ts
@@ -203,11 +203,7 @@ export class PGlite implements PGliteInterface {
         throw new Error("Database already exists, cannot load from tarball");
       }
       this.#log("pglite: loading data from tarball");
-      const { tarball, extension } = options.loadDataDir;
-      await loadTar(this.mod.FS, {
-        tarball,
-        extension: extension === ".tar.gz" ? ".tgz" : extension,
-      });
+      await loadTar(this.mod.FS, options.loadDataDir);
     }
 
     // Check and log if the database exists
@@ -701,9 +697,7 @@ export class PGlite implements PGliteInterface {
    * Dump the PGDATA dir from the filesystem to a gziped tarball.
    */
   async dumpDataDir() {
-    const { tarball, extension } = await this.fs!.dumpTar(this.mod!.FS);
-    let filename = this.dataDir ? this.dataDir.split("/").pop() : "pgdata";
-    filename = `${filename}${extension}`;
-    return { tarball, extension, filename };
+    let dbname = this.dataDir?.split("/").pop() ?? "pgdata";
+    return this.fs!.dumpTar(this.mod!.FS, dbname);
   }
 }

--- a/packages/pglite/src/pglite.ts
+++ b/packages/pglite/src/pglite.ts
@@ -34,6 +34,8 @@ export class PGlite implements PGliteInterface {
   fs?: Filesystem;
   protected mod?: PostgresMod;
 
+  readonly dataDir?: string;
+
   #ready = false;
   #closing = false;
   #closed = false;
@@ -92,6 +94,7 @@ export class PGlite implements PGliteInterface {
     } else {
       options = dataDirOrPGliteOptions;
     }
+    this.dataDir = options.dataDir;
 
     // Enable debug logging if requested
     if (options?.debug !== undefined) {
@@ -676,5 +679,15 @@ export class PGlite implements PGliteInterface {
     options?: O,
   ): PGlite & PGliteInterfaceExtensions<O["extensions"]> {
     return new PGlite(options) as any;
+  }
+
+  /**
+   * Dump the PGDATA dir from the filesystem to a gziped tarball.
+   */
+  async dumpDataDir() {
+    const { tarball, extension } = await this.fs!.dumpTar(this.mod!.FS);
+    let filename = this.dataDir ? this.dataDir.split("/").pop() : "pgdata";
+    filename = `${filename}${extension}`;
+    return { tarball, extension, filename };
   }
 }

--- a/packages/pglite/src/pglite.ts
+++ b/packages/pglite/src/pglite.ts
@@ -16,6 +16,7 @@ import type {
   Extensions,
 } from "./interface.js";
 import { loadExtensionBundle, loadExtensions } from "./extensionUtils.js";
+import { loadTar } from "./fs/tarUtils.js";
 
 import { PGDATA, WASM_PREFIX } from "./fs/index.js";
 
@@ -193,6 +194,21 @@ export class PGlite implements PGliteInterface {
 
     // Sync the filesystem from any previous store
     await this.fs!.initialSyncFs(this.mod.FS);
+
+    // If the user has provided a tarball to load the database from, do that now.
+    // We do this after the initial sync so that we can throw if the database
+    // already exists.
+    if (options.loadDataDir) {
+      if (this.mod.FS.analyzePath(PGDATA + "/PG_VERSION").exists) {
+        throw new Error("Database already exists, cannot load from tarball");
+      }
+      this.#log("pglite: loading data from tarball");
+      const { tarball, extension } = options.loadDataDir;
+      await loadTar(this.mod.FS, {
+        tarball,
+        extension: extension === ".tar.gz" ? ".tgz" : extension,
+      });
+    }
 
     // Check and log if the database exists
     if (this.mod.FS.analyzePath(PGDATA + "/PG_VERSION").exists) {

--- a/packages/pglite/src/worker/index.ts
+++ b/packages/pglite/src/worker/index.ts
@@ -144,4 +144,8 @@ export class PGliteWorker implements PGliteInterface {
       queueMicrotask(() => listener(channel, payload));
     }
   }
+
+  async dumpDataDir() {
+    return this.#worker.dumpDataDir();
+  }
 }

--- a/packages/pglite/src/worker/process.ts
+++ b/packages/pglite/src/worker/process.ts
@@ -35,12 +35,8 @@ const worker = {
     return await db.execProtocol(message);
   },
   async dumpDataDir() {
-    const ret = await db.dumpDataDir();
-    return {
-      tarball: Comlink.transfer(ret.tarball, [ret.tarball.buffer]),
-      extension: ret.extension,
-      filename: ret.filename,
-    };
+    const file = await db.dumpDataDir();
+    return Comlink.transfer(file, [await file.arrayBuffer()]);
   },
 };
 

--- a/packages/pglite/src/worker/process.ts
+++ b/packages/pglite/src/worker/process.ts
@@ -34,6 +34,14 @@ const worker = {
   async execProtocol(message: Uint8Array) {
     return await db.execProtocol(message);
   },
+  async dumpDataDir() {
+    const ret = await db.dumpDataDir();
+    return {
+      tarball: Comlink.transfer(ret.tarball, [ret.tarball.buffer]),
+      extension: ret.extension,
+      filename: ret.filename,
+    };
+  },
 };
 
 Comlink.expose(worker);

--- a/packages/pglite/tests/dump.test.js
+++ b/packages/pglite/tests/dump.test.js
@@ -1,0 +1,30 @@
+import test from "ava";
+import { PGlite } from "../dist/index.js";
+
+test("dump data dir and load it", async (t) => {
+  const pg1 = new PGlite();
+  await pg1.exec(`
+    CREATE TABLE IF NOT EXISTS test (
+      id SERIAL PRIMARY KEY,
+      name TEXT
+    );
+  `);
+  pg1.exec("INSERT INTO test (name) VALUES ('test');");
+
+  const ret1 = await pg1.query("SELECT * FROM test;");
+  
+  const { tarball, filename, extension } = await pg1.dumpDataDir();
+
+  t.is(typeof tarball, "object");
+  t.is(typeof filename, "string");
+  t.is(typeof extension, "string");
+  
+  const pg2 = new PGlite({
+    // debug: 1,
+    loadDataDir: { tarball, extension },
+  });
+  
+  const ret2 = await pg2.query("SELECT * FROM test;");
+  
+  t.deepEqual(ret1, ret2);
+});

--- a/packages/pglite/tests/dump.test.js
+++ b/packages/pglite/tests/dump.test.js
@@ -13,15 +13,12 @@ test("dump data dir and load it", async (t) => {
 
   const ret1 = await pg1.query("SELECT * FROM test;");
   
-  const { tarball, filename, extension } = await pg1.dumpDataDir();
+  const file = await pg1.dumpDataDir();
 
-  t.is(typeof tarball, "object");
-  t.is(typeof filename, "string");
-  t.is(typeof extension, "string");
+  t.is(typeof file, "object");
   
   const pg2 = new PGlite({
-    // debug: 1,
-    loadDataDir: { tarball, extension },
+    loadDataDir: file,
   });
   
   const ret2 = await pg2.query("SELECT * FROM test;");


### PR DESCRIPTION
This introduces a new `db.dumpDataDir()` method that dumps the databases datadir to a tarball `File` object and where possible gzips it.

To load a dump `File` pass it to the options when starting PGlite:

```
const pg = new PGlite({
  loadDataDir: file,
});
```

The file object to load must be either a tar, or tar.gz. For the gzipped version it must have either a file name ending `.tar.gz` or `.tgz`, or have one of the following mime types:

 - application/x-gtar
 - application/x-tar+gzip
 - application/x-gzip
 - application/gzip

If you try to load a dump into a filesystem that already has a database initiated, it will throw an error.

To do:
- [x] `db.dumpDataDir()` to dump a tarball
- [x]  `loadDump: tarball` option when starting PGlite
- [ ] docs
- [x] tests