### PR TITLE
fix(pglite-sync): unsubscribe function typo

### DIFF
--- a/.changeset/angry-items-fry.md
+++ b/.changeset/angry-items-fry.md
@@ -1,0 +1,5 @@
+---
+'@electric-sql/pglite-sync': patch
+---
+
+Fix typo in `unsubscribe` API (was previously `unsuscribe`).

--- a/packages/pglite-sync/src/index.ts
+++ b/packages/pglite-sync/src/index.ts
@@ -64,12 +64,12 @@ async function createPlugin(pg: PGliteInterface, options: ElectricSyncOptions) {
         stream,
         aborter,
       })
-      const unsubsribe = () => {
+      const unsubscribe = () => {
         stream.unsubscribeAll()
         aborter.abort()
       }
       return {
-        unsubsribe,
+        unsubscribe,
         get isUpToDate() {
           return stream.isUpToDate
         },


### PR DESCRIPTION
There seems to be a small typo in the pglite-sync extension. 

Docs are correct though: https://pglite.dev/docs/sync#syncshapetotable-api