### PR TITLE
Fix live query params

### DIFF
--- a/packages/pglite-react/test/react.test.tsx
+++ b/packages/pglite-react/test/react.test.tsx
@@ -186,7 +186,7 @@ function testLiveQuery(queryHook: "useLiveQuery" | "useLiveIncrementalQuery") {
       await waitFor(() => expect(result.current?.rows).toHaveLength(1));
     });
 
-    it.skip("updates when query parameter changes", async () => {
+    it("updates when query parameter changes", async () => {
       await db.exec(`INSERT INTO test (name) VALUES ('test1'),('test2');`);
 
       const { result, rerender } = renderHook(

--- a/packages/pglite/src/index.ts
+++ b/packages/pglite/src/index.ts
@@ -7,3 +7,4 @@ export * as protocol from "pg-protocol/src/index.js";
 export { MemoryFS } from "./fs/memoryfs.js";
 export { IdbFs } from "./fs/idbfs.js";
 export { Mutex } from "async-mutex";
+export { uuid, formatQuery } from "./utils.js";

--- a/packages/pglite/src/interface.ts
+++ b/packages/pglite/src/interface.ts
@@ -19,6 +19,7 @@ export interface QueryOptions {
   parsers?: ParserOptions;
   blob?: Blob | File;
   onNotice?: (notice: NoticeMessage) => void;
+  setAllTypes?: boolean;
 }
 
 export interface ExecProtocolOptions {

--- a/packages/pglite/src/live/index.ts
+++ b/packages/pglite/src/live/index.ts
@@ -10,7 +10,7 @@ import type {
   LiveChangesReturn,
   Change,
 } from "./interface";
-import { uuid } from "../utils.js";
+import { uuid, formatQuery } from "../utils.js";
 
 const MAX_RETRIES = 5;
 
@@ -33,9 +33,9 @@ const setup = async (pg: PGliteInterface, emscriptenOpts: any) => {
       const init = async () => {
         await pg.transaction(async (tx) => {
           // Create a temporary view with the query
+          const formattedQuery = await formatQuery(tx, query, params || []);
           await tx.query(
-            `CREATE OR REPLACE TEMP VIEW live_query_${id}_view AS ${query}`,
-            params ?? [],
+            `CREATE OR REPLACE TEMP VIEW live_query_${id}_view AS ${formattedQuery}`,
           );
 
           // Get the tables used in the view and add triggers to notify when they change
@@ -124,9 +124,9 @@ const setup = async (pg: PGliteInterface, emscriptenOpts: any) => {
       const init = async () => {
         await pg.transaction(async (tx) => {
           // Create a temporary view with the query
+          const formattedQuery = await formatQuery(tx, query, params || []);
           await tx.query(
-            `CREATE OR REPLACE TEMP VIEW live_query_${id}_view AS ${query}`,
-            params ?? [],
+            `CREATE OR REPLACE TEMP VIEW live_query_${id}_view AS ${formattedQuery}`,
           );
 
           // Get the tables used in the view and add triggers to notify when they change

--- a/packages/pglite/src/live/index.ts
+++ b/packages/pglite/src/live/index.ts
@@ -33,7 +33,7 @@ const setup = async (pg: PGliteInterface, emscriptenOpts: any) => {
       const init = async () => {
         await pg.transaction(async (tx) => {
           // Create a temporary view with the query
-          const formattedQuery = await formatQuery(tx, query, params || []);
+          const formattedQuery = await formatQuery(tx, query, params);
           await tx.query(
             `CREATE OR REPLACE TEMP VIEW live_query_${id}_view AS ${formattedQuery}`,
           );
@@ -124,7 +124,7 @@ const setup = async (pg: PGliteInterface, emscriptenOpts: any) => {
       const init = async () => {
         await pg.transaction(async (tx) => {
           // Create a temporary view with the query
-          const formattedQuery = await formatQuery(tx, query, params || []);
+          const formattedQuery = await formatQuery(tx, query, params);
           await tx.query(
             `CREATE OR REPLACE TEMP VIEW live_query_${id}_view AS ${formattedQuery}`,
           );

--- a/packages/pglite/src/pglite.ts
+++ b/packages/pglite/src/pglite.ts
@@ -86,7 +86,7 @@ export class PGlite implements PGliteInterface, AsyncDisposable {
 
   constructor(
     dataDirOrPGliteOptions: string | PGliteOptions = {},
-    options: PGliteOptions = {}
+    options: PGliteOptions = {},
   ) {
     if (typeof dataDirOrPGliteOptions === "string") {
       options = {
@@ -126,7 +126,7 @@ export class PGlite implements PGliteInterface, AsyncDisposable {
    * @returns A promise that resolves to the PGlite instance when it's ready.
    */
   static async create<O extends PGliteOptions>(
-    options?: O
+    options?: O,
   ): Promise<PGlite & PGliteInterfaceExtensions<O["extensions"]>> {
     const pg = new PGlite(options);
     await pg.waitReady;
@@ -183,7 +183,7 @@ export class PGlite implements PGliteInterface, AsyncDisposable {
               buffer: Uint8Array,
               offset: number,
               length: number,
-              position: number
+              position: number,
             ) => {
               const buf = this.#queryReadBuffer;
               if (!buf) {
@@ -202,12 +202,12 @@ export class PGlite implements PGliteInterface, AsyncDisposable {
               buffer: Uint8Array,
               offset: number,
               length: number,
-              position: number
+              position: number,
             ) => {
               callCounter++;
               this.#queryWriteChunks ??= [];
               this.#queryWriteChunks.push(
-                buffer.slice(offset, offset + length)
+                buffer.slice(offset, offset + length),
               );
               return length;
             },
@@ -246,7 +246,7 @@ export class PGlite implements PGliteInterface, AsyncDisposable {
         }
         if (extRet.bundlePath) {
           extensionBundlePromises[extName] = loadExtensionBundle(
-            extRet.bundlePath
+            extRet.bundlePath,
           ); // Don't await here, this is parallel
         }
         if (extRet.init) {
@@ -323,7 +323,7 @@ export class PGlite implements PGliteInterface, AsyncDisposable {
         if (pgdatabase !== "template1" && pguser !== "postgres") {
           // throw new Error(`Invalid database ${pgdatabase} requested`);
           throw new Error(
-            "INITDB created a new datadir, but an alternative db/user was requested"
+            "INITDB created a new datadir, but an alternative db/user was requested",
           );
         }
       }
@@ -418,7 +418,7 @@ export class PGlite implements PGliteInterface, AsyncDisposable {
   async query<T>(
     query: string,
     params?: any[],
-    options?: QueryOptions
+    options?: QueryOptions,
   ): Promise<Results<T>> {
     await this.#checkReady();
     // We wrap the public query method in the transaction mutex to ensure that
@@ -455,13 +455,14 @@ export class PGlite implements PGliteInterface, AsyncDisposable {
   async #runQuery<T>(
     query: string,
     params?: any[],
-    options?: QueryOptions
+    options?: QueryOptions,
   ): Promise<Results<T>> {
     return await this.#queryMutex.runExclusive(async () => {
       // We need to parse, bind and execute a query with parameters
       this.#log("runQuery", query, params, options);
       await this.#handleBlob(options?.blob);
-      const parsedParams = params?.map((p) => serializeType(p)) || [];
+      const parsedParams =
+        params?.map((p) => serializeType(p, options?.setAllTypes)) || [];
       let results;
       try {
         results = [
@@ -470,17 +471,17 @@ export class PGlite implements PGliteInterface, AsyncDisposable {
               text: query,
               types: parsedParams.map(([, type]) => type),
             }),
-            options
+            options,
           )),
           ...(await this.#execProtocolNoSync(
             serialize.bind({
               values: parsedParams.map(([val]) => val),
             }),
-            options
+            options,
           )),
           ...(await this.#execProtocolNoSync(
             serialize.describe({ type: "P" }),
-            options
+            options,
           )),
           ...(await this.#execProtocolNoSync(serialize.execute({}), options)),
         ];
@@ -499,7 +500,7 @@ export class PGlite implements PGliteInterface, AsyncDisposable {
       return parseResults(
         results.map(([msg]) => msg),
         options,
-        blob
+        blob,
       )[0] as Results<T>;
     });
   }
@@ -513,7 +514,7 @@ export class PGlite implements PGliteInterface, AsyncDisposable {
    */
   async #runExec(
     query: string,
-    options?: QueryOptions
+    options?: QueryOptions,
   ): Promise<Array<Results>> {
     return await this.#queryMutex.runExclusive(async () => {
       // No params so we can just send the query
@@ -523,7 +524,7 @@ export class PGlite implements PGliteInterface, AsyncDisposable {
       try {
         results = await this.#execProtocolNoSync(
           serialize.query(query),
-          options
+          options,
         );
       } finally {
         await this.#execProtocolNoSync(serialize.sync(), options);
@@ -540,7 +541,7 @@ export class PGlite implements PGliteInterface, AsyncDisposable {
       return parseResults(
         results.map(([msg]) => msg),
         options,
-        blob
+        blob,
       ) as Array<Results>;
     });
   }
@@ -551,7 +552,7 @@ export class PGlite implements PGliteInterface, AsyncDisposable {
    * @returns The result of the transaction
    */
   async transaction<T>(
-    callback: (tx: Transaction) => Promise<T>
+    callback: (tx: Transaction) => Promise<T>,
   ): Promise<T | undefined> {
     await this.#checkReady();
     return await this.#transactionMutex.runExclusive(async () => {
@@ -570,7 +571,7 @@ export class PGlite implements PGliteInterface, AsyncDisposable {
           query: async (
             query: string,
             params?: any[],
-            options?: QueryOptions
+            options?: QueryOptions,
           ) => {
             checkClosed();
             return await this.#runQuery(query, params, options);
@@ -650,7 +651,7 @@ export class PGlite implements PGliteInterface, AsyncDisposable {
    */
   async execProtocolRaw(
     message: Uint8Array,
-    { syncToFs = true }: ExecProtocolOptions = {}
+    { syncToFs = true }: ExecProtocolOptions = {},
   ) {
     const msg_len = message.length;
     const mod = this.mod!;
@@ -684,7 +685,7 @@ export class PGlite implements PGliteInterface, AsyncDisposable {
    */
   async execProtocol(
     message: Uint8Array,
-    { syncToFs = true, onNotice }: ExecProtocolOptions = {}
+    { syncToFs = true, onNotice }: ExecProtocolOptions = {},
   ): Promise<Array<[BackendMessage, Uint8Array]>> {
     const data = await this.execProtocolRaw(message, { syncToFs });
     const results: Array<[BackendMessage, Uint8Array]> = [];
@@ -735,7 +736,7 @@ export class PGlite implements PGliteInterface, AsyncDisposable {
 
   async #execProtocolNoSync(
     message: Uint8Array,
-    options: ExecProtocolOptions = {}
+    options: ExecProtocolOptions = {},
   ): Promise<Array<[BackendMessage, Uint8Array]>> {
     return await this.execProtocol(message, { ...options, syncToFs: false });
   }
@@ -812,7 +813,7 @@ export class PGlite implements PGliteInterface, AsyncDisposable {
    * @param callback The callback to call when a notification is received
    */
   onNotification(
-    callback: (channel: string, payload: string) => void
+    callback: (channel: string, payload: string) => void,
   ): () => void {
     this.#globalNotifyListeners.add(callback);
     return () => {

--- a/packages/pglite/src/utils.ts
+++ b/packages/pglite/src/utils.ts
@@ -1,3 +1,5 @@
+import type { PGliteInterface, Transaction } from "./interface.js";
+
 export const IN_NODE =
   typeof process === "object" &&
   typeof process.versions === "object" &&
@@ -68,3 +70,30 @@ export const uuid = (): string => {
     hexValues.slice(10).join("")
   );
 };
+
+export async function formatQuery(
+  pg: PGliteInterface | Transaction,
+  query: string,
+  params?: any[],
+) {
+  if (!params || params.length === 0) {
+    // no params so no formatting needed
+    return query;
+  }
+
+  // replace $1, $2, etc with  %1L, %2L, etc
+  query = query.replace(/\$([0-9]+)/g, (_, num) => {
+    return "%" + num + "L";
+  });
+
+  const ret = await pg.query<{
+    query: string;
+  }>(
+    `SELECT format($1, ${params.map((_, i) => `$${i + 2}`).join(", ")}) as query`,
+    [query, ...params],
+    {
+      setAllTypes: true,
+    },
+  );
+  return ret.rows[0].query;
+}

--- a/packages/pglite/src/utils.ts
+++ b/packages/pglite/src/utils.ts
@@ -74,7 +74,7 @@ export const uuid = (): string => {
 export async function formatQuery(
   pg: PGliteInterface | Transaction,
   query: string,
-  params?: any[],
+  params?: any[] | null,
 ) {
   if (!params || params.length === 0) {
     // no params so no formatting needed
@@ -82,7 +82,7 @@ export async function formatQuery(
   }
 
   // replace $1, $2, etc with  %1L, %2L, etc
-  query = query.replace(/\$([0-9]+)/g, (_, num) => {
+  const subbedQuery = query.replace(/\$([0-9]+)/g, (_, num) => {
     return "%" + num + "L";
   });
 
@@ -90,7 +90,7 @@ export async function formatQuery(
     query: string;
   }>(
     `SELECT format($1, ${params.map((_, i) => `$${i + 2}`).join(", ")}) as query`,
-    [query, ...params],
+    [subbedQuery, ...params],
     {
       setAllTypes: true,
     },

--- a/packages/pglite/tests/format.test.js
+++ b/packages/pglite/tests/format.test.js
@@ -1,0 +1,28 @@
+import test from "ava";
+import { PGlite, formatQuery } from "../dist/index.js";
+
+let pg;
+
+test.before(async () => {
+  pg = await PGlite.create();
+});
+
+test.serial("format boolean", async (t) => {
+  const ret1 = await formatQuery(pg, "SELECT * FROM test WHERE value = $1;", [true]);
+  t.is(ret1, "SELECT * FROM test WHERE value = 't';");
+});
+
+test.serial("format number", async (t) => {
+  const ret2 = await formatQuery(pg, "SELECT * FROM test WHERE value = $1;", [1]);
+  t.is(ret2, "SELECT * FROM test WHERE value = '1';");
+});
+
+test.serial("format string", async (t) => {
+  const ret3 = await formatQuery(pg, "SELECT * FROM test WHERE value = $1;", ["test"]);
+  t.is(ret3, "SELECT * FROM test WHERE value = 'test';");
+});
+
+test.serial("format json", async (t) => {
+  const ret4 = await formatQuery(pg, "SELECT * FROM test WHERE value = $1;", [{ test: "test" }]);
+  t.is(ret4, "SELECT * FROM test WHERE value = '{\"test\":\"test\"}';");
+});

--- a/packages/pglite/tests/live.test.js
+++ b/packages/pglite/tests/live.test.js
@@ -95,9 +95,92 @@ test.serial("basic live query", async (t) => {
     { id: 4, number: 40 },
     { id: 5, number: 50 },
   ]);
-
 });
 
+test.serial("live query with params", async (t) => {
+  const db = new PGlite({
+    extensions: { live },
+  });
+
+  await db.exec(`
+    CREATE TABLE IF NOT EXISTS test (
+      id SERIAL PRIMARY KEY,
+      number INT
+    );
+  `);
+
+  await db.exec(`
+    INSERT INTO test (number)
+    SELECT i*10 FROM generate_series(1, 5) i;
+  `);
+
+  let updatedResults;
+  const eventTarget = new EventTarget();
+
+  const { initialResults, unsubscribe } = await db.live.query(
+    "SELECT * FROM test WHERE number < $1 ORDER BY number;",
+    [40],
+    (result) => {
+      updatedResults = result;
+      eventTarget.dispatchEvent(new Event("change"));
+    }
+  );
+
+  t.deepEqual(initialResults.rows, [
+    { id: 1, number: 10 },
+    { id: 2, number: 20 },
+    { id: 3, number: 30 },
+  ]);
+
+  db.exec("INSERT INTO test (number) VALUES (25);");
+
+  await new Promise((resolve) =>
+    eventTarget.addEventListener("change", resolve, { once: true })
+  );
+
+  t.deepEqual(updatedResults.rows, [
+    { id: 1, number: 10 },
+    { id: 2, number: 20 },
+    { id: 6, number: 25 },
+    { id: 3, number: 30 },
+  ]);
+
+  db.exec("DELETE FROM test WHERE id = 6;");
+
+  await new Promise((resolve) =>
+    eventTarget.addEventListener("change", resolve, { once: true })
+  );
+
+  t.deepEqual(updatedResults.rows, [
+    { id: 1, number: 10 },
+    { id: 2, number: 20 },
+    { id: 3, number: 30 },
+  ]);
+
+  db.exec("UPDATE test SET number = 15 WHERE id = 3;");
+
+  await new Promise((resolve) =>
+    eventTarget.addEventListener("change", resolve, { once: true })
+  );
+
+  t.deepEqual(updatedResults.rows, [
+    { id: 1, number: 10 },
+    { id: 3, number: 15 },
+    { id: 2, number: 20 },
+  ]);
+
+  unsubscribe();
+
+  db.exec("INSERT INTO test (number) VALUES (35);");
+
+  await new Promise((resolve) => setTimeout(resolve, 100));
+
+  t.deepEqual(updatedResults.rows, [
+    { id: 1, number: 10 },
+    { id: 3, number: 15 },
+    { id: 2, number: 20 },
+  ]);
+});
 
 test.serial("incremental query unordered", async (t) => {
   const db = new PGlite({
@@ -131,7 +214,7 @@ test.serial("incremental query unordered", async (t) => {
 
   t.deepEqual(initialResults.rows, [
     { id: 1, number: 1 },
-    { id: 2, number: 2 }
+    { id: 2, number: 2 },
   ]);
 
   await db.exec("UPDATE test SET number = 10 WHERE id = 1;");
@@ -142,11 +225,11 @@ test.serial("incremental query unordered", async (t) => {
 
   t.deepEqual(updatedResults.rows, [
     { id: 2, number: 2 },
-    { id: 1, number: 10 }
+    { id: 1, number: 10 },
   ]);
 
   unsubscribe();
-})
+});
 
 test.serial("basic live incremental query", async (t) => {
   const db = new PGlite({
@@ -241,6 +324,92 @@ test.serial("basic live incremental query", async (t) => {
     { id: 2, number: 20 },
     { id: 4, number: 40 },
     { id: 5, number: 50 },
+  ]);
+});
+
+test.serial("live incremental query with params", async (t) => {
+  const db = new PGlite({
+    extensions: { live },
+  });
+
+  await db.exec(`
+    CREATE TABLE IF NOT EXISTS test (
+      id SERIAL PRIMARY KEY,
+      number INT
+    );
+  `);
+
+  await db.exec(`
+    INSERT INTO test (number)
+    SELECT i*10 FROM generate_series(1, 5) i;
+  `);
+
+  let updatedResults;
+  const eventTarget = new EventTarget();
+
+  const { initialResults, unsubscribe } = await db.live.incrementalQuery(
+    "SELECT * FROM test WHERE number < $1 ORDER BY number;",
+    [40],
+    "id",
+    (result) => {
+      updatedResults = result;
+      eventTarget.dispatchEvent(new Event("change"));
+    }
+  );
+
+  t.deepEqual(initialResults.rows, [
+    { id: 1, number: 10 },
+    { id: 2, number: 20 },
+    { id: 3, number: 30 },
+  ]);
+
+  await db.exec("INSERT INTO test (number) VALUES (25);");
+
+  await new Promise((resolve) =>
+    eventTarget.addEventListener("change", resolve, { once: true })
+  );
+
+  t.deepEqual(updatedResults.rows, [
+    { id: 1, number: 10 },
+    { id: 2, number: 20 },
+    { id: 6, number: 25 },
+    { id: 3, number: 30 },
+  ]);
+
+  await db.exec("DELETE FROM test WHERE id = 6;");
+
+  await new Promise((resolve) =>
+    eventTarget.addEventListener("change", resolve, { once: true })
+  );
+
+  t.deepEqual(updatedResults.rows, [
+    { id: 1, number: 10 },
+    { id: 2, number: 20 },
+    { id: 3, number: 30 },
+  ]);
+
+  await db.exec("UPDATE test SET number = 15 WHERE id = 3;");
+
+  await new Promise((resolve) =>
+    eventTarget.addEventListener("change", resolve, { once: true })
+  );
+
+  t.deepEqual(updatedResults.rows, [
+    { id: 1, number: 10 },
+    { id: 3, number: 15 },
+    { id: 2, number: 20 },
+  ]);
+
+  unsubscribe();
+
+  await db.exec("INSERT INTO test (number) VALUES (35);");
+
+  await new Promise((resolve) => setTimeout(resolve, 100));
+
+  t.deepEqual(updatedResults.rows, [
+    { id: 1, number: 10 },
+    { id: 3, number: 15 },
+    { id: 2, number: 20 },
   ]);
 });
 

--- a/packages/pglite/tests/types.test.js
+++ b/packages/pglite/tests/types.test.js
@@ -84,9 +84,18 @@ test("serialize string", (t) => {
   t.deepEqual(types.serializeType("test"), ["test", 0]);
 });
 
+test("serialize string set all types", (t) => {
+  t.deepEqual(types.serializeType("test", true), ["test", 25]);
+});
+
 test("serialize number", (t) => {
   t.deepEqual(types.serializeType(1), ["1", 0]);
   t.deepEqual(types.serializeType(1.1), ["1.1", 0]);
+});
+
+test("serialize number set all types", (t) => {
+  t.deepEqual(types.serializeType(1, true), ["1", 20]);
+  t.deepEqual(types.serializeType(1.1, true), ["1.1", 701]);
 });
 
 test("serialize bigint", (t) => {


### PR DESCRIPTION
Live queries use views to save the query in the db and then introspect what tables are used by it. Unfortunately you can't use parameters when creating a view, therefor we have to interpolate the parameters into the sql query.

We do this by introducing a `formatQuery` utility function that interpolates parameters into the query using the Postgres `format` function. Although it requires an instance of PGlite or a transaction as its first argument I decanted to keep it separate rather than a method on pglite/tx as its an advanced utility and not something that should be used all the time.