### PR TITLE
docs: vite wasm configuration

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -66,6 +66,19 @@ or to persist the database to IndexedDB:
 const db = new PGlite('idb://my-pgdata')
 ```
 
+### Using with Vite
+When using Vite, make sure to add `optimizeDeps` inside `vite.config.js`:
+
+```js
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  optimizeDeps: {
+    exclude: ['@electric-sql/pglite'],
+  },
+});
+```
+
 ## Making a query
 
 There are two methods for querying the database, `.query` and `.exec`. The former supports parameters, while the latter supports multiple statements.


### PR DESCRIPTION
I tried using `pglite` with vite and I hit a wasm error. After some research I found the solution [here](https://github.com/electric-sql/pglite/issues/199#issuecomment-2290924017).

Since I think a lot of devs will use vite to try `pglite`, this PR adds info about the vite configuration necessary to run `pglite`.