### PR TITLE
fix: typo in sync.md

### DIFF
--- a/docs/docs/sync.md
+++ b/docs/docs/sync.md
@@ -52,7 +52,7 @@ To stop syncing you can call `unsubscribe` on the shape:
 shape.unsubscribe()
 ```
 
-There is a full example you can run locally in the [GitHib repository](https://github.com/electric-sql/pglite/tree/main/packages/pglite-sync/example).
+There is a full example you can run locally in the [GitHub repository](https://github.com/electric-sql/pglite/tree/main/packages/pglite-sync/example).
 
 ## syncShapeToTable API
 


### PR DESCRIPTION
Fixes a typo from `GitHib -> GitHub`.