### PR TITLE
feat: add turbo build support

### DIFF
--- a/.changeset/blue-maps-sit.md
+++ b/.changeset/blue-maps-sit.md
@@ -1,0 +1,11 @@
+---
+'benchmark': major
+'@electric-sql/pg-protocol': major
+'@electric-sql/pglite': major
+'@electric-sql/pglite-react': major
+'@electric-sql/pglite-repl': major
+'@electric-sql/pglite-sync': major
+'@electric-sql/pglite-vue': major
+---
+
+add turbo build tool for project

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.turbo
 .vscode
 
 node_modules

--- a/package.json
+++ b/package.json
@@ -4,12 +4,16 @@
     "node": ">=20",
     "pnpm": ">=9"
   },
+  "name": "@electric-sql/pglite",
   "packageManager": "pnpm@9.7.0",
   "private": true,
   "type": "module",
   "scripts": {
     "ci:version": "pnpm exec changeset version",
     "ci:publish": "pnpm changeset publish",
+    "build": "turbo run build",
+    "lint": "turbo run lint",
+    "test": "turbo run test",
     "wasm:build": "bash ./cibuild/build-with-docker.sh"
   },
   "devDependencies": {
@@ -22,6 +26,7 @@
     "prettier": "3.2.5",
     "tsup": "^8.1.0",
     "tsx": "^4.8.1",
+    "turbo": "^2.1.0",
     "typescript": "^5.3.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,10 +31,13 @@ importers:
         version: 3.2.5
       tsup:
         specifier: ^8.1.0
-        version: 8.2.4(@microsoft/api-extractor@7.47.4(@types/node@22.4.1))(postcss@8.4.41)(tsx@4.17.0)(typescript@5.5.4)
+        version: 8.2.4(@microsoft/api-extractor@7.47.4)(postcss@8.4.41)(tsx@4.17.0)(typescript@5.5.4)
       tsx:
         specifier: ^4.8.1
         version: 4.17.0
+      turbo:
+        specifier: ^2.1.0
+        version: 2.1.0
       typescript:
         specifier: ^5.3.3
         version: 5.5.4
@@ -4117,6 +4120,40 @@ packages:
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
+  turbo-darwin-64@2.1.0:
+    resolution: {integrity: sha512-gHwpDk2gyB7qZ57gUUwDIS/IkglqEjjVtPZCTxmCRg28Tiwjui0azsLVKrnHP9UZHllozwbi28x8HXLXLEFF1w==}
+    cpu: [x64]
+    os: [darwin]
+
+  turbo-darwin-arm64@2.1.0:
+    resolution: {integrity: sha512-GLaqGetNC6eS4eqXgsheLOHic/OcnGCGDi5boVf+TFZTXYH6YE15L4ugZha4xHXCr1KouCLILHh+f8EHEmWylg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  turbo-linux-64@2.1.0:
+    resolution: {integrity: sha512-VzBOsj7JyGoZtiNZZ6brjnY7UehRnClluw7pwznuLPzClkqOOPMd2jOcgkWxnP/xW4NBmOoFANXXrtvKBD4f2w==}
+    cpu: [x64]
+    os: [linux]
+
+  turbo-linux-arm64@2.1.0:
+    resolution: {integrity: sha512-St7svJnOO5g4F6R7Z32e10I/0M3e6qpNjEYybXwPNul9NSfnUXeky4WoKaALwqNhyJ7nYemoFpZ1d+i8hFQTHg==}
+    cpu: [arm64]
+    os: [linux]
+
+  turbo-windows-64@2.1.0:
+    resolution: {integrity: sha512-iSobNud2MrJ1SZ1upVPlErT8xexsr0MQtKapdfq6z0M0rBnrDGEq5bUCSScWyGu+O4+glB4br9xkTAkGFqaxqQ==}
+    cpu: [x64]
+    os: [win32]
+
+  turbo-windows-arm64@2.1.0:
+    resolution: {integrity: sha512-d61jN4rjE5PnUfF66GKrKoj8S8Ql4FGXzFFzZz4kjsHpZZzCTtqlzPZBmd1byzGYhDPTorTqG3G1USohbdyohA==}
+    cpu: [arm64]
+    os: [win32]
+
+  turbo@2.1.0:
+    resolution: {integrity: sha512-A969/LO/sPHKlapIarY2VVzqQ5JnnW2/1kksZlnMEpsRD6gwOELvVL+ozfMiO7av9RILt3UeN02L17efr6HUCA==}
+    hasBin: true
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -5557,15 +5594,6 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  '@microsoft/api-extractor-model@7.29.4(@types/node@22.4.1)':
-    dependencies:
-      '@microsoft/tsdoc': 0.15.0
-      '@microsoft/tsdoc-config': 0.17.0
-      '@rushstack/node-core-library': 5.5.1(@types/node@22.4.1)
-    transitivePeerDependencies:
-      - '@types/node'
-    optional: true
-
   '@microsoft/api-extractor@7.47.4(@types/node@20.14.15)':
     dependencies:
       '@microsoft/api-extractor-model': 7.29.4(@types/node@20.14.15)
@@ -5583,25 +5611,6 @@ snapshots:
       typescript: 5.4.2
     transitivePeerDependencies:
       - '@types/node'
-
-  '@microsoft/api-extractor@7.47.4(@types/node@22.4.1)':
-    dependencies:
-      '@microsoft/api-extractor-model': 7.29.4(@types/node@22.4.1)
-      '@microsoft/tsdoc': 0.15.0
-      '@microsoft/tsdoc-config': 0.17.0
-      '@rushstack/node-core-library': 5.5.1(@types/node@22.4.1)
-      '@rushstack/rig-package': 0.5.3
-      '@rushstack/terminal': 0.13.3(@types/node@22.4.1)
-      '@rushstack/ts-command-line': 4.22.3(@types/node@22.4.1)
-      lodash: 4.17.21
-      minimatch: 3.0.8
-      resolve: 1.22.8
-      semver: 7.5.4
-      source-map: 0.6.1
-      typescript: 5.4.2
-    transitivePeerDependencies:
-      - '@types/node'
-    optional: true
 
   '@microsoft/tsdoc-config@0.17.0':
     dependencies:
@@ -5747,20 +5756,6 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.14.15
 
-  '@rushstack/node-core-library@5.5.1(@types/node@22.4.1)':
-    dependencies:
-      ajv: 8.13.0
-      ajv-draft-04: 1.0.0(ajv@8.13.0)
-      ajv-formats: 3.0.1(ajv@8.13.0)
-      fs-extra: 7.0.1
-      import-lazy: 4.0.0
-      jju: 1.4.0
-      resolve: 1.22.8
-      semver: 7.5.4
-    optionalDependencies:
-      '@types/node': 22.4.1
-    optional: true
-
   '@rushstack/rig-package@0.5.3':
     dependencies:
       resolve: 1.22.8
@@ -5773,14 +5768,6 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.14.15
 
-  '@rushstack/terminal@0.13.3(@types/node@22.4.1)':
-    dependencies:
-      '@rushstack/node-core-library': 5.5.1(@types/node@22.4.1)
-      supports-color: 8.1.1
-    optionalDependencies:
-      '@types/node': 22.4.1
-    optional: true
-
   '@rushstack/ts-command-line@4.22.3(@types/node@20.14.15)':
     dependencies:
       '@rushstack/terminal': 0.13.3(@types/node@20.14.15)
@@ -5789,16 +5776,6 @@ snapshots:
       string-argv: 0.3.2
     transitivePeerDependencies:
       - '@types/node'
-
-  '@rushstack/ts-command-line@4.22.3(@types/node@22.4.1)':
-    dependencies:
-      '@rushstack/terminal': 0.13.3(@types/node@22.4.1)
-      '@types/argparse': 1.0.38
-      argparse: 1.0.10
-      string-argv: 0.3.2
-    transitivePeerDependencies:
-      - '@types/node'
-    optional: true
 
   '@shikijs/core@1.12.1':
     dependencies:
@@ -6217,10 +6194,26 @@ snapshots:
       magic-string: 0.30.11
       msw: 2.3.5(typescript@5.5.4)
       sirv: 2.0.4
-      vitest: 2.0.5(@types/node@22.4.1)(@vitest/browser@2.0.5)(@vitest/ui@2.0.5)(jsdom@24.1.1)(terser@5.31.6)
+      vitest: 2.0.5(@types/node@20.14.15)(@vitest/browser@2.0.5)(@vitest/ui@2.0.5)(jsdom@24.1.1)(terser@5.31.6)
       ws: 8.18.0
     optionalDependencies:
       playwright: 1.46.0
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+    optional: true
+
+  '@vitest/browser@2.0.5(typescript@5.5.4)(vitest@2.0.5)':
+    dependencies:
+      '@testing-library/dom': 10.4.0
+      '@testing-library/user-event': 14.5.2(@testing-library/dom@10.4.0)
+      '@vitest/utils': 2.0.5
+      magic-string: 0.30.11
+      msw: 2.3.5(typescript@5.5.4)
+      sirv: 2.0.4
+      vitest: 2.0.5(@types/node@22.4.1)(@vitest/browser@2.0.5)(@vitest/ui@2.0.5)(jsdom@24.1.1)(terser@5.31.6)
+      ws: 8.18.0
     transitivePeerDependencies:
       - bufferutil
       - typescript
@@ -8902,7 +8895,7 @@ snapshots:
 
   tslib@2.6.3: {}
 
-  tsup@8.2.4(@microsoft/api-extractor@7.47.4(@types/node@22.4.1))(postcss@8.4.41)(tsx@4.17.0)(typescript@5.5.4):
+  tsup@8.2.4(@microsoft/api-extractor@7.47.4)(postcss@8.4.41)(tsx@4.17.0)(typescript@5.5.4):
     dependencies:
       bundle-require: 5.0.0(esbuild@0.23.0)
       cac: 6.7.14
@@ -8921,7 +8914,7 @@ snapshots:
       sucrase: 3.35.0
       tree-kill: 1.2.2
     optionalDependencies:
-      '@microsoft/api-extractor': 7.47.4(@types/node@22.4.1)
+      '@microsoft/api-extractor': 7.47.4(@types/node@20.14.15)
       postcss: 8.4.41
       typescript: 5.5.4
     transitivePeerDependencies:
@@ -8940,6 +8933,33 @@ snapshots:
   tunnel-agent@0.6.0:
     dependencies:
       safe-buffer: 5.2.1
+
+  turbo-darwin-64@2.1.0:
+    optional: true
+
+  turbo-darwin-arm64@2.1.0:
+    optional: true
+
+  turbo-linux-64@2.1.0:
+    optional: true
+
+  turbo-linux-arm64@2.1.0:
+    optional: true
+
+  turbo-windows-64@2.1.0:
+    optional: true
+
+  turbo-windows-arm64@2.1.0:
+    optional: true
+
+  turbo@2.1.0:
+    optionalDependencies:
+      turbo-darwin-64: 2.1.0
+      turbo-darwin-arm64: 2.1.0
+      turbo-linux-64: 2.1.0
+      turbo-linux-arm64: 2.1.0
+      turbo-windows-64: 2.1.0
+      turbo-windows-arm64: 2.1.0
 
   type-check@0.4.0:
     dependencies:
@@ -9188,7 +9208,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.4.1
-      '@vitest/browser': 2.0.5(playwright@1.46.0)(typescript@5.5.4)(vitest@2.0.5)
+      '@vitest/browser': 2.0.5(typescript@5.5.4)(vitest@2.0.5)
       '@vitest/ui': 2.0.5(vitest@2.0.5)
       jsdom: 24.1.1
     transitivePeerDependencies:

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://turborepo.org/schema.json",
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/"]
+    },
+    "lint": {
+      "cache": false
+    },
+    "test": {
+      "cache": false
+    }
+  }
+}


### PR DESCRIPTION
This pr is to add [turbo](https://turbo.build/pack/docs) support, and then can run the `pnpm lint`, `pnpm build` or `pnpm test` in the root path of project.