### PR TITLE
fix: `changes` live API trying to cast `NULL` and failing union?

### DIFF
--- a/.changeset/lucky-bears-change.md
+++ b/.changeset/lucky-bears-change.md
@@ -1,0 +1,5 @@
+---
+'@electric-sql/pglite': patch
+---
+
+Fix `incrementalQuery` and `changes` APIs not working when keyed on non-integer primary keys like `TEXT` and `UUID`.

--- a/packages/pglite/src/live/index.ts
+++ b/packages/pglite/src/live/index.ts
@@ -182,7 +182,7 @@ const setup = async (pg: PGliteInterface, _emscriptenOpts: any) => {
                         if (column_name === key) {
                           return `prev."${column_name}" AS "${column_name}"`
                         } else {
-                          return `NULL::${data_type === 'USER-DEFINED' ? udt_name : data_type} AS "${column_name}"`
+                          return `NULL${data_type === 'USER-DEFINED' ? `::${udt_name}` : ``} AS "${column_name}"`
                         }
                       })
                       .join(',\n')},
@@ -201,7 +201,7 @@ const setup = async (pg: PGliteInterface, _emscriptenOpts: any) => {
                           : `CASE 
                               WHEN curr."${column_name}" IS DISTINCT FROM prev."${column_name}" 
                               THEN curr."${column_name}"
-                              ELSE NULL::${data_type === 'USER-DEFINED' ? udt_name : data_type} 
+                              ELSE NULL${data_type === 'USER-DEFINED' ? `::${udt_name}` : ``}
                               END AS "${column_name}"`,
                       )
                       .join(',\n')},

--- a/packages/pglite/tests/live.test.js
+++ b/packages/pglite/tests/live.test.js
@@ -242,6 +242,37 @@ await testEsmAndCjs(async (importType) => {
       unsubscribe()
     })
 
+    it.only('incremental query non-int key', async () => {
+      const db = new PGlite({
+        extensions: { live },
+      })
+
+      await db.exec(`
+        CREATE TABLE IF NOT EXISTS test (
+          id TEXT PRIMARY KEY,
+          number INT
+        );
+      `)
+
+      await db.exec(`
+        INSERT INTO test (id, number)
+        VALUES ('potato', 1), ('banana', 2);
+      `)
+
+      const { initialResults, unsubscribe } = await db.live.incrementalQuery(
+        'SELECT * FROM test;',
+        [],
+        'id',
+      )
+
+      expect(initialResults.rows).toEqual([
+        { id: 'potato', number: 1 },
+        { id: 'banana', number: 2 },
+      ])
+
+      unsubscribe()
+    })
+
     it('basic live incremental query', async () => {
       const db = new PGlite({
         extensions: { live },


### PR DESCRIPTION
Addresses https://github.com/electric-sql/pglite/issues/233

When the data type is not user defined, then we shouldn't need to be casting NULL to a specific type? I'm not even sure why we need it for the user defined types but I'm not familiar with them at all @samwillis - it would be good to add tests for those as well.