### PR TITLE
feat: Enable event triggers in single user mode

### DIFF
--- a/.changeset/purple-bugs-approve.md
+++ b/.changeset/purple-bugs-approve.md
@@ -1,0 +1,5 @@
+---
+'@electric-sql/pglite': patch
+---
+
+Enable event triggers like `ddl_command_end`.

--- a/.gitignore
+++ b/.gitignore
@@ -7,10 +7,8 @@ node_modules
 /packages/pglite/package-lock.json
 /packages/**/dist
 /build
-/postgresql-16.2.tar.bz2
-/postgresql-16.2
-/postgresql-16.3.tar.bz2
-/postgresql-16.3
+/postgresql-*.tar.bz2
+/postgresql-*
 /postgresql
 
 docs/.vitepress/dist

--- a/cibuild/build-with-docker.sh
+++ b/cibuild/build-with-docker.sh
@@ -17,11 +17,11 @@ IMG_TAG="${PG_VERSION}_${SDK_VERSION}"
 
 docker run \
   --rm \
+  -e OBJDUMP=${OBJDUMP:-true} \
   -v ./cibuild.sh:/workspace/cibuild.sh \
   -v ./cibuild:/workspace/cibuild \
   -v ./patches:/opt/patches \
   -v ./tests:/workspace/tests \
   -v ./packages/pglite:/workspace/packages/pglite \
   $IMG_NAME:$IMG_TAG \
-  -e OBJDUMP=${OBJDUMP:-true} \
   bash ./cibuild/build-all.sh

--- a/packages/pglite/package.json
+++ b/packages/pglite/package.json
@@ -80,7 +80,7 @@
     "test:integration": "pnpm test:runtimes && pnpm test:web",
     "test:clean": "rm -rf ./pgdata-test",
     "build:js": "tsup && tsx scripts/bundle-wasm.ts",
-    "build": "pnpm build:js || pnpm build:js || pnpm build:js",
+    "build": "pnpm build:js",
     "dev": "concurrently \"tsup --watch\" \"sleep 1 && tsx scripts/bundle-wasm.ts\" \"pnpm dev-server\"",
     "dev-server": "pnpm http-server ../",
     "lint": "eslint ./src ./tests --report-unused-disable-directives --max-warnings 0",

