### PR TITLE
fix: Add `dataDir` string arg to `create` factory method

### DIFF
--- a/.changeset/odd-files-itch.md
+++ b/.changeset/odd-files-itch.md
@@ -1,0 +1,5 @@
+---
+'@electric-sql/pglite': patch
+---
+
+Implement `.create(dataDir: string, options: PGliteOptions)` signature for factory method to match constructor.

--- a/packages/pglite/src/pglite.ts
+++ b/packages/pglite/src/pglite.ts
@@ -70,7 +70,7 @@ export class PGlite implements PGliteInterface, AsyncDisposable {
    * @param dataDir The directory to store the database files
    *                Prefix with idb:// to use indexeddb filesystem in the browser
    *                Use memory:// to use in-memory filesystem
-   * @param options Optional options
+   * @param options PGlite options
    */
   constructor(dataDir?: string, options?: PGliteOptions)
 
@@ -115,16 +115,42 @@ export class PGlite implements PGliteInterface, AsyncDisposable {
    * Create a new PGlite instance with extensions on the Typescript interface
    * (The main constructor does enable extensions, however due to the limitations
    * of Typescript, the extensions are not available on the instance interface)
+   * @param options PGlite options including the data directory
+   * @returns A promise that resolves to the PGlite instance when it's ready.
+   */
+
+  static async create<O extends PGliteOptions>(
+    options?: O,
+  ): Promise<PGlite & PGliteInterfaceExtensions<O['extensions']>>
+
+  /**
+   * Create a new PGlite instance with extensions on the Typescript interface
+   * (The main constructor does enable extensions, however due to the limitations
+   * of Typescript, the extensions are not available on the instance interface)
    * @param dataDir The directory to store the database files
    *                Prefix with idb:// to use indexeddb filesystem in the browser
    *                Use memory:// to use in-memory filesystem
-   * @param options Optional options
+   * @param options PGlite options
    * @returns A promise that resolves to the PGlite instance when it's ready.
    */
   static async create<O extends PGliteOptions>(
+    dataDir?: string,
+    options?: O,
+  ): Promise<PGlite & PGliteInterfaceExtensions<O['extensions']>>
+
+  static async create<O extends PGliteOptions>(
+    dataDirOrPGliteOptions?: string | O,
     options?: O,
   ): Promise<PGlite & PGliteInterfaceExtensions<O['extensions']>> {
-    const pg = new PGlite(options)
+    const resolvedOpts: PGliteOptions =
+      typeof dataDirOrPGliteOptions === 'string'
+        ? {
+            dataDir: dataDirOrPGliteOptions,
+            ...(options ?? {}),
+          }
+        : dataDirOrPGliteOptions ?? {}
+
+    const pg = new PGlite(resolvedOpts)
     await pg.waitReady
     return pg as any
   }

--- a/packages/pglite/tests/instantiation.test.ts
+++ b/packages/pglite/tests/instantiation.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+import { PGlite } from '../dist/index.js'
+
+describe('instantiation', () => {
+  testInstatiationMethod('constructor')
+  testInstatiationMethod('static `create` factory')
+})
+
+function testInstatiationMethod(
+  method: 'constructor' | 'static `create` factory',
+) {
+  const instantiateDb = async (...args) => {
+    switch (method) {
+      case 'constructor':
+        return new PGlite(...args)
+      case 'static `create` factory':
+        return await PGlite.create(...args)
+      default:
+        throw new Error(`Invalid instantiation method ${method}`)
+    }
+  }
+
+  describe(`${method}`, () => {
+    it('should instantiate with defaults', async () => {
+      const pg = await instantiateDb()
+      const res = await pg.query(`SELECT 1 as one;`)
+      expect(res.rows[0]?.['one']).toBe(1)
+    })
+
+    it('should instantiate with data dir argument', async () => {
+      const pg = await instantiateDb('./pgdata-test')
+      const res = await pg.query(`SELECT 1 as one;`)
+      expect(res.rows[0]?.['one']).toBe(1)
+    })
+
+    it('should instantiate with options', async () => {
+      const pg = await instantiateDb({
+        dataDir: './pgdata-test',
+      })
+      const res = await pg.query(`SELECT 1 as one;`)
+      expect(res.rows[0]?.['one']).toBe(1)
+    })
+  })
+}

--- a/packages/pglite/vitest.config.ts
+++ b/packages/pglite/vitest.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     typecheck: { enabled: true },
     testTimeout: 30000,
     hookTimeout: 30000,
-    include: ['**/*.{test,test.web}.js'],
+    include: ['**/*.{test,test.web}.{js,ts}'],
     server: {
       deps: {
         external: [/\/tests\/targets\/web\//],


### PR DESCRIPTION
Addresses https://github.com/electric-sql/pglite/issues/268

Docs already mention the `.create` factory method having this signature but it does not support it, so I implemented it to match the constructor.

I've added some _very_ basic tests for instantiation, they don't cover all options or even test they work (no checking of the assigned data dir being created) but they're a boilerplate for the method signature existing and we can add to it. Also mind the test is now a typescript test, as vitest and bun both support those - we can migrate the existing ones to .ts as well.