### PR TITLE
chore: refactor serialization to be driven by expected types from Postgres

### DIFF
--- a/.changeset/tender-otters-lie.md
+++ b/.changeset/tender-otters-lie.md
@@ -1,0 +1,5 @@
+---
+'@electric-sql/pglite': patch
+---
+
+Change parameter serialization to be driven by expected types from Postgres, rather than inferring from the JS type

--- a/packages/pglite/src/base.ts
+++ b/packages/pglite/src/base.ts
@@ -166,7 +166,7 @@ export abstract class BasePGlite
       const parsedParams =
         params.map((p) => serializeType(p, options?.setAllTypes))
       
-      let results: BackendMessage[] = []
+      const results: BackendMessage[] = []
 
       try {
         for (const [msg] of await this.#execProtocolNoSync(
@@ -191,7 +191,7 @@ export abstract class BasePGlite
           const pgOid = dataTypeIds[i]
           const value = params[i]
 
-          if (parsedOid !== pgOid) {
+          if (parsedOid !== pgOid && value !== null && value !== undefined) {
             return serializerForOid(pgOid)(value)
           }
           return parsedParam

--- a/packages/pglite/src/base.ts
+++ b/packages/pglite/src/base.ts
@@ -1,6 +1,6 @@
 import { query as queryTemplate } from './templating.js'
 import { parseDescribeStatementResults, parseResults } from './parse.js'
-import { inferType, serializerForOid } from './types.js'
+import { serializerForOid } from './types.js'
 import type {
   DebugLevel,
   PGliteInterface,
@@ -168,10 +168,7 @@ export abstract class BasePGlite
 
       try {
         for (const [msg] of await this.#execProtocolNoSync(
-          serialize.parse({
-            text: query,
-            types: params.map((p) => inferType(p)),
-          }),
+          serialize.parse({ text: query }),
           options,
         )) {
           results.push(msg)

--- a/packages/pglite/src/base.ts
+++ b/packages/pglite/src/base.ts
@@ -89,6 +89,14 @@ export abstract class BasePGlite
 
   // # Concrete implementations:
 
+  /**
+   * Initialize the array types
+   * The oid if the type of an element and the typarray is the oid of the type of the
+   * array.
+   * We extract these from the databaes then create the serializers/parsers for
+   * each type.
+   * This should be called at the end of #init() in the implementing class.
+   */
   async _initArrayTypes() {
     if (this.#arrayTypesInitialized) return
     this.#arrayTypesInitialized = true

--- a/packages/pglite/src/interface.ts
+++ b/packages/pglite/src/interface.ts
@@ -20,7 +20,7 @@ export interface QueryOptions {
   parsers?: ParserOptions
   blob?: Blob | File
   onNotice?: (notice: NoticeMessage) => void
-  setAllTypes?: boolean
+  paramTypes?: number[]
 }
 
 export interface ExecProtocolOptions {

--- a/packages/pglite/src/live/index.ts
+++ b/packages/pglite/src/live/index.ts
@@ -33,7 +33,7 @@ const setup = async (pg: PGliteInterface, _emscriptenOpts: any) => {
       const init = async () => {
         await pg.transaction(async (tx) => {
           // Create a temporary view with the query
-          const formattedQuery = await formatQuery(tx, query, params)
+          const formattedQuery = await formatQuery(pg, query, params, tx)
           await tx.query(
             `CREATE OR REPLACE TEMP VIEW live_query_${id}_view AS ${formattedQuery}`,
           )
@@ -124,7 +124,7 @@ const setup = async (pg: PGliteInterface, _emscriptenOpts: any) => {
       const init = async () => {
         await pg.transaction(async (tx) => {
           // Create a temporary view with the query
-          const formattedQuery = await formatQuery(tx, query, params)
+          const formattedQuery = await formatQuery(pg, query, params, tx)
           await tx.query(
             `CREATE OR REPLACE TEMP VIEW live_query_${id}_view AS ${formattedQuery}`,
           )

--- a/packages/pglite/src/parse.ts
+++ b/packages/pglite/src/parse.ts
@@ -3,6 +3,7 @@ import {
   RowDescriptionMessage,
   DataRowMessage,
   CommandCompleteMessage,
+  ParameterDescriptionMessage,
 } from '@electric-sql/pg-protocol/messages'
 import type { Results, QueryOptions } from './interface.js'
 import { parseType } from './types.js'
@@ -98,4 +99,15 @@ function retrieveRowCount(msg: CommandCompleteMessage): number {
     default:
       return 0
   }
+}
+
+/** Get the dataTypeIDs from a list of messages, if it's available. */
+export function parseDescribeStatementResults(messages: Array<BackendMessage>): number[] {
+  const message = messages.find((msg): msg is ParameterDescriptionMessage => msg.name === 'parameterDescription')
+
+  if (message) {
+    return message.dataTypeIDs
+  }
+
+  return []
 }

--- a/packages/pglite/src/parse.ts
+++ b/packages/pglite/src/parse.ts
@@ -6,7 +6,7 @@ import {
   ParameterDescriptionMessage,
 } from '@electric-sql/pg-protocol/messages'
 import type { Results, QueryOptions } from './interface.js'
-import { parseType } from './types.js'
+import { parseType, type Parser } from './types.js'
 
 /**
  * This function is used to parse the results of either a simple or extended query.
@@ -14,12 +14,14 @@ import { parseType } from './types.js'
  */
 export function parseResults(
   messages: Array<BackendMessage>,
+  defaultParsers: Record<number | string, Parser>,
   options?: QueryOptions,
   blob?: Blob,
 ): Array<Results> {
   const resultSets: Results[] = []
   let currentResultSet: Results = { rows: [], fields: [] }
   let affectedRows = 0
+  const parsers = { ...defaultParsers, ...options?.parsers }
 
   const filteredMessages = messages.filter(
     (msg) =>
@@ -40,11 +42,7 @@ export function parseResults(
       if (options?.rowMode === 'array') {
         currentResultSet.rows.push(
           msg.fields.map((field, i) =>
-            parseType(
-              field,
-              currentResultSet!.fields[i].dataTypeID,
-              options?.parsers,
-            ),
+            parseType(field, currentResultSet!.fields[i].dataTypeID, parsers),
           ),
         )
       } else {
@@ -53,11 +51,7 @@ export function parseResults(
           Object.fromEntries(
             msg.fields.map((field, i) => [
               currentResultSet!.fields[i].name,
-              parseType(
-                field,
-                currentResultSet!.fields[i].dataTypeID,
-                options?.parsers,
-              ),
+              parseType(field, currentResultSet!.fields[i].dataTypeID, parsers),
             ]),
           ),
         )
@@ -102,8 +96,13 @@ function retrieveRowCount(msg: CommandCompleteMessage): number {
 }
 
 /** Get the dataTypeIDs from a list of messages, if it's available. */
-export function parseDescribeStatementResults(messages: Array<BackendMessage>): number[] {
-  const message = messages.find((msg): msg is ParameterDescriptionMessage => msg.name === 'parameterDescription')
+export function parseDescribeStatementResults(
+  messages: Array<BackendMessage>,
+): number[] {
+  const message = messages.find(
+    (msg): msg is ParameterDescriptionMessage =>
+      msg.name === 'parameterDescription',
+  )
 
   if (message) {
     return message.dataTypeIDs

--- a/packages/pglite/src/types.ts
+++ b/packages/pglite/src/types.ts
@@ -226,6 +226,17 @@ export function serializeType(
   return serializerFor(x)(x, setAllTypes)
 }
 
+/** Try to guess a Postgres type based on the JavaScript data type. */
+export function inferType(x: unknown): number {
+  return (
+    x instanceof Date ? TIMESTAMPTZ :
+    x instanceof Uint8Array ? BYTEA :
+    typeof x === 'boolean' ? BOOL :
+    typeof x === 'bigint' ? INT8 :
+    0
+  )
+}
+
 function escapeElement(elementRepresentation: string) {
   const escaped = elementRepresentation
     .replace(/\\/g, '\\\\')

--- a/packages/pglite/src/types.ts
+++ b/packages/pglite/src/types.ts
@@ -86,7 +86,7 @@ export const arrayTypes = {
 export const types = {
   string: {
     to: 0,
-    from: [TEXT, VARCHAR],
+    from: [TEXT, VARCHAR, BPCHAR],
     serialize: (x: string) => x,
     parse: (x: string) => x,
     forceTo: TEXT,

--- a/packages/pglite/src/types.ts
+++ b/packages/pglite/src/types.ts
@@ -227,17 +227,6 @@ export function serializeType(
   return serializerFor(x)(x, setAllTypes)
 }
 
-/** Try to guess a Postgres type based on the JavaScript data type. */
-export function inferType(x: unknown): number {
-  return (
-    x instanceof Date ? TIMESTAMPTZ :
-    x instanceof Uint8Array ? BYTEA :
-    typeof x === 'boolean' ? BOOL :
-    typeof x === 'bigint' ? INT8 :
-    0
-  )
-}
-
 function escapeElement(elementRepresentation: string) {
   const escaped = elementRepresentation
     .replace(/\\/g, '\\\\')

--- a/packages/pglite/src/types.ts
+++ b/packages/pglite/src/types.ts
@@ -1,3 +1,10 @@
+/*
+Based on postgres.js types.js
+https://github.com/porsager/postgres/blob/master/src/types.js
+Published under the Unlicense:
+https://github.com/porsager/postgres/blob/master/UNLICENSE 
+*/
+
 import type { ParserOptions } from './interface.js'
 
 const JSON_parse = globalThis.JSON.parse
@@ -64,50 +71,22 @@ export const BOOL = 16,
   REGNAMESPACE = 4089,
   REGROLE = 4096
 
-export const arrayTypes = {
-  1001: BYTEA,
-  1002: CHAR,
-  1014: BPCHAR,
-  1016: INT8,
-  1005: INT2,
-  1007: INT4,
-  1009: TEXT,
-  1028: OID,
-  199: JSON,
-  1021: FLOAT4,
-  1022: FLOAT8,
-  1015: VARCHAR,
-  3807: JSONB,
-  1182: DATE,
-  1115: TIMESTAMP,
-  1116: TIMESTAMPTZ,
-}
-
 export const types = {
   string: {
     to: 0,
     from: [TEXT, VARCHAR, BPCHAR],
     serialize: (x: string) => x,
     parse: (x: string) => x,
-    forceTo: TEXT,
   },
   number: {
     to: 0,
     from: [INT2, INT4, OID, FLOAT4, FLOAT8],
     serialize: (x: number) => x.toString(),
     parse: (x: string) => +x,
-    forceTo: (x: number) => {
-      if (Number.isInteger(x)) {
-        return INT8
-      } else {
-        return FLOAT8
-      }
-    },
   },
   bigint: {
     to: INT8,
     from: [INT8],
-    js: [BigInt],
     serialize: (x: bigint) => x.toString(),
     parse: (x: string) => {
       const n = BigInt(x)
@@ -127,26 +106,44 @@ export const types = {
   boolean: {
     to: BOOL,
     from: [BOOL],
-    serialize: (x: boolean) => (x === true ? 't' : 'f'),
+    serialize: (x: boolean) => {
+      if (typeof x !== 'boolean') {
+        throw new Error('Invalid input for boolean type')
+      }
+      return x ? 't' : 'f'
+    },
     parse: (x: string) => x === 't',
   },
   date: {
-    to: 1184,
+    to: TIMESTAMPTZ,
     from: [DATE, TIMESTAMP, TIMESTAMPTZ],
-    js: [Date],
-    serialize: (x: Date | string | number) =>
-      (x instanceof Date ? x : new Date(x)).toISOString(),
+    serialize: (x: Date | string | number) => {
+      if (typeof x === 'string') {
+        return x
+      } else if (typeof x === 'number') {
+        return new Date(x).toISOString()
+      } else if (x instanceof Date) {
+        return x.toISOString()
+      } else {
+        throw new Error('Invalid input for date type')
+      }
+    },
     parse: (x: string | number) => new Date(x),
   },
   bytea: {
     to: BYTEA,
     from: [BYTEA],
-    js: [Uint8Array],
-    serialize: (x: Uint8Array) =>
-      '\\x' +
-      Array.from(x)
-        .map((byte) => byte.toString(16).padStart(2, '0'))
-        .join(''),
+    serialize: (x: Uint8Array) => {
+      if (!(x instanceof Uint8Array)) {
+        throw new Error('Invalid input for bytea type')
+      }
+      return (
+        '\\x' +
+        Array.from(x)
+          .map((byte) => byte.toString(16).padStart(2, '0'))
+          .join('')
+      )
+    },
     parse: (x: string): Uint8Array => {
       const hexString = x.slice(2)
       return Uint8Array.from({ length: hexString.length / 2 }, (_, idx) =>
@@ -154,27 +151,16 @@ export const types = {
       )
     },
   },
-  array: {
-    to: 0,
-    from: Object.keys(arrayTypes).map((x) => +x),
-    serialize: (x: any[]) => serializeArray(x),
-    parse: (x: string, typeId?: number) => {
-      let parser
-      if (typeId && typeId in arrayTypes) {
-        parser = parsers[arrayTypes[typeId as keyof typeof arrayTypes]]
-      }
-      return parseArray(x, parser)
-    },
-  },
 } satisfies TypeHandlers
+
+export type Parser = (x: string, typeId?: number) => any
+export type Serializer = (x: any) => string
 
 export type TypeHandler = {
   to: number
   from: number | number[]
-  js?: any
-  serialize: (x: any) => string
-  parse: (x: string, typeId?: number) => any
-  forceTo?: number | ((x: any) => number)
+  serialize: Serializer
+  parse: Parser
 }
 
 export type TypeHandlers = {
@@ -185,126 +171,6 @@ const defaultHandlers = typeHandlers(types)
 
 export const parsers = defaultHandlers.parsers
 export const serializers = defaultHandlers.serializers
-export const serializerInstanceof = defaultHandlers.serializerInstanceof
-
-export type Serializer = (x: any, setAllTypes?: boolean) => [string, number]
-
-export function serializerFor(x: any): Serializer {
-  if (Array.isArray(x)) {
-    return serializers.array
-  }
-  const handler = serializers[typeof x]
-  if (handler) {
-    return handler
-  }
-  for (const [Type, handler] of serializerInstanceof) {
-    if (x instanceof Type) {
-      return handler
-    }
-  }
-  return serializers.json
-}
-
-export function serializerForOid(oid: number): Serializer {
-  const handler: TypeHandler | undefined = Object.values(types).find(
-    (handler) => handler.from.includes(oid),
-  )
-  if (handler) {
-    return (x: any) => {
-      return [handler.serialize(x), oid]
-    }
-  }
-  return serializers.json
-}
-
-export function serializeType(
-  x: any,
-  setAllTypes = false,
-): [string | null, number] {
-  if (x === null || x === undefined) {
-    return [null, 0]
-  }
-  return serializerFor(x)(x, setAllTypes)
-}
-
-function escapeElement(elementRepresentation: string) {
-  const escaped = elementRepresentation
-    .replace(/\\/g, '\\\\')
-    .replace(/"/g, '\\"')
-  return '"' + escaped + '"'
-}
-
-function serializeArray(x: any[]) {
-  let result = '{'
-  for (let i = 0; i < x.length; i++) {
-    if (i > 0) {
-      result = result + ','
-    }
-    if (x[i] === null || typeof x[i] === 'undefined') {
-      result = result + 'NULL'
-    } else if (Array.isArray(x[i])) {
-      result = result + serializeArray(x[i])
-    } else if (ArrayBuffer.isView(x[i]) || x[i] instanceof ArrayBuffer) {
-      const bufferView = ArrayBuffer.isView(x[i])
-        ? new Uint8Array(x[i].buffer, x[i].byteOffset, x[i].byteLength)
-        : new Uint8Array(x[i])
-
-      result += '\\' + types.bytea.serialize(bufferView)
-    } else {
-      result += escapeElement(serializeType(x[i])[0]!)
-    }
-  }
-  result = result + '}'
-  return result
-}
-
-export function parseArray(value: string, parser?: (s: string) => any) {
-  let i = 0
-  let char = null
-  let str = ''
-  let quoted = false
-  let last = 0
-  let p: string | undefined = undefined
-
-  function loop(x: string): any[] {
-    const xs = []
-    for (; i < x.length; i++) {
-      char = x[i]
-      if (quoted) {
-        if (char === '\\') {
-          str += x[++i]
-        } else if (char === '"') {
-          xs.push(parser ? parser(str) : str)
-          str = ''
-          quoted = x[i + 1] === '"'
-          last = i + 2
-        } else {
-          str += char
-        }
-      } else if (char === '"') {
-        quoted = true
-      } else if (char === '{') {
-        last = ++i
-        xs.push(loop(x))
-      } else if (char === '}') {
-        quoted = false
-        last < i &&
-          xs.push(parser ? parser(x.slice(last, i)) : x.slice(last, i))
-        last = i + 1
-        break
-      } else if (char === ',' && p !== '}' && p !== '"') {
-        xs.push(parser ? parser(x.slice(last, i)) : x.slice(last, i))
-        last = i + 1
-      }
-      p = char
-    }
-    last < i &&
-      xs.push(parser ? parser(x.slice(last, i + 1)) : x.slice(last, i + 1))
-    return xs
-  }
-
-  return loop(value)[0]
-}
 
 export function parseType(
   x: string | null,
@@ -324,34 +190,21 @@ export function parseType(
 
 function typeHandlers(types: TypeHandlers) {
   return Object.keys(types).reduce(
-    ({ parsers, serializers, serializerInstanceof }, k) => {
-      const { to, from, serialize, parse = null, forceTo } = types[k]
-      const theSerializer = (x: any, setAllTypes = false) => {
-        return [
-          serialize(x),
-          setAllTypes && forceTo
-            ? typeof forceTo === 'function'
-              ? forceTo(x)
-              : forceTo
-            : to,
-        ] as [string, number]
+    ({ parsers, serializers }, k) => {
+      const { to, from, serialize, parse } = types[k]
+      serializers[to] = serialize
+      serializers[k] = serialize
+      parsers[k] = parse
+      if (Array.isArray(from)) {
+        from.forEach((f) => {
+          parsers[f] = parse
+          serializers[f] = serialize
+        })
+      } else {
+        parsers[from] = parse
+        serializers[from] = serialize
       }
-      serializers[to] = theSerializer
-      serializers[k] = theSerializer
-      if (types[k].js) {
-        types[k].js.forEach((Type: any) =>
-          serializerInstanceof.push([Type, theSerializer]),
-        )
-      }
-      if (parse) {
-        if (Array.isArray(from)) {
-          from.forEach((f) => (parsers[f] = parse))
-        } else {
-          parsers[from] = parse
-        }
-        parsers[k] = parse
-      }
-      return { parsers, serializers, serializerInstanceof }
+      return { parsers, serializers }
     },
     {
       parsers: {} as {
@@ -360,7 +213,103 @@ function typeHandlers(types: TypeHandlers) {
       serializers: {} as {
         [key: number | string]: Serializer
       },
-      serializerInstanceof: [] as Array<[any, Serializer]>,
     },
   )
+}
+
+const escapeBackslash = /\\/g
+const escapeQuote = /"/g
+
+function arrayEscape(x: string) {
+  return x.replace(escapeBackslash, '\\\\').replace(escapeQuote, '\\"')
+}
+
+export function arraySerializer(
+  xs: any,
+  serializer: Serializer | undefined,
+  typarray: number,
+): string {
+  if (Array.isArray(xs) === false) return xs
+
+  if (!xs.length) return '{}'
+
+  const first = xs[0]
+  // Only _box (1020) has the ';' delimiter for arrays, all other types use the ',' delimiter
+  const delimiter = typarray === 1020 ? ';' : ','
+
+  if (Array.isArray(first)) {
+    return `{${xs.map((x) => arraySerializer(x, serializer, typarray)).join(delimiter)}}`
+  } else {
+    return `{${xs
+      .map((x) => {
+        if (x === undefined) {
+          x = null
+          // TODO: Add an option to specify how to handle undefined values
+        }
+        return x === null
+          ? 'null'
+          : '"' + arrayEscape(serializer ? serializer(x) : x.toString()) + '"'
+      })
+      .join(delimiter)}}`
+  }
+}
+
+const arrayParserState = {
+  i: 0,
+  char: null as string | null,
+  str: '',
+  quoted: false,
+  last: 0,
+  p: null as string | null,
+}
+
+export function arrayParser(x: string, parser: Parser, typarray: number) {
+  arrayParserState.i = arrayParserState.last = 0
+  return arrayParserLoop(arrayParserState, x, parser, typarray)[0]
+}
+
+function arrayParserLoop(
+  s: typeof arrayParserState,
+  x: string,
+  parser: Parser | undefined,
+  typarray: number,
+): any[] {
+  const xs = []
+  // Only _box (1020) has the ';' delimiter for arrays, all other types use the ',' delimiter
+  const delimiter = typarray === 1020 ? ';' : ','
+  for (; s.i < x.length; s.i++) {
+    s.char = x[s.i]
+    if (s.quoted) {
+      if (s.char === '\\') {
+        s.str += x[++s.i]
+      } else if (s.char === '"') {
+        xs.push(parser ? parser(s.str) : s.str)
+        s.str = ''
+        s.quoted = x[s.i + 1] === '"'
+        s.last = s.i + 2
+      } else {
+        s.str += s.char
+      }
+    } else if (s.char === '"') {
+      s.quoted = true
+    } else if (s.char === '{') {
+      s.last = ++s.i
+      xs.push(arrayParserLoop(s, x, parser, typarray))
+    } else if (s.char === '}') {
+      s.quoted = false
+      s.last < s.i &&
+        xs.push(parser ? parser(x.slice(s.last, s.i)) : x.slice(s.last, s.i))
+      s.last = s.i + 1
+      break
+    } else if (s.char === delimiter && s.p !== '}' && s.p !== '"') {
+      xs.push(parser ? parser(x.slice(s.last, s.i)) : x.slice(s.last, s.i))
+      s.last = s.i + 1
+    }
+    s.p = s.char
+  }
+  s.last < s.i &&
+    xs.push(
+      parser ? parser(x.slice(s.last, s.i + 1)) : x.slice(s.last, s.i + 1),
+    )
+  return xs
 }

--- a/packages/pglite/src/types.ts
+++ b/packages/pglite/src/types.ts
@@ -67,6 +67,7 @@ export const BOOL = 16,
 export const arrayTypes = {
   1001: BYTEA,
   1002: CHAR,
+  1014: BPCHAR,
   1016: INT8,
   1005: INT2,
   1007: INT4,

--- a/packages/pglite/src/types.ts
+++ b/packages/pglite/src/types.ts
@@ -204,6 +204,18 @@ export function serializerFor(x: any): Serializer {
   return serializers.json
 }
 
+export function serializerForOid(oid: number): Serializer {
+  const handler: TypeHandler | undefined = Object.values(types).find(
+    (handler) => handler.from.includes(oid),
+  )
+  if (handler) {
+    return (x: any) => {
+      return [handler.serialize(x), oid]
+    }
+  }
+  return serializers.json
+}
+
 export function serializeType(
   x: any,
   setAllTypes = false,

--- a/packages/pglite/src/utils.ts
+++ b/packages/pglite/src/utils.ts
@@ -1,4 +1,7 @@
 import type { PGliteInterface, Transaction } from './interface.js'
+import { serialize as serializeProtocol } from '@electric-sql/pg-protocol'
+import { parseDescribeStatementResults } from './parse.js'
+import { TEXT } from './types.js'
 
 export const IN_NODE =
   typeof process === 'object' &&
@@ -72,13 +75,34 @@ export const uuid = (): string => {
 }
 
 export async function formatQuery(
-  pg: PGliteInterface | Transaction,
+  pg: PGliteInterface,
   query: string,
   params?: any[] | null,
+  tx?: Transaction | PGliteInterface,
 ) {
   if (!params || params.length === 0) {
     // no params so no formatting needed
     return query
+  }
+
+  tx = tx ?? pg
+
+  // Get the types of the parameters
+  let dataTypeIDs: number[]
+  try {
+    await pg.execProtocol(serializeProtocol.parse({ text: query }), {
+      syncToFs: false,
+    })
+
+    dataTypeIDs = parseDescribeStatementResults(
+      (
+        await pg.execProtocol(serializeProtocol.describe({ type: 'S' }), {
+          syncToFs: false,
+        })
+      ).map(([msg]) => msg),
+    )
+  } finally {
+    await pg.execProtocol(serializeProtocol.sync(), { syncToFs: false })
   }
 
   // replace $1, $2, etc with  %1L, %2L, etc
@@ -86,14 +110,12 @@ export async function formatQuery(
     return '%' + num + 'L'
   })
 
-  const ret = await pg.query<{
+  const ret = await tx.query<{
     query: string
   }>(
     `SELECT format($1, ${params.map((_, i) => `$${i + 2}`).join(', ')}) as query`,
     [subbedQuery, ...params],
-    {
-      setAllTypes: true,
-    },
+    { paramTypes: [TEXT, ...dataTypeIDs] },
   )
   return ret.rows[0].query
 }

--- a/packages/pglite/src/utils.ts
+++ b/packages/pglite/src/utils.ts
@@ -74,6 +74,17 @@ export const uuid = (): string => {
   )
 }
 
+/**
+ * Formats a query with parameters
+ * Expects that any tables/relations referenced in the query exist in the database
+ * due to requiring them to be present to describe the parameters types.
+ * `tx` is optional, and to be used when formatQuery is called during a transaction.
+ * @param pg - The PGlite instance
+ * @param query - The query to format
+ * @param params - The parameters to format the query with
+ * @param tx - The transaction to use, defaults to the PGlite instance
+ * @returns The formatted query
+ */
 export async function formatQuery(
   pg: PGliteInterface,
   query: string,

--- a/packages/pglite/src/worker/index.ts
+++ b/packages/pglite/src/worker/index.ts
@@ -186,7 +186,9 @@ export class PGliteWorker
     this.#leaderNotifyLoop()
 
     // Init array types
-    await this._initArrayTypes()
+    // We don't await this as it will result in a deadlock
+    // It immediately takes out the transaction lock as so another query
+    this._initArrayTypes()
   }
 
   async #leaderNotifyLoop() {

--- a/packages/pglite/src/worker/index.ts
+++ b/packages/pglite/src/worker/index.ts
@@ -184,6 +184,9 @@ export class PGliteWorker
     })
 
     this.#leaderNotifyLoop()
+
+    // Init array types
+    await this._initArrayTypes()
   }
 
   async #leaderNotifyLoop() {

--- a/packages/pglite/tests/basic.test.js
+++ b/packages/pglite/tests/basic.test.js
@@ -314,8 +314,9 @@ await testEsmAndCjs(async (importType) => {
           array_text TEXT[]
         );
       `)
-    
-      await db.query(`
+
+      await db.query(
+        `
         INSERT INTO test (json, array_text) VALUES ($1, $2);
       `,
         [
@@ -324,21 +325,20 @@ await testEsmAndCjs(async (importType) => {
         ],
       )
 
-      const res = await db.query(`
+      const res = await db.query(
+        `
         SELECT * FROM test WHERE id = ANY($1);
       `,
-        [
-          [0, 1, 2, 3],
-        ],
+        [[0, 1, 2, 3]],
       )
-    
+
       expect(res).toEqual({
         rows: [
           {
             id: 1,
             json: ['hello', 'world'],
             array_text: ['yolo', 'fam'],
-          }
+          },
         ],
         fields: [
           {

--- a/packages/pglite/tests/basic.test.js
+++ b/packages/pglite/tests/basic.test.js
@@ -305,6 +305,55 @@ await testEsmAndCjs(async (importType) => {
       })
     })
 
+    it('array params', async () => {
+      const db = new PGlite()
+      await db.query(`
+        CREATE TABLE IF NOT EXISTS test (
+          id SERIAL PRIMARY KEY,
+          json JSONB,
+          array_text TEXT[]
+        );
+      `)
+    
+      await db.query(`
+        INSERT INTO test (json, array_text) VALUES ($1, $2);
+      `,
+        [
+          ['hello', 'world'],
+          ['yolo', 'fam'],
+        ],
+      )
+
+      const res = await db.query(`
+        SELECT * FROM test;
+      `)
+    
+      expect(res).toEqual({
+        rows: [
+          {
+            id: 1,
+            json: ['hello', 'world'],
+            array_text: ['yolo', 'fam'],
+          }
+        ],
+        fields: [
+          {
+            name: 'id',
+            dataTypeID: 23,
+          },
+          {
+            name: 'json',
+            dataTypeID: 3802,
+          },
+          {
+            name: 'array_text',
+            dataTypeID: 1009,
+          },
+        ],
+        affectedRows: 0,
+      })
+    })
+
     it('error', async () => {
       const db = new PGlite()
       await expectToThrowAsync(async () => {

--- a/packages/pglite/tests/basic.test.js
+++ b/packages/pglite/tests/basic.test.js
@@ -325,8 +325,12 @@ await testEsmAndCjs(async (importType) => {
       )
 
       const res = await db.query(`
-        SELECT * FROM test;
-      `)
+        SELECT * FROM test WHERE id = ANY($1);
+      `,
+        [
+          [0, 1, 2, 3],
+        ],
+      )
     
       expect(res).toEqual({
         rows: [

--- a/packages/pglite/tests/format.test.js
+++ b/packages/pglite/tests/format.test.js
@@ -8,30 +8,62 @@ describe('format', () => {
   })
 
   it('boolean', async () => {
-    const ret1 = await formatQuery(pg, 'SELECT * FROM test WHERE value = $1;', [
-      true,
-    ])
-    expect(ret1).toBe("SELECT * FROM test WHERE value = 't';")
+    await pg.exec(`
+      CREATE TABLE test1 (
+        id SERIAL PRIMARY KEY,
+        value BOOLEAN
+      );
+    `)
+    const ret1 = await formatQuery(
+      pg,
+      'SELECT * FROM test1 WHERE value = $1;',
+      [true],
+    )
+    expect(ret1).toBe("SELECT * FROM test1 WHERE value = 't';")
   })
 
   it('number', async () => {
-    const ret2 = await formatQuery(pg, 'SELECT * FROM test WHERE value = $1;', [
-      1,
-    ])
-    expect(ret2).toBe("SELECT * FROM test WHERE value = '1';")
+    await pg.exec(`
+      CREATE TABLE test2 (
+        id SERIAL PRIMARY KEY,
+        value INTEGER
+      );
+    `)
+    const ret2 = await formatQuery(
+      pg,
+      'SELECT * FROM test2 WHERE value = $1;',
+      [1],
+    )
+    expect(ret2).toBe("SELECT * FROM test2 WHERE value = '1';")
   })
 
   it('string', async () => {
-    const ret3 = await formatQuery(pg, 'SELECT * FROM test WHERE value = $1;', [
-      'test',
-    ])
-    expect(ret3).toBe("SELECT * FROM test WHERE value = 'test';")
+    await pg.exec(`
+      CREATE TABLE test3 (
+        id SERIAL PRIMARY KEY,
+        value VARCHAR
+      );
+    `)
+    const ret3 = await formatQuery(
+      pg,
+      'SELECT * FROM test3 WHERE value = $1;',
+      ['test'],
+    )
+    expect(ret3).toBe("SELECT * FROM test3 WHERE value = 'test';")
   })
 
   it('json', async () => {
-    const ret4 = await formatQuery(pg, 'SELECT * FROM test WHERE value = $1;', [
-      { test: 'test' },
-    ])
-    expect(ret4).toBe('SELECT * FROM test WHERE value = \'{"test":"test"}\';')
+    await pg.exec(`
+      CREATE TABLE test4 (
+        id SERIAL PRIMARY KEY,
+        value JSONB
+      );
+    `)
+    const ret4 = await formatQuery(
+      pg,
+      'SELECT * FROM test4 WHERE value = $1;',
+      [{ test: 'test' }],
+    )
+    expect(ret4).toBe('SELECT * FROM test4 WHERE value = \'{"test": "test"}\';')
   })
 })

--- a/packages/pglite/tests/types.test.ts
+++ b/packages/pglite/tests/types.test.ts
@@ -78,46 +78,35 @@ describe('parse', () => {
 // Serialize type tests
 describe('serialize', () => {
   it('string', () => {
-    expect(types.serializeType('test')).toEqual(['test', 0])
-  })
-
-  it('string set all types', () => {
-    expect(types.serializeType('test', true)).toEqual(['test', 25])
+    expect(types.serializers[25]('test')).toEqual('test')
   })
 
   it('number', () => {
-    expect(types.serializeType(1)).toEqual(['1', 0])
-    expect(types.serializeType(1.1)).toEqual(['1.1', 0])
-  })
-
-  it('number set all types', () => {
-    expect(types.serializeType(1, true)).toEqual(['1', 20])
-    expect(types.serializeType(1.1, true)).toEqual(['1.1', 701])
+    expect(types.serializers[0](1)).toEqual('1')
+    expect(types.serializers[0](1.1)).toEqual('1.1')
   })
 
   it('bigint', () => {
-    expect(types.serializeType(1n)).toEqual(['1', 20])
+    expect(types.serializers[20](1n)).toEqual('1')
   })
 
   it('bool', () => {
-    expect(types.serializeType(true)).toEqual(['t', 16])
+    expect(types.serializers[16](true)).toEqual('t')
   })
 
   it('date', () => {
-    expect(types.serializeType(new Date('2021-01-01T00:00:00.000Z'))).toEqual([
-      '2021-01-01T00:00:00.000Z',
-      1184,
-    ])
+    expect(
+      types.serializers[1184](new Date('2021-01-01T00:00:00.000Z')),
+    ).toEqual('2021-01-01T00:00:00.000Z')
   })
 
   it('json', () => {
-    expect(types.serializeType({ test: 1 })).toEqual(['{"test":1}', 114])
+    expect(types.serializers[114]({ test: 1 })).toEqual('{"test":1}')
   })
 
   it('blob', () => {
-    expect(types.serializeType(Uint8Array.from([1, 2, 3]))).toEqual([
+    expect(types.serializers[17](Uint8Array.from([1, 2, 3]))).toEqual(
       '\\x010203',
-      17,
-    ])
+    )
   })
 })

--- a/packages/pglite/tests/xml.test.ts
+++ b/packages/pglite/tests/xml.test.ts
@@ -41,8 +41,8 @@ describe('XML functionality', () => {
     `)
 
     expect(result.rows).toEqual([
-      { elements: '{value1}' },
-      { elements: '{value2}' },
+      { elements: ['value1'] },
+      { elements: ['value2'] },
     ])
   })
 


### PR DESCRIPTION
This is based on #306 but additionally refactors much of the type handling. It also lays the foundation for users to add they own serialises and parser to a PGlite instance either directly or via a plugin/extension - this will come in a later PR.

In the old version type serialization was driven by inferring the type on the JS side, converting to a serialised string, and then setting the type OID on the query for each parameter.

This new version uses the "describe" protocol message to get the expected type of each parameter in a query, and then try and serialise the value based on that. This is based on how it's done in [postgres.js](https://github.com/porsager/postgres/blob/master/src/types.js)