### PR TITLE
feat: Add SQL string templating to React and Vue bindings

### DIFF
--- a/.changeset/happy-waves-obey.md
+++ b/.changeset/happy-waves-obey.md
@@ -1,0 +1,5 @@
+---
+'@electric-sql/pglite': patch
+---
+
+Add `    tx.sql`` ` API to PGliteWorker transactions.

--- a/.changeset/silent-bulldogs-confess.md
+++ b/.changeset/silent-bulldogs-confess.md
@@ -1,0 +1,5 @@
+---
+'@electric-sql/pglite-react': patch
+---
+
+Add `useLiveSql` hook for SQL string templating.

--- a/.changeset/silent-bulldogs-confess.md
+++ b/.changeset/silent-bulldogs-confess.md
@@ -2,4 +2,4 @@
 '@electric-sql/pglite-react': patch
 ---
 
-Add `useLiveSql` hook for SQL string templating.
+Add `useLiveQuery.sql` hook for SQL string templating.

--- a/.changeset/stupid-seahorses-chew.md
+++ b/.changeset/stupid-seahorses-chew.md
@@ -2,4 +2,4 @@
 '@electric-sql/pglite-vue': patch
 ---
 
-Add `useLiveSql` hook for SQL string templating.
+Add `useLiveQuery.sql` hook for SQL string templating.

--- a/.changeset/stupid-seahorses-chew.md
+++ b/.changeset/stupid-seahorses-chew.md
@@ -1,0 +1,5 @@
+---
+'@electric-sql/pglite-vue': patch
+---
+
+Add `useLiveSql` hook for SQL string templating.

