### PR TITLE
fix: Transactional application of `ShapeStream` messages

### DIFF
--- a/.changeset/chilly-shrimps-shake.md
+++ b/.changeset/chilly-shrimps-shake.md
@@ -1,0 +1,5 @@
+---
+'@electric-sql/pglite-sync': patch
+---
+
+Commit `ShapeStream` message batches transactionally, and apply backpressure.

--- a/packages/pglite-sync/src/index.ts
+++ b/packages/pglite-sync/src/index.ts
@@ -45,12 +45,13 @@ async function createPlugin(
         ...options,
         signal: aborter.signal,
       })
+
       stream.subscribe(async (messages) => {
         if (debug) {
           console.log('sync messages received', messages)
         }
-        for (const message of messages) {
-          pg.transaction(async (tx) => {
+        await pg.transaction(async (tx) => {
+          for (const message of messages) {
             await applyMessageToTable({
               pg: tx,
               rawMessage: message,
@@ -60,8 +61,8 @@ async function createPlugin(
               primaryKey: options.primaryKey,
               debug,
             })
-          })
-        }
+          }
+        })
       })
       streams.push({
         stream,


### PR DESCRIPTION
Should apply all messages from `ShapeStream` transactionally (even though with chunking you cannot guarantee that the batch of messages received form a transaction) - previously was using one transaction per message and blocking the main loop as well!

We could potentially remove the transaction altogether but I'm assuming that pg might optimize writing many messages together when committing as a transaction either way.

I've also awaited each transaction to finish as the new version of `ShapeStream` will be able to apply backpressure based on the callback provided to process messages, and avoid flooding PG