### PR TITLE
fix: Don't add artifacts as PR comment on PRs from forks

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -7,6 +7,7 @@ concurrency:
 permissions:
   pull-requests: write
   issues: write
+  contents: read
 
 on:
   workflow_dispatch:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -103,7 +103,8 @@ jobs:
 
       - name: Create or update build outputs comment
         uses: peter-evans/create-or-update-comment@v4
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        continue-on-error: true
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
@@ -200,7 +201,8 @@ jobs:
 
       - name: Create or update build outputs comment
         uses: peter-evans/create-or-update-comment@v4
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        continue-on-error: true
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -4,6 +4,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  pull-requests: write
+  issues: write
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/build_wasm_postgres.yml
+++ b/.github/workflows/build_wasm_postgres.yml
@@ -112,7 +112,8 @@ jobs:
 
       - name: Create or update build outputs comment
         uses: peter-evans/create-or-update-comment@v4
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        continue-on-error: true
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/build_wasm_postgres.yml
+++ b/.github/workflows/build_wasm_postgres.yml
@@ -3,6 +3,7 @@ name: Build WASM PGlite files
 permissions:
   pull-requests: write
   issues: write
+  contents: read
 
 on:
   workflow_call:

--- a/.github/workflows/build_wasm_postgres.yml
+++ b/.github/workflows/build_wasm_postgres.yml
@@ -1,5 +1,9 @@
 name: Build WASM PGlite files
 
+permissions:
+  pull-requests: write
+  issues: write
+
 on:
   workflow_call:
 
@@ -33,7 +37,7 @@ jobs:
             /tmp/sdk/postgres-*.tar.gz
             postgres
             postgresql-*
-          key: build-cache-${{ hashFiles('cibuild/**', 'patches/*.c', 'patches/postgresql-*') }}
+          key: build-cache-${{ hashFiles('cibuild.sh', '.github/workflows/build_wasm_postgres.yml', 'package.json', 'cibuild/**', 'patches/*.c', 'patches/**/*.diff') }}
 
       - name: Install python-wasm-sdk for emsdk/wasi+prebuilts
         if: steps.cache-restore.outputs.cache-hit != 'true'


### PR DESCRIPTION
PRs from forks only get a read-only token from GH and thus cannot write to the pull request comments and the step will fail (see [action docs](https://github.com/peter-evans/create-or-update-comment?tab=readme-ov-file#action-inputs) )

Either we allow these tasks to fail or not run without appropriate permissions for PRs frok public forks or we use [pull_request_target](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request_target) that does grant read/write permissions on PRs from forks but is a security concern (as anything can be run from an external PR with read/write perms)

I've also updated the cache key to match @pmp-p 's suggestion