### PR TITLE
docs: enable local search

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -130,6 +130,9 @@ export default defineConfig({
         'Dual-licensed under <a href="https://github.com/electric-sql/pglite/blob/main/LICENSE">Apache 2.0</a> and the <a href="https://github.com/electric-sql/pglite/blob/main/POSTGRES-LICENSE">PostgreSQL License</a>',
       copyright: '© <a href="https://electric-sql.com/">ElectricSQL</a>',
     },
+    search: {
+      provider: 'local',
+    },
   },
   vue: {
     template: {


### PR DESCRIPTION
This enables the vitepress local search feature:

![image](https://github.com/user-attachments/assets/688848a5-9e1c-4ed3-b0b2-ef45caf8386c)
