### PR TITLE
Fix close and add support for new stage 3 ECMAScript explicit resource management

### DIFF
--- a/packages/pglite/src/pglite.ts
+++ b/packages/pglite/src/pglite.ts
@@ -31,7 +31,7 @@ import {
   NotificationResponseMessage,
 } from "pg-protocol/dist/messages.js";
 
-export class PGlite implements PGliteInterface {
+export class PGlite implements PGliteInterface, AsyncDisposable {
   fs?: Filesystem;
   protected mod?: PostgresMod;
 
@@ -362,6 +362,15 @@ export class PGlite implements PGliteInterface {
 
     this.#closed = true;
     this.#closing = false;
+  }
+
+  /**
+   * Close the database when the object exits scope
+   * Stage 3 ECMAScript Explicit Resource Management
+   * https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-2.html#using-declarations-and-explicit-resource-management
+   */
+  async [Symbol.asyncDispose]() {
+    await this.close();
   }
 
   /**

--- a/packages/pglite/src/worker/index.ts
+++ b/packages/pglite/src/worker/index.ts
@@ -16,7 +16,7 @@ export type PGliteWorkerOptions = PGliteOptions & {
   id?: string;
 };
 
-export class PGliteWorker implements PGliteInterface {
+export class PGliteWorker implements PGliteInterface, AsyncDisposable {
   #initPromise: Promise<void>;
   #debug: DebugLevel = 0;
 
@@ -298,6 +298,15 @@ export class PGliteWorker implements PGliteInterface {
     this.#tabChannel?.close();
     this.#releaseTabCloseLock?.();
     this.#workerProcess.terminate();
+  }
+
+  /**
+   * Close the database when the object exits scope
+   * Stage 3 ECMAScript Explicit Resource Management
+   * https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-2.html#using-declarations-and-explicit-resource-management
+   */
+  async [Symbol.asyncDispose]() {
+    await this.close();
   }
 
   /**

--- a/packages/pglite/tests/basic.test.js
+++ b/packages/pglite/tests/basic.test.js
@@ -371,3 +371,23 @@ test("basic copy to/from blob", async (t) => {
     affectedRows: 0,
   });
 });
+
+test("basic close", async (t) => {
+  const db = new PGlite();
+  await db.query(`
+    CREATE TABLE IF NOT EXISTS test (
+      id SERIAL PRIMARY KEY,
+      name TEXT
+    );
+  `);
+  await db.query("INSERT INTO test (name) VALUES ('test');");
+  await db.close();
+  await t.throwsAsync(
+    async () => {
+      await db.query("SELECT * FROM test;");
+    },
+    {
+      message: "PGlite is closed",
+    }
+  );
+});

--- a/packages/pglite/tests/targets/base.js
+++ b/packages/pglite/tests/targets/base.js
@@ -132,6 +132,19 @@ export function tests(env, dbFilename, target) {
     });
   });
 
+  test.serial(`targets ${target} close`, async (t) => {
+    const err = await evaluate(async () => {
+      try {
+        await db.close();
+      } catch (e) {
+        console.error(e);
+        return e.message;
+      }
+      return null;
+    });
+    t.is(err, null);
+  });
+
   if (dbFilename === "memory://") {
     // Skip the rest of the tests for memory:// as it's not persisted
     return;


### PR DESCRIPTION
There was previously a bug in Emscripten that resulted in it throwing an error when we closed the database. The code was written to expect this. With a newer Emscripten this no longer happens. I have left the old catch in place so that if we revert Emscripten or it is re-introduced this will continue to work. I have added explicit closes to the tests.

I have also (as its in the same area) added support for the new ECMAScript "Explicit Resource Management": 

https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-2.html#using-declarations-and-explicit-resource-management

https://github.com/tc39/proposal-explicit-resource-management