### PR TITLE
chore: Update package version and release settings

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,6 +7,6 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["docs"],
+  "ignore": [],
   "privatePackages": { "tag": true, "version": true }
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,7 @@
 {
   "name": "docs",
   "type": "module",
+  "private": true,
   "scripts": {
     "docs:dev": "vitepress dev",
     "docs:build": "vitepress build",

--- a/packages/pglite/package.json
+++ b/packages/pglite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@electric-sql/pglite",
-  "version": "0.2.0-alpha.9",
+  "version": "0.2.0",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/packages/repl/package.json
+++ b/packages/repl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@electric-sql/pglite-repl",
-  "version": "0.0.1-alpha.0",
+  "version": "0.2.0",
   "author": "Electric DB Limited",
   "license": "Apache-2.0",
   "private": false,


### PR DESCRIPTION
Turn docs into private package so changeset ignores it

Also bump all packages to `0.2.0` for the release

@samwillis we will have to manually release `pglite-react` and `pglite-sync` before changesets can start bumping those