### PR TITLE
should close #223

### DIFF
--- a/cibuild.sh
+++ b/cibuild.sh
@@ -222,9 +222,9 @@ END
 
     # store all pg options that have impact on cmd line initdb/boot
     cat > ${PGROOT}/pgopts.sh <<END
-export CDEBUG=$CDEBUG
-export LDEBUG=$LDEBUG
-export PGDEBUG=$PGDEBUG
+export CDEBUG="$CDEBUG"
+export LDEBUG="$LDEBUG"
+export PGDEBUG="$PGDEBUG"
 export PG_DEBUG_HEADER=$PG_DEBUG_HEADER
 export PGOPTS="\\
  -c log_checkpoints=false \\

--- a/patches/interactive_one.c
+++ b/patches/interactive_one.c
@@ -130,7 +130,7 @@ static void io_init(bool in_auth, bool out_auth) {
     	whereToSendOutput = DestRemote; /* now safe to ereport to client */
         MyProcPort = (Port *) calloc(1, sizeof(Port));
         if (!MyProcPort) {
-            PDEBUG("# 131 io_init   --------- NO CLIENT (oom) ---------");
+            PDEBUG("# 133: io_init   --------- NO CLIENT (oom) ---------");
             abort();
         }
         MyProcPort->canAcceptConnections = CAC_OK;
@@ -138,7 +138,7 @@ static void io_init(bool in_auth, bool out_auth) {
 
         SOCKET_FILE = NULL;
         SOCKET_DATA = 0;
-        PDEBUG("# 139 io_init  --------- CLIENT (ready) ---------");
+        PDEBUG("# 141: io_init  --------- CLIENT (ready) ---------");
 
 
 }
@@ -147,7 +147,7 @@ static void wait_unlock() {
     int busy = 0;
     while (access(PGS_OLOCK, F_OK) == 0) {
         if (!(busy++ % 1110222))
-            printf("FIXME: busy wait lock removed %d\n", busy);
+            printf("# 150: FIXME: busy wait lock removed %d\n", busy);
     }
 }
 
@@ -263,9 +263,9 @@ interactive_one() {
 
                         if (!firstchar) {
                             if (ProcessStartupPacket(MyProcPort, true, true) != STATUS_OK) {
-                                PDEBUG("# 274: ProcessStartupPacket !OK");
+                                PDEBUG("# 266: ProcessStartupPacket !OK");
                             } else {
-                                PDEBUG("# 276: auth request");
+                                PDEBUG("# 267: auth request");
                                 //ClientAuthentication(MyProcPort);
     ClientAuthInProgress = true;
                                 md5Salt[0]=0x01;
@@ -498,7 +498,7 @@ incoming:
 #endif
 
     if (force_echo) {
-        printf("# 524: wire=%d socket=%d repl=%c: %s", is_wire, is_socket, firstchar, inBuf->data);
+        printf("# 501: wire=%d socket=%d repl=%c: %s", is_wire, is_socket, firstchar, inBuf->data);
     }
 
 
@@ -530,10 +530,11 @@ incoming:
 wire_flush:
         if (SOCKET_DATA>0) {
             if (!ClientAuthInProgress) {
-                PDEBUG("# 529: end packet - sending rfq");
-                ReadyForQuery(DestRemote);
+                PDEBUG("# 533: end packet - sending rfq");
+                if (send_ready_for_query)
+                    ReadyForQuery(DestRemote);
             } else {
-                PDEBUG("# 532: end packet (ClientAuthInProgress - no rfq) ");
+                PDEBUG("# 537: end packet (ClientAuthInProgress - no rfq) ");
             }
 
             if (sockfiles) {
@@ -548,9 +549,9 @@ wire_flush:
                 SOCKET_FILE = NULL;
                 SOCKET_DATA = 0;
                 if (cma_wsize)
-                    PDEBUG("# 551: cma and sockfile ???");
+                    PDEBUG("# 552: cma and sockfile ???");
                 if (sockfiles) {
-                    PDEBUG("# 553: setting sockfile lock, ready to read");
+                    PDEBUG("# 554: setting sockfile lock, ready to read");
                     PDEBUG(PGS_OLOCK);
                     c_lock = fopen(PGS_OLOCK, "w");
                     fclose(c_lock);

--- a/patches/interactive_one.c
+++ b/patches/interactive_one.c
@@ -317,6 +317,8 @@ interactive_one() {
 
 PDEBUG("# 324 : TODO: set a pg_main started flag");
                             sf_connected++;
+// CHECK ME see 538 / 563
+                            send_ready_for_query = true;
                         } // auth
                     } else {
 #if PGDEBUG
@@ -491,6 +493,8 @@ incoming:
             goto wire_flush;
         }
         RESUME_INTERRUPTS();
+
+        send_ready_for_query = true;
         return;
     }
 
@@ -533,7 +537,6 @@ wire_flush:
                 PDEBUG("# 533: end packet - sending rfq");
                 if (send_ready_for_query) {
                     ReadyForQuery(DestRemote);
-                    send_ready_for_query = false;
                 }
             } else {
                 PDEBUG("# 537: end packet (ClientAuthInProgress - no rfq) ");
@@ -558,6 +561,8 @@ wire_flush:
                     c_lock = fopen(PGS_OLOCK, "w");
                     fclose(c_lock);
                 }
+// CHECK ME 320 / 538 . only initially or after error
+                // send_ready_for_query = true;
             }
 
         } else {

--- a/patches/interactive_one.c
+++ b/patches/interactive_one.c
@@ -531,17 +531,17 @@ incoming:
 
     if (is_wire) {
 wire_flush:
-        if (SOCKET_DATA>0) {
-            if (!ClientAuthInProgress) {
-                PDEBUG("# 537: end packet - sending rfq");
-                if (send_ready_for_query) {
-                    ReadyForQuery(DestRemote);
-                    send_ready_for_query = false;
-                }
-            } else {
-                PDEBUG("# 542: end packet (ClientAuthInProgress - no rfq) ");
+        if (!ClientAuthInProgress) {
+            PDEBUG("# 537: end packet - sending rfq");
+            if (send_ready_for_query) {
+                ReadyForQuery(DestRemote);
+                send_ready_for_query = false;
             }
+        } else {
+            PDEBUG("# 542: end packet (ClientAuthInProgress - no rfq) ");
+        }
 
+        if (SOCKET_DATA>0) {
             if (sockfiles) {
                 if (cma_wsize)
                     puts("ERROR: cma was not flushed before socketfile interface");

--- a/patches/interactive_one.c
+++ b/patches/interactive_one.c
@@ -531,8 +531,10 @@ wire_flush:
         if (SOCKET_DATA>0) {
             if (!ClientAuthInProgress) {
                 PDEBUG("# 533: end packet - sending rfq");
-                if (send_ready_for_query)
+                if (send_ready_for_query) {
                     ReadyForQuery(DestRemote);
+                    send_ready_for_query = false;
+                }
             } else {
                 PDEBUG("# 537: end packet (ClientAuthInProgress - no rfq) ");
             }

--- a/patches/interactive_one.c
+++ b/patches/interactive_one.c
@@ -344,12 +344,11 @@ PDEBUG("# 324 : TODO: set a pg_main started flag");
                     if (!firstchar || (firstchar==112)) {
                         PDEBUG("# 351: handshake/auth skip");
                         goto wire_flush;
-//                        return;
                     }
 
                     /* else it is wire msg */
 #if PGDEBUG
-printf("# 362 : node+repl is wire : %c\n", firstchar);
+printf("# 352 : node+repl is wire : %c\n", firstchar);
                     force_echo = true;
 #endif
                     is_socket = true;
@@ -534,12 +533,13 @@ incoming:
 wire_flush:
         if (SOCKET_DATA>0) {
             if (!ClientAuthInProgress) {
-                PDEBUG("# 533: end packet - sending rfq");
+                PDEBUG("# 537: end packet - sending rfq");
                 if (send_ready_for_query) {
                     ReadyForQuery(DestRemote);
+                    send_ready_for_query = false;
                 }
             } else {
-                PDEBUG("# 537: end packet (ClientAuthInProgress - no rfq) ");
+                PDEBUG("# 542: end packet (ClientAuthInProgress - no rfq) ");
             }
 
             if (sockfiles) {
@@ -554,14 +554,14 @@ wire_flush:
                 SOCKET_FILE = NULL;
                 SOCKET_DATA = 0;
                 if (cma_wsize)
-                    PDEBUG("# 552: cma and sockfile ???");
+                    PDEBUG("# 557: cma and sockfile ???");
                 if (sockfiles) {
-                    PDEBUG("# 554: setting sockfile lock, ready to read");
+                    PDEBUG("# 559: setting sockfile lock, ready to read");
                     PDEBUG(PGS_OLOCK);
                     c_lock = fopen(PGS_OLOCK, "w");
                     fclose(c_lock);
                 }
-// CHECK ME 320 / 538 . only initially or after error
+// CHECK ME 320 / 540 . only initially or after error
                 // send_ready_for_query = true;
             }
 


### PR DESCRIPTION
there are cases where outside auth, where ReadyForQuery should not be sent.
that state is stored in the global "send_ready_for_query" and should have been tested and reset to false each time.