--- a/packages/pglite/tests/triggers.test.js
+++ b/packages/pglite/tests/triggers.test.js
@@ -1,0 +1,126 @@
+import { describe, it, beforeEach, afterEach } from 'vitest'
+import { PGlite } from '../dist/index.js'
+
+describe('db triggers', () => {
+  let db
+  let eventTarget
+
+  beforeEach(async () => {
+    db = await PGlite.create()
+    eventTarget = new EventTarget()
+    await db.listen('messages', (event) =>
+      eventTarget.dispatchEvent(new Event(event)),
+    )
+  })
+
+  afterEach(() => {
+    db.unlisten('messages')
+  })
+
+  describe('regular triggers', () => {
+    it('should detect insert on table', async () => {
+      const eventType = `table changed`
+      await db.exec(`
+      CREATE TABLE foo_table (id TEXT, value TEXT);
+
+      CREATE OR REPLACE FUNCTION foo() RETURNS trigger AS $$ 
+      BEGIN
+        PERFORM pg_notify('messages', '${eventType}');
+        RETURN NULL;
+      END;
+      $$ LANGUAGE plpgsql;
+
+      CREATE OR REPLACE TRIGGER table_trigger 
+      AFTER INSERT OR UPDATE OR DELETE ON foo_table 
+      EXECUTE FUNCTION foo();
+    `)
+
+      db.query(`INSERT INTO foo_table (id, value) VALUES ('foo', 'bar');`)
+      await new Promise((resolve) =>
+        eventTarget.addEventListener(eventType, resolve, { once: true }),
+      )
+    })
+  })
+
+  describe('event triggers', () => {
+    it('should detect ddl_command_end', async () => {
+      const eventType = `table created or dropped`
+      await db.exec(`
+      CREATE OR REPLACE FUNCTION foo() RETURNS event_trigger AS $$ 
+      BEGIN 
+        PERFORM pg_notify('messages','${eventType}');
+        
+      END;
+      $$ LANGUAGE plpgsql;
+
+      CREATE EVENT TRIGGER ddl_trigger
+      ON ddl_command_end
+      EXECUTE FUNCTION foo();
+    `)
+
+      db.exec(`CREATE TABLE foo_table (id TEXT, value TEXT);`)
+      await new Promise((resolve) =>
+        eventTarget.addEventListener(eventType, resolve, { once: true }),
+      )
+
+      db.exec(`DROP TABLE foo_table;`)
+      await new Promise((resolve) =>
+        eventTarget.addEventListener(eventType, resolve, { once: true }),
+      )
+    })
+
+    it('should detect ddl_command_start', async () => {
+      const eventType = `table created or dropped`
+      await db.exec(`
+      CREATE OR REPLACE FUNCTION foo() RETURNS event_trigger AS $$ 
+      BEGIN 
+        PERFORM pg_notify('messages','${eventType}');
+        
+      END;
+      $$ LANGUAGE plpgsql;
+
+      CREATE EVENT TRIGGER ddl_trigger
+      ON ddl_command_start
+      EXECUTE FUNCTION foo();
+    `)
+
+      db.exec(`CREATE TABLE foo_table (id TEXT, value TEXT);`)
+      await new Promise((resolve) =>
+        eventTarget.addEventListener(eventType, resolve, { once: true }),
+      )
+
+      db.exec(`DROP TABLE foo_table;`)
+      await new Promise((resolve) =>
+        eventTarget.addEventListener(eventType, resolve, { once: true }),
+      )
+    })
+
+    it('should detect sql_drop', async () => {
+      const eventType = `table  dropped`
+      await db.exec(`
+      CREATE OR REPLACE FUNCTION foo() RETURNS event_trigger AS $$ 
+      BEGIN 
+        PERFORM pg_notify('messages','${eventType}');
+        
+      END;
+      $$ LANGUAGE plpgsql;
+
+      CREATE EVENT TRIGGER ddl_trigger
+      ON sql_drop
+      EXECUTE FUNCTION foo();
+    `)
+
+      db.exec(`CREATE TABLE foo_table (id TEXT, value TEXT);`)
+      // -> Should NOT fire the event trigger
+      await new Promise((resolve, reject) => {
+        eventTarget.addEventListener(eventType, reject, { once: true })
+        setTimeout(resolve, 500)
+      })
+
+      db.exec(`DROP TABLE foo_table;`)
+      await new Promise((resolve) =>
+        eventTarget.addEventListener(eventType, resolve, { once: true }),
+      )
+    })
+  })
+})

