### PR TITLE
feature: wasmModule and fsBundle options and caching of module+fsBundle

### DIFF
--- a/.changeset/giant-mice-dream.md
+++ b/.changeset/giant-mice-dream.md
@@ -1,0 +1,5 @@
+---
+'@electric-sql/pglite': patch
+---
+
+Add wasmModule and fsBundle options to manually load the WASM module and FS bundle. Additionally cache the WASM module and FS bundle after the first download for a speedup on subsequent calls.

--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -58,6 +58,10 @@ Path to the directory for storing the Postgres database. You can provide a URI s
   The database from the Postgres cluster within the `dataDir` to connect to.
 - `initialMemory?: number`<br />
   The initial amount of memory in bytes to allocate for the PGlite instance. PGlite will grow the memory automatically, but if you have a particularly large database you can set this higher to prevent the pause during memory growth.
+- `wasmModule?: WebAssembly.Module`<br />
+  A precompiled WASM module to use instead of downloading the default version, or when using a bundler that either can, or requires, loading the WASM module with a ESM import.
+- `fsBundle?: Blob | File`<br />
+  A filesystem bundle to use instead of downloading the default version. This is useful if in a restricted environment such as an edge worker.
 
 #### `options.extensions`
 

--- a/packages/pglite/examples/dump-data-dir.html
+++ b/packages/pglite/examples/dump-data-dir.html
@@ -15,7 +15,7 @@
 <body>
 <h1>PGlite Dump Datadir Example</h1>
 <div class="script-plus-log">
-<script type="module" src="./dumpDataDir.js"></script>
+<script type="module" src="./dump-data-dir.js"></script>
 <div id="log"></div>
 </div>
 </body>

--- a/packages/pglite/src/interface.ts
+++ b/packages/pglite/src/interface.ts
@@ -68,6 +68,7 @@ export interface PGliteOptions {
   extensions?: Extensions
   loadDataDir?: Blob | File
   initialMemory?: number
+  wasmModule?: WebAssembly.Module
 }
 
 export type PGliteInterface = {

--- a/packages/pglite/src/interface.ts
+++ b/packages/pglite/src/interface.ts
@@ -69,6 +69,7 @@ export interface PGliteOptions {
   loadDataDir?: Blob | File
   initialMemory?: number
   wasmModule?: WebAssembly.Module
+  fsBundle?: Blob | File
 }
 
 export type PGliteInterface = {

--- a/packages/pglite/src/pglite.ts
+++ b/packages/pglite/src/pglite.ts
@@ -1,7 +1,7 @@
 import { Mutex } from 'async-mutex'
 import PostgresModFactory, { type PostgresMod } from './postgresMod.js'
 import { type Filesystem, parseDataDir, loadFs } from './fs/index.js'
-import { makeLocateFile } from './utils.js'
+import { makeLocateFile, instantiateWasm } from './utils.js'
 import type {
   DebugLevel,
   PGliteOptions,
@@ -189,6 +189,15 @@ export class PGlite
         ? { print: console.info, printErr: console.error }
         : { print: () => {}, printErr: () => {} }),
       locateFile: await makeLocateFile(),
+      instantiateWasm: (imports, successCallback) => {
+        instantiateWasm(imports, options.wasmModule).then(
+          ({ instance, module }) => {
+            // @ts-ignore wrong type in Emscripten typings
+            successCallback(instance, module)
+          },
+        )
+        return {}
+      },
       preRun: [
         (mod: any) => {
           // Register /dev/blob device

--- a/packages/pglite/src/pglite.ts
+++ b/packages/pglite/src/pglite.ts
@@ -186,6 +186,11 @@ export class PGlite
     }
 
     // Get the fs bundle
+    // We don't await the loading of the fs bundle at this point as we can continue
+    // with other work.
+    // It's resolved value `fsBundleBuffer` is set and used in `getPreloadedPackage`
+    // which is called via `PostgresModFactory` after we have awaited
+    // `fsBundleBufferPromise` below.
     const fsBundleBufferPromise = options.fsBundle
       ? options.fsBundle.arrayBuffer()
       : getFsBundle()
@@ -326,7 +331,8 @@ export class PGlite
     }
     emscriptenOpts['pg_extensions'] = extensionBundlePromises
 
-    // Await the fs bundle
+    // Await the fs bundle - we do this just before calling PostgresModFactory
+    // as it needs the fs bundle to be ready.
     await fsBundleBufferPromise
 
     // Load the database engine

--- a/packages/pglite/src/utils.ts
+++ b/packages/pglite/src/utils.ts
@@ -8,7 +8,7 @@ export const IN_NODE =
 let wasmDownloadPromise: Promise<Response> | undefined
 
 export async function startWasmDownload() {
-  if (IN_NODE) {
+  if (IN_NODE || wasmDownloadPromise) {
     return
   }
   const moduleUrl = new URL('../release/postgres.wasm', import.meta.url)

--- a/packages/pglite/src/utils.ts
+++ b/packages/pglite/src/utils.ts
@@ -27,8 +27,12 @@ export async function instantiateWasm(
   module: WebAssembly.Module
 }> {
   if (module || cachedWasmModule) {
+    WebAssembly.instantiate(module || cachedWasmModule!, imports)
     return {
-      instance: new WebAssembly.Instance(module || cachedWasmModule!, imports),
+      instance: await WebAssembly.instantiate(
+        module || cachedWasmModule!,
+        imports,
+      ),
       module: module || cachedWasmModule!,
     }
   }


### PR DESCRIPTION
This adds additional options for the wasmModule and fsBundle, along with caching of the default ones if used.

This should enable a route to running in a Cloudflare worker (pending further changes) as you can do something like:

```ts
import { PGlite } from '@electric-sql/pglite';
import wasm from '@electric-sql/pglite/dist/postgres.wasm';
import fsBundle from '@electric-sql/pglite/dist/postgres.wasm';

pg = await PGlite.create({
	wasmModule: wasm,
	fsBundle: fsBinary,
});
```

We had something working similar to this in the old v0.1.n version of PGlite on Cloudflare

Fixes: #329 #81