### PR TITLE
New method `execProtocolRaw()`

### DIFF
--- a/packages/pglite/src/interface.ts
+++ b/packages/pglite/src/interface.ts
@@ -74,6 +74,10 @@ export type PGliteInterface = {
   transaction<T>(
     callback: (tx: Transaction) => Promise<T>,
   ): Promise<T | undefined>;
+  execProtocolRaw(
+    message: Uint8Array,
+    options?: ExecProtocolOptions,
+  ): Promise<Uint8Array>;
   execProtocol(
     message: Uint8Array,
     options?: ExecProtocolOptions,

--- a/packages/pglite/src/pglite.ts
+++ b/packages/pglite/src/pglite.ts
@@ -562,7 +562,13 @@ export class PGlite implements PGliteInterface {
   }
 
   /**
-   * Execute a postgres wire protocol message directly without wrapping the response
+   * Execute a postgres wire protocol message directly without wrapping the response.
+   * Only use if `execProtocol()` doesn't suite your needs.
+   *
+   * **Warning:** This bypasses PGlite's protocol wrappers that manage error/notice messages,
+   * transactions, and notification listeners. Only use if you need to bypass these wrappers and
+   * don't intend to use the above features.
+   *
    * @param message The postgres wire protocol message to execute
    * @returns The direct message data response produced by Postgres
    */

--- a/packages/pglite/src/worker/index.ts
+++ b/packages/pglite/src/worker/index.ts
@@ -87,6 +87,10 @@ export class PGliteWorker implements PGliteInterface {
     return this.#worker.transaction(callbackProxy);
   }
 
+  async execProtocolRaw(message: Uint8Array): Promise<Uint8Array> {
+    return this.#worker.execProtocolRaw(message);
+  }
+
   async execProtocol(
     message: Uint8Array,
   ): Promise<Array<[BackendMessage, Uint8Array]>> {

--- a/packages/pglite/src/worker/process.ts
+++ b/packages/pglite/src/worker/process.ts
@@ -31,6 +31,9 @@ const worker = {
       return callback(Comlink.proxy(tx));
     });
   },
+  async execProtocolRaw(message: Uint8Array) {
+    return await db.execProtocolRaw(message);
+  },
   async execProtocol(message: Uint8Array) {
     return await db.execProtocol(message);
   },


### PR DESCRIPTION
When passing raw message data directly to PGlite via `execProtocol()` (through [`pg-gateway`](https://github.com/supabase-community/pg-gateway)), pg protocol error messages end up getting thrown by PGlite which means:
- I have to re-create the protocol error message from the `DatabaseError` object
- We lose any other messages that PG sent back (often a `ReadyForQuery` message)

Ideally there would be a way to `execProtocol` without the wrapping logic for this kind of use case. This PR proposes an `execProtocolRaw()` method that simply forwards raw message data in and returns the raw message result from PG.

Alternatively, if there is a way for `execProtocol` to not throw the `DatabaseError` and/or return the full raw message in the event of an error, that should work too.