--- a/patches/postgresql-emscripten/src-backend-commands-event_trigger.c.diff
+++ b/patches/postgresql-emscripten/src-backend-commands-event_trigger.c.diff
@@ -1,0 +1,67 @@
+--- postgresql/src/backend/commands/event_trigger.c
++++ postgresql-wasm/src/backend/commands/event_trigger.c
+@@ -643,6 +643,8 @@ EventTriggerDDLCommandStart(Node *parsetree)
+ 	List	   *runlist;
+ 	EventTriggerData trigdata;
+ 
++#if defined(__EMSCRIPTEN__)
++#else
+ 	/*
+ 	 * Event Triggers are completely disabled in standalone mode.  There are
+ 	 * (at least) two reasons for this:
+@@ -661,6 +663,7 @@ EventTriggerDDLCommandStart(Node *parsetree)
+ 	 */
+ 	if (!IsUnderPostmaster)
+ 		return;
++#endif
+ 
+ 	runlist = EventTriggerCommonSetup(parsetree,
+ 									  EVT_DDLCommandStart,
+@@ -691,12 +694,15 @@ EventTriggerDDLCommandEnd(Node *parsetree)
+ 	List	   *runlist;
+ 	EventTriggerData trigdata;
+ 
++#if defined(__EMSCRIPTEN__)
++#else
+ 	/*
+ 	 * See EventTriggerDDLCommandStart for a discussion about why event
+ 	 * triggers are disabled in single user mode.
+ 	 */
+ 	if (!IsUnderPostmaster)
+ 		return;
++#endif
+ 
+ 	/*
+ 	 * Also do nothing if our state isn't set up, which it won't be if there
+@@ -739,12 +745,15 @@ EventTriggerSQLDrop(Node *parsetree)
+ 	List	   *runlist;
+ 	EventTriggerData trigdata;
+ 
++#if defined(__EMSCRIPTEN__)
++#else
+ 	/*
+ 	 * See EventTriggerDDLCommandStart for a discussion about why event
+ 	 * triggers are disabled in single user mode.
+ 	 */
+ 	if (!IsUnderPostmaster)
+ 		return;
++#endif
+ 
+ 	/*
+ 	 * Use current state to determine whether this event fires at all.  If
+@@ -810,12 +819,15 @@ EventTriggerTableRewrite(Node *parsetree, Oid tableOid, int reason)
+ 	List	   *runlist;
+ 	EventTriggerData trigdata;
+ 
++#if defined(__EMSCRIPTEN__)
++#else
+ 	/*
+ 	 * See EventTriggerDDLCommandStart for a discussion about why event
+ 	 * triggers are disabled in single user mode.
+ 	 */
+ 	if (!IsUnderPostmaster)
+ 		return;
++#endif
+ 
+ 	/*
+ 	 * Also do nothing if our state isn't set up, which it won't be if there

--- a/patches/postgresql-wasm/src-backend-commands-event_trigger.c.diff
+++ b/patches/postgresql-wasm/src-backend-commands-event_trigger.c.diff
@@ -4,7 +4,7 @@
  	List	   *runlist;
  	EventTriggerData trigdata;
  
-+#if defined(__EMSCRIPTEN__)
++#if defined(__EMSCRIPTEN__) || defined(__wasi__)
 +#else
  	/*
  	 * Event Triggers are completely disabled in standalone mode.  There are
@@ -21,7 +21,7 @@
  	List	   *runlist;
  	EventTriggerData trigdata;
  
-+#if defined(__EMSCRIPTEN__)
++#if defined(__EMSCRIPTEN__) || defined(__wasi__)
 +#else
  	/*
  	 * See EventTriggerDDLCommandStart for a discussion about why event
@@ -37,7 +37,7 @@
  	List	   *runlist;
  	EventTriggerData trigdata;
  
-+#if defined(__EMSCRIPTEN__)
++#if defined(__EMSCRIPTEN__) || defined(__wasi__)
 +#else
  	/*
  	 * See EventTriggerDDLCommandStart for a discussion about why event
@@ -53,7 +53,7 @@
  	List	   *runlist;
  	EventTriggerData trigdata;
  
-+#if defined(__EMSCRIPTEN__)
++#if defined(__EMSCRIPTEN__) || defined(__wasi__)
 +#else
  	/*
  	 * See EventTriggerDDLCommandStart for a discussion about why event


### PR DESCRIPTION
Addresses https://github.com/electric-sql/pglite/issues/258

In regular postgres, event triggers are disabled in single user mode as per [the docs](https://www.postgresql.org/docs/current/sql-createeventtrigger.html#notes):
> Event triggers are disabled in single-user mode (see [postgres](https://www.postgresql.org/docs/current/app-postgres.html)). If an erroneous event trigger disables the database so much that you can't even drop the trigger, restart in single-user mode and you'll be able to do that.

I've patched `event_triggers.c` to skip the check in order to enable them in single user mode and thus PGlite. I'm not sure what "layer" the patch belongs to @pmp-p would love your input.

I've also added a test suite for the event triggers, and did a little bit of cleanup on the build scripts since I encountered some issues while working on this.