### PR TITLE
pglite-sync import can't find source files

### DIFF
--- a/.changeset/sharp-bees-smash.md
+++ b/.changeset/sharp-bees-smash.md
@@ -1,0 +1,5 @@
+---
+'@electric-sql/pglite-sync': patch
+---
+
+Fix pglite-sync package which incorrectly pointed to ./build not ./dist

--- a/packages/pglite-sync/package.json
+++ b/packages/pglite-sync/package.json
@@ -35,9 +35,9 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./build/index.d.ts",
-      "import": "./build/index.js",
-      "require": "./build/index.cjs"
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
     }
   },
   "files": [


### PR DESCRIPTION
Inside of the pglite-sync `package.json` I've replaced the non-existing `build` directory with the correct `dist` directory.