### PR TITLE
Fix OPFS AHP state WAL loading

### DIFF
--- a/packages/pglite/src/fs/opfs-ahp/opfsAhp.ts
+++ b/packages/pglite/src/fs/opfs-ahp/opfsAhp.ts
@@ -122,7 +122,7 @@ export class OpfsAhp {
       if (typeof this[methodName as keyof this] === 'function') {
         try {
           const method = this[methodName as keyof this] as any
-          method(...entry.args)
+          method.bind(this)(...entry.args)
         } catch (e) {
           console.warn('Error applying OPFS AHP WAL entry', entry, e)
         }


### PR DESCRIPTION
Fixes subtle bug introduced in #152 where the method is called without being bound to `this`.