### PR TITLE
Add a "browser" field to package.json to hint to bundlers what is not required in the browser

### DIFF
--- a/packages/pglite/package.json
+++ b/packages/pglite/package.json
@@ -88,5 +88,17 @@
     "tsup": "^8.1.0",
     "tsx": "^4.7.1",
     "typescript": "^5.3.3"
+  },
+  "browser": {
+    "fs": false,
+    "path": false,
+    "url": false,
+    "zlib": false,
+    "stream": false,
+    "stream/promises": false,
+    "crypto": false,
+    "ws": false,
+    "child_process": false,
+    "module": false
   }
 }


### PR DESCRIPTION
Adds a "browser" field to package.json to hint to bundlers what is not required in the browser. This is a list of imports that bundlers should ignore when bundling for the web, all Node builtins either used by PGlite directly, or on some code path in the Emscripten generated js.

Fixes #139