### PR TITLE
docs: add typeorm snippet

### DIFF
--- a/docs/docs/orm-support.md
+++ b/docs/docs/orm-support.md
@@ -51,11 +51,10 @@ class LitePg {
     }
   }
   end(callback) {
-    if (callback) {
-      setImmediate(callback);
-    } else {
-      return Promise.resolve();
+    if (!callback) {
+      return db.close();
     }
+    db.close().then(callback, callback);
   }
   connect(callback) {
     if (callback) {


### PR DESCRIPTION
All postgres ORMs rely on the [pg](https://www.npmjs.com/package/pg) driver. Thankfully, pglite's API is nearly identical to pg's making it very easy to adapt. This is an example of one such adapter for typeorm, though it is applicable to any orm that supports plugging in a custom driver.