### PR TITLE
Add mobile support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 
 ![PGlite](https://raw.githubusercontent.com/electric-sql/pglite/main/screenshot.png)
 
-PGlite is a WASM Postgres build packaged into a TypeScript client library that enables you to run Postgres in the browser, Node.js and Bun, with no need to install any other dependencies. It is only 3mb gzipped and has support for many Postgres extensions, including [pgvector](https://github.com/pgvector/pgvector).
+PGlite is a WASM Postgres build packaged into a TypeScript client library that enables you to run Postgres in the browser, Node.js, Bun, and mobile platforms using React Native and Expo, with no need to install any other dependencies. It is only 3mb gzipped and has support for many Postgres extensions, including [pgvector](https://github.com/pgvector/pgvector).
 
 ```javascript
 import { PGlite } from "@electric-sql/pglite";
@@ -98,6 +98,32 @@ or to persist to the filesystem:
 
 ```javascript
 const db = new PGlite("./path/to/pgdata");
+```
+
+## Mobile (React Native/Expo)
+
+Install into your project:
+
+```bash
+npm install @electric-sql/pglite
+```
+
+To use the in-memory Postgres:
+
+```javascript
+import { PGlite } from "@electric-sql/pglite";
+
+const db = new PGlite();
+await db.query("select 'Hello world' as message;");
+// -> { rows: [ { message: "Hello world" } ] }
+```
+
+or to persist to the filesystem:
+
+```javascript
+import * as FileSystem from 'expo-file-system';
+
+const db = new PGlite(FileSystem.documentDirectory + 'pgdata');
 ```
 
 ## How it works

--- a/docs/docs/about.md
+++ b/docs/docs/about.md
@@ -1,6 +1,6 @@
 # What is PGlite
 
-PGlite is a [WASM](https://webassembly.org/) Postgres build packaged into a TypeScript/JavaScript client library, that enables you to run Postgres in the browser, [Node.js](https://nodejs.org/) and [Bun](https://bun.sh/), with no need to install any other dependencies. It's under 3mb Gzipped, and has support for many [Postgres extensions](../extensions/), including [pgvector](../extensions/#pgvector).
+PGlite is a [WASM](https://webassembly.org/) Postgres build packaged into a TypeScript/JavaScript client library, that enables you to run Postgres in the browser, [Node.js](https://nodejs.org/), [Bun](https://bun.sh/), and mobile platforms using React Native and Expo, with no need to install any other dependencies. It's under 3mb Gzipped, and has support for many [Postgres extensions](../extensions/), including [pgvector](../extensions/#pgvector).
 
 Getting started with PGlite is simple: just install and import the NPM package, then create your embedded database:
 

--- a/docs/docs/filesystems.md
+++ b/docs/docs/filesystems.md
@@ -117,3 +117,29 @@ The Origin Private Filesystem API provides both asynchronous and synchronous met
 To overcome these limitations, and to provide a fully synchronous file system to PGlite on top of OPFS, we use something called an "access handle pool". When you first start PGlite we open a pool of OPFS access handles with randomised file names; these are then allocated to files as needed. After each query, a pool maintenance job is scheduled that maintains its size. When you inspect the OPFS directory where the database is stored, you will not see the normal Postgres directory layout, but rather a pool of files and a state file containing the directory tree mapping along with file metadata.
 
 The PGlite OPFS AHP FS is inspired by the [wa-sqlite](https://github.com/rhashimoto/wa-sqlite) access handle pool file system by [Roy Hashimoto](https://github.com/rhashimoto).
+
+## Mobile FS
+
+The Mobile FS is designed for use with React Native and Expo, allowing PGlite to persist data to the filesystem on mobile devices.
+
+To use the Mobile FS you can use one of these methods:
+
+- Set the `dataDir` to a directory within the mobile filesystem
+  ```ts
+  import * as FileSystem from 'expo-file-system';
+  const pg = new PGlite(FileSystem.documentDirectory + 'pgdata')
+  ```
+- Import and pass the FS explicitly
+  ```ts
+  import { MobileFS } from '@electric-sql/pglite/mobile'
+  import * as FileSystem from 'expo-file-system';
+  const pg = new PGlite({
+    fs: new MobileFS(FileSystem.documentDirectory + 'pgdata'),
+  })
+  ```
+
+### Platform Support
+
+| Node | Bun | Chrome | Safari | Firefox | React Native | Expo |
+| ---- | --- | ------ | ------ | ------- | ------------ | ---- |
+|      |     |        |        |         | ✓            | ✓    |

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -1,6 +1,6 @@
 # Getting started with PGlite
 
-PGlite can be used in both Node/Bun or the browser, and with any JavaScript framework.
+PGlite can be used in Node.js, Bun, the browser, and mobile platforms using React Native and Expo, and with any JavaScript framework.
 
 ## Install and start in Node/Bun
 
@@ -64,6 +64,46 @@ or to persist the database to IndexedDB:
 
 ```js
 const db = new PGlite('idb://my-pgdata')
+```
+
+## Install and start in mobile applications
+
+Install into your project:
+
+::: code-group
+
+```bash [npm]
+npm install @electric-sql/pglite
+```
+
+```bash [pnpm]
+pnpm install @electric-sql/pglite
+```
+
+```bash [yarn]
+yarn add @electric-sql/pglite
+```
+
+```bash [bun]
+bun install @electric-sql/pglite
+```
+
+:::
+
+To use the in-memory Postgres:
+
+```js
+import { PGlite } from '@electric-sql/pglite'
+
+const db = new PGlite()
+```
+
+or to persist to the filesystem:
+
+```js
+import * as FileSystem from 'expo-file-system';
+
+const db = new PGlite(FileSystem.documentDirectory + 'pgdata');
 ```
 
 ## Making a query

--- a/packages/pglite/src/fs/index.ts
+++ b/packages/pglite/src/fs/index.ts
@@ -1,6 +1,7 @@
 import type { FsType, Filesystem } from './types.js'
 import { IdbFs } from './idbfs.js'
 import { MemoryFS } from './memoryfs.js'
+import { MobileFS } from './mobilefs.js'
 
 export type * from './types.js'
 
@@ -24,6 +25,10 @@ export function parseDataDir(dataDir?: string) {
     // Remove the opfsahp:// prefix, and use opfs access handle pool filesystem
     dataDir = dataDir.slice(11)
     fsType = 'opfs-ahp'
+  } else if (dataDir?.startsWith('mobile://')) {
+    // Remove the mobile:// prefix, and use mobile filesystem
+    dataDir = dataDir.slice(9)
+    fsType = 'mobilefs'
   } else if (!dataDir || dataDir?.startsWith('memory://')) {
     // Use in-memory filesystem
     fsType = 'memoryfs'
@@ -46,6 +51,8 @@ export async function loadFs(dataDir?: string, fsType?: FsType) {
     // Lazy load the opfs-ahp to so that it's optional in the bundle
     const { OpfsAhpFS } = await import('./opfs-ahp/index.js')
     fs = new OpfsAhpFS(dataDir)
+  } else if (dataDir && fsType === 'mobilefs') {
+    fs = new MobileFS(dataDir)
   } else {
     fs = new MemoryFS()
   }

--- a/packages/pglite/src/fs/mobilefs.ts
+++ b/packages/pglite/src/fs/mobilefs.ts
@@ -1,0 +1,40 @@
+import * as FileSystem from 'expo-file-system';
+import { FilesystemBase } from './types.js';
+import type { PostgresMod, FS } from '../postgresMod.js';
+import { dumpTar } from './tarUtils.js';
+
+export class MobileFS extends FilesystemBase {
+  async emscriptenOpts(opts: Partial<PostgresMod>) {
+    const options: Partial<PostgresMod> = {
+      ...opts,
+      preRun: [
+        ...(opts.preRun || []),
+        (mod: any) => {
+          mod.FS.mkdir('/mobilefs');
+          mod.FS.mount(mod.FS.filesystems.NODEFS, { root: this.dataDir }, '/mobilefs');
+        },
+      ],
+    };
+    return options;
+  }
+
+  async dumpTar(mod: FS, dbname: string) {
+    return dumpTar(mod, dbname);
+  }
+
+  async close(FS: FS): Promise<void> {
+    FS.quit();
+  }
+
+  async readFile(path: string): Promise<string> {
+    return await FileSystem.readAsStringAsync(path);
+  }
+
+  async writeFile(path: string, contents: string): Promise<void> {
+    await FileSystem.writeAsStringAsync(path, contents);
+  }
+
+  async deleteFile(path: string): Promise<void> {
+    await FileSystem.deleteAsync(path);
+  }
+}

--- a/packages/pglite/src/pglite.ts
+++ b/packages/pglite/src/pglite.ts
@@ -71,6 +71,7 @@ export class PGlite implements PGliteInterface, AsyncDisposable {
    * @param dataDir The directory to store the database files
    *                Prefix with idb:// to use indexeddb filesystem in the browser
    *                Use memory:// to use in-memory filesystem
+   *                Use mobile:// to use mobile filesystem in React Native/Expo
    * @param options Optional options
    */
   constructor(dataDir?: string, options?: PGliteOptions)
@@ -119,6 +120,7 @@ export class PGlite implements PGliteInterface, AsyncDisposable {
    * @param dataDir The directory to store the database files
    *                Prefix with idb:// to use indexeddb filesystem in the browser
    *                Use memory:// to use in-memory filesystem
+   *                Use mobile:// to use mobile filesystem in React Native/Expo
    * @param options Optional options
    * @returns A promise that resolves to the PGlite instance when it's ready.
    */

--- a/packages/pglite/tests/targets/mobile-fs.test.js
+++ b/packages/pglite/tests/targets/mobile-fs.test.js
@@ -1,0 +1,54 @@
+import test from '../polytest.js'
+import { PGlite } from '../../dist/index.js'
+import { MobileFS } from '../../dist/fs/mobilefs.js'
+import * as FileSystem from 'expo-file-system'
+
+test('MobileFS read, write, delete', async (t) => {
+  const db = new PGlite({
+    fs: new MobileFS(FileSystem.documentDirectory + 'pgdata'),
+  })
+
+  await db.exec(`
+    CREATE TABLE IF NOT EXISTS test (
+      id SERIAL PRIMARY KEY,
+      name TEXT
+    );
+  `)
+
+  await db.exec("INSERT INTO test (name) VALUES ('test');")
+
+  const res = await db.query(`
+    SELECT * FROM test;
+  `)
+
+  t.deepEqual(res, {
+    rows: [
+      {
+        id: 1,
+        name: 'test',
+      },
+    ],
+    fields: [
+      {
+        name: 'id',
+        dataTypeID: 23,
+      },
+      {
+        name: 'name',
+        dataTypeID: 25,
+      },
+    ],
+    affectedRows: 0,
+  })
+
+  // Test reading file
+  const filePath = FileSystem.documentDirectory + 'pgdata/test.txt'
+  await FileSystem.writeAsStringAsync(filePath, 'Hello, world!')
+  const fileContent = await FileSystem.readAsStringAsync(filePath)
+  t.is(fileContent, 'Hello, world!')
+
+  // Test deleting file
+  await FileSystem.deleteAsync(filePath)
+  const fileExists = await FileSystem.getInfoAsync(filePath)
+  t.false(fileExists.exists)
+})


### PR DESCRIPTION
Add support for mobile platforms using React Native and Expo.

* **README.md**:
  - Mention mobile support in the introduction.
  - Add instructions for using PGlite in mobile applications using React Native and Expo.

* **docs/docs/about.md**:
  - Mention mobile support in the introduction.

* **docs/docs/index.md**:
  - Mention mobile support in the introduction.
  - Add instructions for using PGlite in mobile applications using React Native and Expo.

* **docs/docs/filesystems.md**:
  - Add a new section for mobile-specific file systems.

* **packages/pglite/src/pglite.ts**:
  - Add mobile-specific configurations in the `PGlite` class constructor.
  - Update comments to include mobile filesystem support.

