### PR TITLE
docs: add deno install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 
 ![PGlite](https://raw.githubusercontent.com/electric-sql/pglite/main/screenshot.png)
 
-PGlite is a WASM Postgres build packaged into a TypeScript client library that enables you to run Postgres in the browser, Node.js and Bun, with no need to install any other dependencies. It is only 3mb gzipped and has support for many Postgres extensions, including [pgvector](https://github.com/pgvector/pgvector).
+PGlite is a WASM Postgres build packaged into a TypeScript client library that enables you to run Postgres in the browser, Node.js, Bun and Deno, with no need to install any other dependencies. It is only 3mb gzipped and has support for many Postgres extensions, including [pgvector](https://github.com/pgvector/pgvector).
 
 ```javascript
 import { PGlite } from "@electric-sql/pglite";
@@ -43,7 +43,7 @@ await db.query("select 'Hello world' as message;");
 // -> { rows: [ { message: "Hello world" } ] }
 ```
 
-It can be used as an ephemeral in-memory database, or with persistence either to the file system (Node/Bun) or indexedDB (Browser).
+It can be used as an ephemeral in-memory database, or with persistence either to the file system (Node/Bun/Deno) or indexedDB (Browser).
 
 Unlike previous "Postgres in the browser" projects, PGlite does not use a Linux virtual machine - it is simply Postgres in WASM.
 
@@ -76,12 +76,26 @@ or to persist the database to indexedDB:
 const db = new PGlite("idb://my-pgdata");
 ```
 
-## Node/Bun
+## Node/Bun/Deno
 
 Install into your project:
 
+**NodeJS**
+
 ```bash
 npm install @electric-sql/pglite
+```
+
+**Bun**
+
+```bash
+bun install @electric-sql/pglite
+```
+
+**Deno**
+
+```bash
+deno add npm:@electric-sql/pglite
 ```
 
 To use the in-memory Postgres:

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -24,6 +24,10 @@ yarn add @electric-sql/pglite
 bun install @electric-sql/pglite
 ```
 
+```bash [deno]
+deno add npm:@electric-sql/pglite
+```
+
 :::
 
 To use the in-memory Postgres:

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -1,8 +1,8 @@
 # Getting started with PGlite
 
-PGlite can be used in both Node/Bun or the browser, and with any JavaScript framework.
+PGlite can be used in both Node/Bun/Deno or the browser, and with any JavaScript framework.
 
-## Install and start in Node/Bun
+## Install and start in Node/Bun/Deno
 
 Install into your project:
 


### PR DESCRIPTION
Since Deno 1.46 we also have the possibility to use PGlite in Deno as well. See the [release blog post](https://deno.com/blog/v1.46#nodejs-and-npm-compatibility) and PR [#25030](https://github.com/denoland/deno/pull/25030) and [25049](https://github.com/denoland/deno/pull/25049) in the Deno runtime repository.

Therefore I suggest adding this to the supported runtimes.

What do you think? 