--- a/docs/docs/framework-hooks/react.md
+++ b/docs/docs/framework-hooks/react.md
@@ -117,6 +117,24 @@ const MyComponent = () => {
 }
 ```
 
+### useLiveSql
+
+Similarly to how you can use [`    sql`` `](../api.md#sql) to to construct SQL queries through string templating, you can do that with `    useLiveSql`` ` for the hook equivalent. See the [templating](../api.md#tagged-template-queries) section of the API for more details.
+
+```ts
+import { useLiveSql } from '@electric-sql/pglite-react'
+
+const MyComponent = () => {
+  const maxNumber = 100
+  const items = useLiveSql`
+    SELECT *
+    FROM my_table
+    WHERE number <= ${maxNumber}
+    ORDER BY number;
+  `
+// ...
+```
+
 ### useLiveIncrementalQuery
 
 The `useLiveIncrementalQuery` hook enables you to reactively re-render your component whenever the results of a live query change. It wraps the [`.live.incrementalQuery()`](../live-queries.md#liveincrementalquery) API, which provides a way to efficiently diff the query results in Postgres.
@@ -124,7 +142,7 @@ The `useLiveIncrementalQuery` hook enables you to reactively re-render your comp
 It has the interface:
 
 ```ts
-function useLiveQuery<T = { [key: string]: unknown }>(
+function useLiveIncrementalQuery<T = { [key: string]: unknown }>(
   query: string,
   params: unknown[] | undefined | null,
   key: string,

--- a/docs/docs/framework-hooks/react.md
+++ b/docs/docs/framework-hooks/react.md
@@ -117,16 +117,16 @@ const MyComponent = () => {
 }
 ```
 
-### useLiveSql
+### useLiveQuery.sql
 
-Similarly to how you can use [`    sql`` `](../api.md#sql) to to construct SQL queries through string templating, you can do that with `    useLiveSql`` ` for the hook equivalent. See the [templating](../api.md#tagged-template-queries) section of the API for more details.
+Similarly to how you can use [`    sql`` `](../api.md#sql) to to construct SQL queries through string templating, you can do that with `    useLiveQuery.sql`` ` for the hook equivalent. See the [templating](../api.md#tagged-template-queries) section of the API for more details.
 
 ```ts
-import { useLiveSql } from '@electric-sql/pglite-react'
+import { useLiveQuery } from '@electric-sql/pglite-react'
 
 const MyComponent = () => {
   const maxNumber = 100
-  const items = useLiveSql`
+  const items = useLiveQuery.sql`
     SELECT *
     FROM my_table
     WHERE number <= ${maxNumber}

--- a/docs/docs/framework-hooks/vue.md
+++ b/docs/docs/framework-hooks/vue.md
@@ -106,16 +106,16 @@ const items = useLiveQuery(
 </template>
 ```
 
-### useLiveSql
+### useLiveQuery.sql
 
-Similarly to how you can use [`    sql`` `](../api.md#sql) to to construct SQL queries through string templating, you can do that with `    useLiveSql`` ` for the hook equivalent. See the [templating](../api.md#tagged-template-queries) section of the API for more details.
+Similarly to how you can use [`    sql`` `](../api.md#sql) to to construct SQL queries through string templating, you can do that with `    useLiveQuery.sql`` ` for the hook equivalent. See the [templating](../api.md#tagged-template-queries) section of the API for more details.
 
 ```vue
 <script lang="ts">
 import { useLiveQuery } from '@electric-sql/pglite-vue'
 
 const maxNumber = 100
-const items = useLiveSql`
+const items = useLiveQuery.sql`
   SELECT *
   FROM my_table
   WHERE number <= ${maxNumber}

--- a/docs/docs/framework-hooks/vue.md
+++ b/docs/docs/framework-hooks/vue.md
@@ -76,7 +76,7 @@ It has the interface:
 ```ts
 function useLiveQuery<T = { [key: string]: unknown }>(
   query: string | WatchSource<string>,
-  params?: QueryParams | WatchSource<QueryParams>,
+  params?: QueryParams | WatchSource<QueryParams> | WatchSource<unknown>[],
 ): LiveQueryResults<T>
 ```
 
@@ -106,6 +106,25 @@ const items = useLiveQuery(
 </template>
 ```
 
+### useLiveSql
+
+Similarly to how you can use [`    sql`` `](../api.md#sql) to to construct SQL queries through string templating, you can do that with `    useLiveSql`` ` for the hook equivalent. See the [templating](../api.md#tagged-template-queries) section of the API for more details.
+
+```vue
+<script lang="ts">
+import { useLiveQuery } from '@electric-sql/pglite-vue'
+
+const maxNumber = 100
+const items = useLiveSql`
+  SELECT *
+  FROM my_table
+  WHERE number <= ${maxNumber}
+  ORDER BY number;
+`
+</script>
+// ...
+```
+
 ### useLiveIncrementalQuery
 
 The `useLiveIncrementalQuery` hook enables you to reactively receive updates whenever the results of a live query change. It wraps the [`.live.incrementalQuery()`](../live-queries.md#liveincrementalquery) API, which provides a way to efficiently diff the query results in Postgres.
@@ -115,7 +134,7 @@ It has the interface:
 ```ts
 export function useLiveIncrementalQuery<T = { [key: string]: unknown }>(
   query: string | WatchSource<string>,
-  params: QueryParams | WatchSource<QueryParams>,
+  params: QueryParams | WatchSource<QueryParams> | WatchSource<unknown>[],
   key: string | WatchSource<string>,
 ): LiveQueryResults<T>
 ```

--- a/packages/pglite-react/src/hooks.ts
+++ b/packages/pglite-react/src/hooks.ts
@@ -46,11 +46,13 @@ export function useLiveQuery<T = { [key: string]: unknown }>(
   return useLiveQueryImpl<T>(query, params)
 }
 
-export function useLiveSql<T = { [key: string]: unknown }>(
+useLiveQuery.sql = function <T = { [key: string]: unknown }>(
   strings: TemplateStringsArray,
   ...values: any[]
 ): Results<T> | undefined {
   const { query, params } = buildQuery(strings, ...values)
+  // eslint-disable-next-line react-compiler/react-compiler
+  // eslint-disable-next-line react-hooks/rules-of-hooks
   return useLiveQueryImpl<T>(query, params)
 }
 

--- a/packages/pglite-react/src/hooks.ts
+++ b/packages/pglite-react/src/hooks.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { Results } from '@electric-sql/pglite'
 import { usePGlite } from './provider'
+import { query as buildQuery } from '@electric-sql/pglite/template'
 
 function useLiveQueryImpl<T = { [key: string]: unknown }>(
   query: string,
@@ -42,6 +43,15 @@ export function useLiveQuery<T = { [key: string]: unknown }>(
   query: string,
   params: unknown[] | undefined | null,
 ): Results<T> | undefined {
+  return useLiveQueryImpl<T>(query, params)
+}
+
+export function useLiveSql<T = { [key: string]: unknown }>(
+  strings: TemplateStringsArray,
+  ...values: any[]
+): Results<T> | undefined {
+  const { query, params } = buildQuery(strings, ...values)
+  console.log(query, params)
   return useLiveQueryImpl<T>(query, params)
 }
 

--- a/packages/pglite-react/src/hooks.ts
+++ b/packages/pglite-react/src/hooks.ts
@@ -51,7 +51,6 @@ export function useLiveSql<T = { [key: string]: unknown }>(
   ...values: any[]
 ): Results<T> | undefined {
   const { query, params } = buildQuery(strings, ...values)
-  console.log(query, params)
   return useLiveQueryImpl<T>(query, params)
 }
 

--- a/packages/pglite-react/test/hooks.test.tsx
+++ b/packages/pglite-react/test/hooks.test.tsx
@@ -16,7 +16,7 @@ describe('hooks', () => {
 
   testLiveQuery('useLiveIncrementalQuery')
 
-  describe.only('useLiveSql', () => {
+  describe('useLiveSql', () => {
     let db: PGliteWithLive
     let wrapper: ({
       children,

--- a/packages/pglite-react/test/hooks.test.tsx
+++ b/packages/pglite-react/test/hooks.test.tsx
@@ -11,7 +11,7 @@ describe('hooks', () => {
 
   testLiveQuery('useLiveIncrementalQuery')
 
-  describe('useLiveSql', () => {
+  describe('useLiveQuery.sql', () => {
     let db: PGliteWithLive
     let wrapper: ({
       children,

--- a/packages/pglite-react/test/hooks.test.tsx
+++ b/packages/pglite-react/test/hooks.test.tsx
@@ -4,12 +4,7 @@ import { waitFor } from '@testing-library/dom'
 import React from 'react'
 import { PGlite } from '@electric-sql/pglite'
 import { live, PGliteWithLive } from '@electric-sql/pglite/live'
-import {
-  PGliteProvider,
-  useLiveQuery,
-  useLiveIncrementalQuery,
-  useLiveSql,
-} from '../src'
+import { PGliteProvider, useLiveQuery, useLiveIncrementalQuery } from '../src'
 
 describe('hooks', () => {
   testLiveQuery('useLiveQuery')
@@ -48,7 +43,7 @@ describe('hooks', () => {
 
       const { result, rerender } = renderHook(
         (props) =>
-          useLiveSql`SELECT * FROM test WHERE name = ${props.params[0]};`,
+          useLiveQuery.sql`SELECT * FROM test WHERE name = ${props.params[0]};`,
         { wrapper, initialProps: { params: ['test1'] } },
       )
 

--- a/packages/pglite-vue/src/hooks.ts
+++ b/packages/pglite-vue/src/hooks.ts
@@ -104,7 +104,7 @@ export function useLiveQuery<T = { [key: string]: unknown }>(
   return useLiveQueryImpl<T>(query, params)
 }
 
-export function useLiveSql<T = { [key: string]: unknown }>(
+useLiveQuery.sql = function <T = { [key: string]: unknown }>(
   strings: TemplateStringsArray,
   ...values: any[]
 ): LiveQueryResults<T> {

--- a/packages/pglite-vue/src/hooks.ts
+++ b/packages/pglite-vue/src/hooks.ts
@@ -10,8 +10,10 @@ import {
   onScopeDispose,
   ref,
   isRef,
+  unref,
 } from 'vue-demi'
 import { Results } from '@electric-sql/pglite'
+import { query as buildQuery } from '@electric-sql/pglite/template'
 import { injectPGlite } from './dependency-injection'
 
 type UnsubscribeFn = () => Promise<void>
@@ -23,7 +25,7 @@ type LiveQueryResults<T> = ToRefs<DeepReadonly<QueryResult<T>>>
 
 function useLiveQueryImpl<T = { [key: string]: unknown }>(
   query: string | WatchSource<string>,
-  params?: QueryParams | WatchSource<QueryParams>,
+  params?: QueryParams | WatchSource<QueryParams> | WatchSource<unknown>[],
   key?: string | WatchSource<string>,
 ): LiveQueryResults<T> {
   const db = injectPGlite()!
@@ -41,14 +43,18 @@ function useLiveQueryImpl<T = { [key: string]: unknown }>(
   const unsubscribeRef = shallowRef<UnsubscribeFn>()
 
   const querySource = typeof query === 'string' ? ref(query) : query
-  const paramsSource =
-    !isRef(params) && typeof params !== 'function' ? ref(params) : params
+  const paramsSources = !params
+    ? [ref(params)]
+    : Array.isArray(params)
+      ? params.map(ref)
+      : [params]
+
   const keySource = typeof key === 'string' ? ref(key) : key
 
   watch(
     key !== undefined
-      ? [querySource, paramsSource, keySource]
-      : [querySource, paramsSource],
+      ? [querySource, keySource, ...paramsSources]
+      : [querySource, ...paramsSources],
     () => {
       let cancelled = false
       const cb = (results: Results<T>) => {
@@ -60,14 +66,22 @@ function useLiveQueryImpl<T = { [key: string]: unknown }>(
         }
       }
 
-      const query = isRef(querySource) ? querySource.value : querySource()
-      const params = isRef(paramsSource) ? paramsSource.value : paramsSource()
+      const query = isRef(querySource) ? unref(querySource) : querySource()
+
+      const paramVals = isRef(params)
+        ? unref(params)
+        : typeof params === 'function'
+          ? params()
+          : Array.isArray(params)
+            ? params.map(unref)
+            : [params]
+
       const key = isRef(keySource) ? keySource.value : keySource?.()
 
       const ret =
         key !== undefined
-          ? db.live.incrementalQuery<T>(query, params, key, cb)
-          : db.live.query<T>(query, params, cb)
+          ? db.live.incrementalQuery<T>(query, paramVals, key, cb)
+          : db.live.query<T>(query, paramVals, cb)
 
       unsubscribeRef.value = () => {
         cancelled = true
@@ -85,14 +99,22 @@ function useLiveQueryImpl<T = { [key: string]: unknown }>(
 
 export function useLiveQuery<T = { [key: string]: unknown }>(
   query: string | WatchSource<string>,
-  params?: QueryParams | WatchSource<QueryParams>,
+  params?: QueryParams | WatchSource<QueryParams> | WatchSource<unknown>[],
 ): LiveQueryResults<T> {
+  return useLiveQueryImpl<T>(query, params)
+}
+
+export function useLiveSql<T = { [key: string]: unknown }>(
+  strings: TemplateStringsArray,
+  ...values: any[]
+): LiveQueryResults<T> {
+  const { query, params } = buildQuery(strings, ...values)
   return useLiveQueryImpl<T>(query, params)
 }
 
 export function useLiveIncrementalQuery<T = { [key: string]: unknown }>(
   query: string | WatchSource<string>,
-  params: QueryParams | WatchSource<QueryParams>,
+  params: QueryParams | WatchSource<QueryParams> | WatchSource<unknown>[],
   key: string | WatchSource<string>,
 ): LiveQueryResults<T> {
   return useLiveQueryImpl<T>(query, params, key)

--- a/packages/pglite-vue/test/hooks.test.ts
+++ b/packages/pglite-vue/test/hooks.test.ts
@@ -26,7 +26,7 @@ describe('hooks', () => {
 
   testLiveQuery('useLiveIncrementalQuery')
 
-  describe('useLiveSql', () => {
+  describe('useLiveQuery.sql', () => {
     beforeEach(async () => {
       // prepare db for test
       db = await PGlite.create({
@@ -44,12 +44,12 @@ describe('hooks', () => {
     })
 
     it('updates when query parameter ref changes', async () => {
-      const { useLiveSql } = await import('../src')
+      const { useLiveQuery } = await import('../src')
       await db.exec(`INSERT INTO test (name) VALUES ('test1'),('test2');`)
 
       const param = ref('test1')
 
-      const result = useLiveSql`SELECT * FROM test WHERE name = ${param};`
+      const result = useLiveQuery.sql`SELECT * FROM test WHERE name = ${param};`
 
       await flushPromises()
       expect(result?.rows?.value).toEqual([

--- a/packages/pglite-vue/test/hooks.test.ts
+++ b/packages/pglite-vue/test/hooks.test.ts
@@ -2,7 +2,7 @@ import { vi, describe, it, expect, beforeEach, beforeAll } from 'vitest'
 import { ref } from 'vue-demi'
 import { PGlite } from '@electric-sql/pglite'
 import { live, PGliteWithLive } from '@electric-sql/pglite/live'
-import type { useLiveIncrementalQuery, useLiveQuery } from '../src'
+import { type useLiveIncrementalQuery, type useLiveQuery } from '../src'
 
 function flushPromises(timeoutMs = 0): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, timeoutMs))
@@ -25,6 +25,51 @@ describe('hooks', () => {
   testLiveQuery('useLiveQuery')
 
   testLiveQuery('useLiveIncrementalQuery')
+
+  describe('useLiveSql', () => {
+    beforeEach(async () => {
+      // prepare db for test
+      db = await PGlite.create({
+        extensions: {
+          live,
+        },
+      })
+
+      await db.exec(`
+        CREATE TABLE IF NOT EXISTS test (
+          id SERIAL PRIMARY KEY,
+          name TEXT
+        );
+      `)
+    })
+
+    it('updates when query parameter ref changes', async () => {
+      const { useLiveSql } = await import('../src')
+      await db.exec(`INSERT INTO test (name) VALUES ('test1'),('test2');`)
+
+      const param = ref('test1')
+
+      const result = useLiveSql`SELECT * FROM test WHERE name = ${param};`
+
+      await flushPromises()
+      expect(result?.rows?.value).toEqual([
+        {
+          id: 1,
+          name: 'test1',
+        },
+      ])
+
+      param.value = 'test2'
+
+      await flushPromises()
+      expect(result?.rows?.value).toEqual([
+        {
+          id: 2,
+          name: 'test2',
+        },
+      ])
+    })
+  })
 })
 function testLiveQuery(queryHook: 'useLiveQuery' | 'useLiveIncrementalQuery') {
   describe(queryHook, () => {


### PR DESCRIPTION
Self explanatory, adds `    useLiveSql`` ` hooks to both React and Vue bindings along with docs and tests