### PR TITLE
feat: PGlite-sync naive resumability

### DIFF
--- a/.changeset/chilly-shrimps-shake.md
+++ b/.changeset/chilly-shrimps-shake.md
@@ -7,3 +7,4 @@ Implement `shapeKey` option to `syncShapeToTable` to persist stream.
 Implement `metadataSchema` option to `electricSync` configuration to specify where stream metadata is peristed.
 Implement in-memory lock to disallow multiple shapes on single table.
 Fix `must-refetch` handling by truncating underlying table on refetch.
+[BREAKING] Move `ShapeStreamOptions` as separate property of `SyncShapeToTableOptions` rather than extension

--- a/.changeset/chilly-shrimps-shake.md
+++ b/.changeset/chilly-shrimps-shake.md
@@ -2,4 +2,8 @@
 '@electric-sql/pglite-sync': patch
 ---
 
-Commit `ShapeStream` message batches transactionally, and apply backpressure.
+Commit `ShapeStream` message batches transactionally.
+Implement `shapeKey` option to `syncShapeToTable` to persist stream.
+Implement `metadataSchema` option to `electricSync` configuration to specify where stream metadata is peristed.
+Implement in-memory lock to disallow multiple shapes on single table.
+Fix `must-refetch` handling by truncating underlying table on refetch.

--- a/.changeset/orange-bears-sing.md
+++ b/.changeset/orange-bears-sing.md
@@ -1,0 +1,5 @@
+---
+'@electric-sql/pglite-sync': patch
+---
+
+Implement naive resumability which truncates the synced table on restart.

--- a/docs/docs/sync.md
+++ b/docs/docs/sync.md
@@ -55,6 +55,7 @@ shape.unsubscribe()
 There is a full example you can run locally in the [GitHub repository](https://github.com/electric-sql/pglite/tree/main/packages/pglite-sync/example).
 
 ## electricSync API
+
 The `electricSync` plugin can be given some configuration options to allow customization of the sync process.
 
 - `metadataSchema?: string`<br>
@@ -86,7 +87,6 @@ It takes the following options as an object:
 
 - `shapeKey: string`<br>
   Optional identifier for the shape subscription - if provided the stream state will be persisted along with the data in order to allow resuming the stream between sessions.
-  
 
 The returned `shape` object from the `syncShapeToTable` call has the following methods:
 

--- a/docs/docs/sync.md
+++ b/docs/docs/sync.md
@@ -108,9 +108,6 @@ The returned `shape` object from the `syncShapeToTable` call has the following m
 - `unsubscribeMustRefresh(cb: () => void)`<br>
   Unsubscribe from the `mustRefresh` notification.
 
-- `lastOffset: string`<br>
-  The last offset that was committed to the database
-
 - `unsubscribe()`<br>
   Unsubscribe from the shape. Note that this does not clear the state that has been synced into the table.
 

--- a/packages/pglite-sync/package.json
+++ b/packages/pglite-sync/package.json
@@ -45,7 +45,7 @@
     "dist"
   ],
   "dependencies": {
-    "@electric-sql/client": "^0.5.1"
+    "@electric-sql/client": "^0.6.0"
   },
   "devDependencies": {
     "@electric-sql/pglite": "workspace:*",

--- a/packages/pglite-sync/package.json
+++ b/packages/pglite-sync/package.json
@@ -45,14 +45,14 @@
     "dist"
   ],
   "dependencies": {
-    "@electric-sql/client": "^0.3.2"
+    "@electric-sql/client": "^0.5.1"
   },
   "devDependencies": {
     "@electric-sql/pglite": "workspace:*",
-    "@eslint-react/eslint-plugin": "^1.12.1",
+    "@eslint-react/eslint-plugin": "^1.14.2",
     "@vitejs/plugin-react": "^4.2.1",
     "globals": "^15.9.0",
-    "vitest": "^2.0.5"
+    "vitest": "^2.1.1"
   },
   "peerDependencies": {
     "@electric-sql/pglite": "workspace:^"

--- a/packages/pglite-sync/src/index.ts
+++ b/packages/pglite-sync/src/index.ts
@@ -88,7 +88,6 @@ async function createPlugin(
       // or use a separate connection to hold a long transaction
       let messageAggregator: ChangeMessage<any>[] = []
       let truncateNeeded = false
-      let lastOffsetAdded = shapeSubState?.offset
 
       stream.subscribe(async (messages) => {
         if (debug) console.log('sync messages received', messages)
@@ -145,14 +144,13 @@ async function createPlugin(
                   messageAggregator.length > 0 &&
                   stream.shapeId !== undefined
                 ) {
-                  lastOffsetAdded =
-                    messageAggregator[messageAggregator.length - 1].offset
                   await updateShapeSubscriptionState({
                     pg: tx,
                     metadataSchema,
                     shapeKey: options.shapeKey,
                     shapeId: stream.shapeId,
-                    lastOffset: lastOffsetAdded,
+                    lastOffset:
+                      messageAggregator[messageAggregator.length - 1].offset,
                   })
                 }
               })
@@ -178,9 +176,6 @@ async function createPlugin(
         },
         get shapeId() {
           return stream.shapeId
-        },
-        get lastOffset() {
-          return lastOffsetAdded
         },
         subscribeOnceToUpToDate: (
           cb: () => void,

--- a/packages/pglite-sync/src/index.ts
+++ b/packages/pglite-sync/src/index.ts
@@ -3,8 +3,13 @@ import type {
   PGliteInterface,
   Transaction,
 } from '@electric-sql/pglite'
-import { ShapeStream, Message, ChangeMessage } from '@electric-sql/client'
-import type { ShapeStreamOptions } from '@electric-sql/client'
+import {
+  ShapeStream,
+  ChangeMessage,
+  isChangeMessage,
+  isControlMessage,
+} from '@electric-sql/client'
+import type { Offset, ShapeStreamOptions } from '@electric-sql/client'
 
 export type MapColumnsMap = Record<string, string>
 export type MapColumnsFn = (message: ChangeMessage<any>) => Record<string, any>
@@ -33,6 +38,16 @@ async function createPlugin(
 
   const namespaceObj = {
     syncShapeToTable: async (options: SyncShapeToTableOptions) => {
+      // create subscription metadata table
+      await pg.exec(subscriptionTableQuery)
+      const shapeSubState = await getShapeSubscriptionState({
+        pg,
+        table: options.table,
+      })
+      if (debug && shapeSubState) {
+        console.log('resuming from shape state', shapeSubState)
+      }
+
       const aborter = new AbortController()
       if (options.signal) {
         // we new to have our own aborter to be able to abort the stream
@@ -43,6 +58,7 @@ async function createPlugin(
       }
       const stream = new ShapeStream({
         ...options,
+        ...(shapeSubState ?? {}),
         signal: aborter.signal,
       })
 
@@ -51,15 +67,49 @@ async function createPlugin(
           console.log('sync messages received', messages)
         }
         await pg.transaction(async (tx) => {
+          let lastOffsetAdded: Offset | void = undefined
+          let shapeId: string | void = undefined
+
           for (const message of messages) {
-            await applyMessageToTable({
+            shapeId ??= stream.shapeId
+
+            if (isChangeMessage(message)) {
+              await applyMessageToTable({
+                pg: tx,
+                message: message,
+                table: options.table,
+                schema: options.schema,
+                mapColumns: options.mapColumns,
+                primaryKey: options.primaryKey,
+                debug,
+              })
+              lastOffsetAdded = message.offset
+            }
+
+            if (isControlMessage(message)) {
+              switch (message.headers.control) {
+                case 'must-refetch':
+                  if (debug) console.log('clearing and refetching shape')
+                  shapeId = undefined
+                  await cleanUpShapeSubscription({
+                    pg: tx,
+                    table: options.table,
+                  })
+                  break
+
+                case 'up-to-date':
+                  // no-op - we commit all messages at the end
+                  break
+              }
+            }
+          }
+
+          if (lastOffsetAdded !== undefined && shapeId !== undefined) {
+            await updateShapeSubscriptionState({
               pg: tx,
-              rawMessage: message,
               table: options.table,
-              schema: options.schema,
-              mapColumns: options.mapColumns,
-              primaryKey: options.primaryKey,
-              debug,
+              shapeId,
+              lastOffset: lastOffsetAdded,
             })
           }
         })
@@ -142,7 +192,7 @@ interface ApplyMessageToTableOptions {
   pg: PGliteInterface | Transaction
   table: string
   schema?: string
-  rawMessage: Message
+  message: ChangeMessage<any>
   mapColumns?: MapColumns
   primaryKey: string[]
   debug: boolean
@@ -152,63 +202,149 @@ async function applyMessageToTable({
   pg,
   table,
   schema = 'public',
-  rawMessage,
+  message,
   mapColumns,
   primaryKey,
   debug,
 }: ApplyMessageToTableOptions) {
-  if (!(rawMessage as any).headers.operation) return
-  const message = rawMessage as ChangeMessage<any>
   const data = mapColumns ? doMapColumns(mapColumns, message) : message.value
-  if (message.headers.operation === 'insert') {
-    if (debug) {
-      console.log('inserting', data)
+
+  switch (message.headers.operation) {
+    case 'insert': {
+      if (debug) console.log('inserting', data)
+      const columns = Object.keys(data)
+      return await pg.query(
+        `
+            INSERT INTO "${schema}"."${table}"
+            (${columns.map((s) => '"' + s + '"').join(', ')})
+            VALUES
+            (${columns.map((_v, i) => '$' + (i + 1)).join(', ')})
+          `,
+        columns.map((column) => data[column]),
+      )
     }
-    const columns = Object.keys(data)
-    await pg.query(
-      `
-        INSERT INTO "${schema}"."${table}"
-        (${columns.map((s) => '"' + s + '"').join(', ')})
-        VALUES
-        (${columns.map((_v, i) => '$' + (i + 1)).join(', ')})
-      `,
-      columns.map((column) => data[column]),
-    )
-  } else if (message.headers.operation === 'update') {
-    if (debug) {
-      console.log('updating', data)
+
+    case 'update': {
+      if (debug) console.log('updating', data)
+      const columns = Object.keys(data).filter(
+        // we don't update the primary key, they are used to identify the row
+        (column) => !primaryKey.includes(column),
+      )
+      return await pg.query(
+        `
+            UPDATE "${schema}"."${table}"
+            SET ${columns
+              .map((column, i) => '"' + column + '" = $' + (i + 1))
+              .join(', ')}
+            WHERE ${primaryKey
+              .map(
+                (column, i) =>
+                  '"' + column + '" = $' + (columns.length + i + 1),
+              )
+              .join(' AND ')}
+          `,
+        [
+          ...columns.map((column) => data[column]),
+          ...primaryKey.map((column) => data[column]),
+        ],
+      )
     }
-    const columns = Object.keys(data).filter(
-      // we don't update the primary key, they are used to identify the row
-      (column) => !primaryKey.includes(column),
-    )
-    await pg.query(
-      `
-        UPDATE "${schema}"."${table}"
-        SET ${columns
-          .map((column, i) => '"' + column + '" = $' + (i + 1))
-          .join(', ')}
-        WHERE ${primaryKey
-          .map((column, i) => '"' + column + '" = $' + (columns.length + i + 1))
-          .join(' AND ')}
-      `,
-      [
-        ...columns.map((column) => data[column]),
-        ...primaryKey.map((column) => data[column]),
-      ],
-    )
-  } else if (message.headers.operation === 'delete') {
-    if (debug) {
-      console.log('deleting', data)
+
+    case 'delete': {
+      if (debug) console.log('deleting', data)
+      return await pg.query(
+        `
+            DELETE FROM "${schema}"."${table}"
+            WHERE ${primaryKey
+              .map((column, i) => '"' + column + '" = $' + (i + 1))
+              .join(' AND ')}
+          `,
+        [...primaryKey.map((column) => data[column])],
+      )
     }
-    await pg.query(
-      `
-        DELETE FROM "${schema}"."${table}"
-        WHERE ${primaryKey
-          .map((column, i) => '"' + column + '" = $' + (i + 1))
-          .join(' AND ')}
-      `,
-      [...primaryKey.map((column) => data[column])],
-    )
   }
 }
+
+interface GetShapeSubscriptionStateOptions {
+  pg: PGliteInterface | Transaction
+  table: string
+}
+
+interface ShapeSubscriptionState {
+  shapeId: string
+  lastOffset: string
+}
+
+async function getShapeSubscriptionState({
+  pg,
+  table,
+}: GetShapeSubscriptionStateOptions): Promise<ShapeSubscriptionState | null> {
+  const result = await pg.query<{ shape_id: string; last_offset: string }>(
+    `
+    SELECT shape_id, last_offset
+    FROM ${subscriptionTableName}
+    WHERE table_name = $1
+  `,
+    [table],
+  )
+
+  if (result.rows.length === 0) return null
+
+  const { shape_id: shapeId, last_offset: lastOffset } = result.rows[0]
+  return {
+    shapeId,
+    lastOffset,
+  }
+}
+
+interface UpdateShapeSubscriptionStateOptions {
+  pg: PGliteInterface | Transaction
+  table: string
+  shapeId: string
+  lastOffset: string
+}
+
+async function updateShapeSubscriptionState({
+  pg,
+  table,
+  shapeId,
+  lastOffset,
+}: UpdateShapeSubscriptionStateOptions) {
+  await pg.query(
+    `
+    INSERT INTO ${subscriptionTableName} (table_name, shape_id, last_offset)
+    VALUES ($1, $2, $3)
+    ON CONFLICT(table_name)
+    DO UPDATE SET
+      shape_id = EXCLUDED.shape_id,
+      last_offset = EXCLUDED.last_offset;
+  `,
+    [table, shapeId, lastOffset],
+  )
+}
+
+interface CleanUpShapeSubscriptionOptions {
+  pg: PGliteInterface | Transaction
+  table: string
+}
+
+async function cleanUpShapeSubscription({
+  pg,
+  table,
+}: CleanUpShapeSubscriptionOptions) {
+  // TODO: sync into shadow table and reference count
+  // for now just clear the whole table
+  await pg.exec(`TRUNCATE ${table};`)
+  await pg.query(`DELETE FROM ${subscriptionTableName} WHERE table_name = $1`, [
+    table,
+  ])
+}
+
+const subscriptionTableName = `__electric_shape_subscriptions_metadata`
+const subscriptionTableQuery = `
+CREATE TABLE IF NOT EXISTS ${subscriptionTableName} (
+  table_name TEXT PRIMARY KEY,
+  shape_id TEXT NOT NULL,
+  last_offset TEXT NOT NULL
+)
+`

--- a/packages/pglite-sync/src/index.ts
+++ b/packages/pglite-sync/src/index.ts
@@ -16,7 +16,8 @@ export type MapColumnsFn = (message: ChangeMessage<any>) => Record<string, any>
 export type MapColumns = MapColumnsMap | MapColumnsFn
 export type ShapeKey = string
 
-export interface SyncShapeToTableOptions extends ShapeStreamOptions {
+export interface SyncShapeToTableOptions {
+  shapeStream: ShapeStreamOptions
   table: string
   schema?: string
   mapColumns?: MapColumns
@@ -67,15 +68,19 @@ async function createPlugin(
       }
 
       const aborter = new AbortController()
-      if (options.signal) {
+      if (options.shapeStream.signal) {
         // we new to have our own aborter to be able to abort the stream
         // but still accept the signal from the user
-        options.signal.addEventListener('abort', () => aborter.abort(), {
-          once: true,
-        })
+        options.shapeStream.signal.addEventListener(
+          'abort',
+          () => aborter.abort(),
+          {
+            once: true,
+          },
+        )
       }
       const stream = new ShapeStream({
-        ...options,
+        ...options.shapeStream,
         ...(shapeSubState ?? {}),
         signal: aborter.signal,
       })

--- a/packages/pglite-sync/src/index.ts
+++ b/packages/pglite-sync/src/index.ts
@@ -17,7 +17,7 @@ export type MapColumns = MapColumnsMap | MapColumnsFn
 export type ShapeKey = string
 
 export interface SyncShapeToTableOptions {
-  shapeStream: ShapeStreamOptions
+  shape: ShapeStreamOptions
   table: string
   schema?: string
   mapColumns?: MapColumns
@@ -68,19 +68,15 @@ async function createPlugin(
       }
 
       const aborter = new AbortController()
-      if (options.shapeStream.signal) {
+      if (options.shape.signal) {
         // we new to have our own aborter to be able to abort the stream
         // but still accept the signal from the user
-        options.shapeStream.signal.addEventListener(
-          'abort',
-          () => aborter.abort(),
-          {
-            once: true,
-          },
-        )
+        options.shape.signal.addEventListener('abort', () => aborter.abort(), {
+          once: true,
+        })
       }
       const stream = new ShapeStream({
-        ...options.shapeStream,
+        ...options.shape,
         ...(shapeSubState ?? {}),
         signal: aborter.signal,
       })

--- a/packages/pglite-sync/test/sync.test.ts
+++ b/packages/pglite-sync/test/sync.test.ts
@@ -52,7 +52,7 @@ describe('pglite-sync', () => {
     }))
 
     const shape = await pg.electric.syncShapeToTable({
-      url: 'http://localhost:3000/v1/shape/todo',
+      shapeStream: { url: 'http://localhost:3000/v1/shape/todo' },
       table: 'todo',
       primaryKey: ['id'],
     })
@@ -121,7 +121,7 @@ describe('pglite-sync', () => {
     }))
 
     const shape = await pg.electric.syncShapeToTable({
-      url: 'http://localhost:3000/v1/shape/todo',
+      shapeStream: { url: 'http://localhost:3000/v1/shape/todo' },
       table: 'todo',
       primaryKey: ['id'],
     })
@@ -201,7 +201,7 @@ describe('pglite-sync', () => {
     const numResumes = 3
     for (let i = 0; i < numResumes; i++) {
       const shape = await pg.electric.syncShapeToTable({
-        url: 'http://localhost:3000/v1/shape/todo',
+        shapeStream: { url: 'http://localhost:3000/v1/shape/todo' },
         table: 'todo',
         primaryKey: ['id'],
         shapeKey: 'foo',
@@ -274,7 +274,7 @@ describe('pglite-sync', () => {
 
     const numInserts = 100
     const shape = await pg.electric.syncShapeToTable({
-      url: 'http://localhost:3000/v1/shape/todo',
+      shapeStream: { url: 'http://localhost:3000/v1/shape/todo' },
       table: 'todo',
       primaryKey: ['id'],
       shapeKey: 'foo',
@@ -327,7 +327,7 @@ describe('pglite-sync', () => {
 
     // resuming should
     const resumedShape = await pg.electric.syncShapeToTable({
-      url: 'http://localhost:3000/v1/shape/todo',
+      shapeStream: { url: 'http://localhost:3000/v1/shape/todo' },
       table: 'todo',
       primaryKey: ['id'],
       shapeKey: 'foo',
@@ -368,7 +368,7 @@ describe('pglite-sync', () => {
     const altTable = 'bar'
 
     const shape1 = await pg.electric.syncShapeToTable({
-      url: 'http://localhost:3000/v1/shape/todo',
+      shapeStream: { url: 'http://localhost:3000/v1/shape/todo' },
       table: table,
       primaryKey: ['id'],
     })
@@ -377,7 +377,7 @@ describe('pglite-sync', () => {
     await expect(
       async () =>
         await pg.electric.syncShapeToTable({
-          url: 'http://localhost:3000/v1/shape/todo_alt',
+          shapeStream: { url: 'http://localhost:3000/v1/shape/todo_alt' },
           table: table,
           primaryKey: ['id'],
         }),
@@ -385,7 +385,7 @@ describe('pglite-sync', () => {
 
     // should be able to sync shape into other table
     const altShape = await pg.electric.syncShapeToTable({
-      url: 'http://localhost:3000/v1/shape/bar',
+      shapeStream: { url: 'http://localhost:3000/v1/shape/bar' },
       table: altTable,
       primaryKey: ['id'],
     })
@@ -396,7 +396,7 @@ describe('pglite-sync', () => {
     await shape1.unsubscribe()
 
     const shape2 = await pg.electric.syncShapeToTable({
-      url: 'http://localhost:3000/v1/shape/todo_alt',
+      shapeStream: { url: 'http://localhost:3000/v1/shape/todo_alt' },
       table: table,
       primaryKey: ['id'],
     })

--- a/packages/pglite-sync/test/sync.test.ts
+++ b/packages/pglite-sync/test/sync.test.ts
@@ -187,6 +187,7 @@ describe('pglite-sync', () => {
         url: 'http://localhost:3000/v1/shape/todo',
         table: 'todo',
         primaryKey: ['id'],
+        shapeKey: 'foo',
       })
 
       await feedMessages(
@@ -259,6 +260,7 @@ describe('pglite-sync', () => {
       url: 'http://localhost:3000/v1/shape/todo',
       table: 'todo',
       primaryKey: ['id'],
+      shapeKey: 'foo',
     })
 
     await feedMessages(
@@ -311,6 +313,7 @@ describe('pglite-sync', () => {
       url: 'http://localhost:3000/v1/shape/todo',
       table: 'todo',
       primaryKey: ['id'],
+      shapeKey: 'foo',
     })
     await resumedShape.unsubscribe()
 

--- a/packages/pglite-sync/test/sync.test.ts
+++ b/packages/pglite-sync/test/sync.test.ts
@@ -151,8 +151,8 @@ describe('pglite-sync', () => {
     // should have exact number of inserts added transactionally
     expect((await pg.sql`SELECT * FROM todo;`).rows).toHaveLength(numInserts)
 
-    // should have processed microtask within 5ms, not blocking main loop
-    expect(timeToProcessMicrotask).toBeLessThan(5)
+    // should have processed microtask within 15ms, not blocking main loop
+    expect(timeToProcessMicrotask).toBeLessThan(15)
 
     await shape.unsubscribe()
   })

--- a/packages/pglite-sync/test/sync.test.ts
+++ b/packages/pglite-sync/test/sync.test.ts
@@ -52,7 +52,7 @@ describe('pglite-sync', () => {
     }))
 
     const shape = await pg.electric.syncShapeToTable({
-      shapeStream: { url: 'http://localhost:3000/v1/shape/todo' },
+      shape: { url: 'http://localhost:3000/v1/shape/todo' },
       table: 'todo',
       primaryKey: ['id'],
     })
@@ -121,7 +121,7 @@ describe('pglite-sync', () => {
     }))
 
     const shape = await pg.electric.syncShapeToTable({
-      shapeStream: { url: 'http://localhost:3000/v1/shape/todo' },
+      shape: { url: 'http://localhost:3000/v1/shape/todo' },
       table: 'todo',
       primaryKey: ['id'],
     })
@@ -201,7 +201,7 @@ describe('pglite-sync', () => {
     const numResumes = 3
     for (let i = 0; i < numResumes; i++) {
       const shape = await pg.electric.syncShapeToTable({
-        shapeStream: { url: 'http://localhost:3000/v1/shape/todo' },
+        shape: { url: 'http://localhost:3000/v1/shape/todo' },
         table: 'todo',
         primaryKey: ['id'],
         shapeKey: 'foo',
@@ -274,7 +274,7 @@ describe('pglite-sync', () => {
 
     const numInserts = 100
     const shape = await pg.electric.syncShapeToTable({
-      shapeStream: { url: 'http://localhost:3000/v1/shape/todo' },
+      shape: { url: 'http://localhost:3000/v1/shape/todo' },
       table: 'todo',
       primaryKey: ['id'],
       shapeKey: 'foo',
@@ -327,7 +327,7 @@ describe('pglite-sync', () => {
 
     // resuming should
     const resumedShape = await pg.electric.syncShapeToTable({
-      shapeStream: { url: 'http://localhost:3000/v1/shape/todo' },
+      shape: { url: 'http://localhost:3000/v1/shape/todo' },
       table: 'todo',
       primaryKey: ['id'],
       shapeKey: 'foo',
@@ -368,7 +368,7 @@ describe('pglite-sync', () => {
     const altTable = 'bar'
 
     const shape1 = await pg.electric.syncShapeToTable({
-      shapeStream: { url: 'http://localhost:3000/v1/shape/todo' },
+      shape: { url: 'http://localhost:3000/v1/shape/todo' },
       table: table,
       primaryKey: ['id'],
     })
@@ -377,7 +377,7 @@ describe('pglite-sync', () => {
     await expect(
       async () =>
         await pg.electric.syncShapeToTable({
-          shapeStream: { url: 'http://localhost:3000/v1/shape/todo_alt' },
+          shape: { url: 'http://localhost:3000/v1/shape/todo_alt' },
           table: table,
           primaryKey: ['id'],
         }),
@@ -385,7 +385,7 @@ describe('pglite-sync', () => {
 
     // should be able to sync shape into other table
     const altShape = await pg.electric.syncShapeToTable({
-      shapeStream: { url: 'http://localhost:3000/v1/shape/bar' },
+      shape: { url: 'http://localhost:3000/v1/shape/bar' },
       table: altTable,
       primaryKey: ['id'],
     })
@@ -396,7 +396,7 @@ describe('pglite-sync', () => {
     await shape1.unsubscribe()
 
     const shape2 = await pg.electric.syncShapeToTable({
-      shapeStream: { url: 'http://localhost:3000/v1/shape/todo_alt' },
+      shape: { url: 'http://localhost:3000/v1/shape/todo_alt' },
       table: table,
       primaryKey: ['id'],
     })

--- a/packages/pglite-sync/test/sync.test.ts
+++ b/packages/pglite-sync/test/sync.test.ts
@@ -322,4 +322,22 @@ describe('pglite-sync', () => {
     expect(shapeStreamInits.mock.calls[1][0]).not.toHaveProperty('shapeId')
     expect(shapeStreamInits.mock.calls[1][0]).not.toHaveProperty('offset')
   })
+
+  it('uses the specified metadata schema for subscription metadata', async () => {
+    const metadataSchema = 'foobar'
+    const db = await PGlite.create({
+      extensions: {
+        electric: electricSync({
+          metadataSchema,
+        }),
+      },
+    })
+
+    const result = await db.query(
+      `SELECT schema_name FROM information_schema.schemata WHERE schema_name = $1`,
+      [metadataSchema],
+    )
+    expect(result.rows).toHaveLength(1)
+    expect(result.rows[0]).toEqual({ schema_name: metadataSchema })
+  })
 })

--- a/packages/pglite-sync/test/sync.test.ts
+++ b/packages/pglite-sync/test/sync.test.ts
@@ -219,13 +219,11 @@ describe('pglite-sync', () => {
       expect(shapeStreamInits).toHaveBeenCalledTimes(i + 1)
       if (i === 0) {
         expect(shapeStreamInits.mock.calls[i][0]).not.toHaveProperty('shapeId')
-        expect(shapeStreamInits.mock.calls[i][0]).not.toHaveProperty(
-          'lastOffset',
-        )
+        expect(shapeStreamInits.mock.calls[i][0]).not.toHaveProperty('offset')
       } else {
         expect(shapeStreamInits.mock.calls[i][0]).toMatchObject({
           shapeId: shapeIds[i],
-          lastOffset: `1_${i * numInserts - 1}`,
+          offset: `1_${i * numInserts - 1}`,
         })
       }
     }
@@ -319,6 +317,6 @@ describe('pglite-sync', () => {
     expect(shapeStreamInits).toHaveBeenCalledTimes(2)
 
     expect(shapeStreamInits.mock.calls[1][0]).not.toHaveProperty('shapeId')
-    expect(shapeStreamInits.mock.calls[1][0]).not.toHaveProperty('lastOffset')
+    expect(shapeStreamInits.mock.calls[1][0]).not.toHaveProperty('offset')
   })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -252,15 +252,15 @@ importers:
   packages/pglite-sync:
     dependencies:
       '@electric-sql/client':
-        specifier: ^0.3.2
-        version: 0.3.2
+        specifier: ^0.5.1
+        version: 0.5.1
     devDependencies:
       '@electric-sql/pglite':
         specifier: workspace:*
         version: link:../pglite
       '@eslint-react/eslint-plugin':
-        specifier: ^1.12.1
-        version: 1.12.1(eslint@8.57.0)(typescript@5.5.4)
+        specifier: ^1.14.2
+        version: 1.14.2(eslint@8.57.0)(typescript@5.5.4)
       '@vitejs/plugin-react':
         specifier: ^4.2.1
         version: 4.3.1(vite@5.4.0(@types/node@22.4.1)(terser@5.31.6))
@@ -268,8 +268,8 @@ importers:
         specifier: ^15.9.0
         version: 15.9.0
       vitest:
-        specifier: ^2.0.5
-        version: 2.0.5(@types/node@22.4.1)(@vitest/browser@2.0.5)(@vitest/ui@2.0.5)(jsdom@24.1.1)(terser@5.31.6)
+        specifier: ^2.1.1
+        version: 2.1.1(@types/node@22.4.1)(jsdom@24.1.1)(msw@2.3.5(typescript@5.5.4))(terser@5.31.6)
 
   packages/pglite-vue:
     dependencies:
@@ -630,8 +630,8 @@ packages:
       search-insights:
         optional: true
 
-  '@electric-sql/client@0.3.2':
-    resolution: {integrity: sha512-DVOtrIfg7xlXpU95F53MnLXLeIn1eYkSRz01vj63NzZZ7bf6vLSHzNKvil0413C3U3769btfQytGNWmsb744WQ==}
+  '@electric-sql/client@0.5.1':
+    resolution: {integrity: sha512-7SBuZGVYxhdi8mOUN5SwP4lXXfEw/1E/MdPrLyOIjnrfG4AGftMNfCTWBQwHhErAVxKf34mqoAIkCpuIVL3jVA==}
 
   '@embedded-postgres/darwin-arm64@15.5.1-beta.11':
     resolution: {integrity: sha512-5m96qe7TFR/wzL05fyl1TRKfm+I73gIdDea+vXh60MQzUUfX9FXSiR8id6TI4aRhomUrd/l8hLTq8E2ymTCIFw==}
@@ -976,14 +976,14 @@ packages:
   '@eslint-react/ast@1.10.1':
     resolution: {integrity: sha512-8KC3Q425Es1h9E6vSuyoqLZIbT/Dpv2UV+DIH0zlosR3OxHcglUvR+b2FeNcm6PIr43OxNn3uht6O6fmsilukQ==}
 
-  '@eslint-react/ast@1.12.1':
-    resolution: {integrity: sha512-RMxFdoAMBCptcYqGXizYnLnPxA53vOHSgMAoc8/2x2P0xOiW5hOk2iSEX8Og/1I8wIU2KNk+592Nw5aufyTCCQ==}
+  '@eslint-react/ast@1.14.2':
+    resolution: {integrity: sha512-waFjfqN9estBOSPHB2QzLm0s+10rEK86qzww/BkSLAORZLSftxQ1YrAL7vECBw+7G8RI1ehEh6s5ZFkBedUirA==}
 
   '@eslint-react/core@1.10.1':
     resolution: {integrity: sha512-3tXmEZgV556gyYKGlOiHgMkDPDl/lg71+60dIdnvY+KSVgeieeJoQ2Z7kez2ds1a/882gfaNmj8/6qxROtDagQ==}
 
-  '@eslint-react/core@1.12.1':
-    resolution: {integrity: sha512-YrXdB4U/QAyjQSvVT8rZLYwkDt4yLsMBe9sv5EWDqTVSSWRUx+4WpHxlHzgel0lHsYLsa9Xtk4F9A6BoTQlk5A==}
+  '@eslint-react/core@1.14.2':
+    resolution: {integrity: sha512-DpyKNgYB+bYrBEhvlTzqcifzNuYH9GF0y4lyIeWD8Pr72M5zjMD8NgpzT6h+2Vx0TVcW12Ej8Kd86BsEqhmZPQ==}
 
   '@eslint-react/eslint-plugin@1.10.1':
     resolution: {integrity: sha512-ZZoqeE4L3Ciu7uNiyfxKTjDBsuNIJlqEc9zy1r8Jk+O0dx1cBBrH+eHCXAMRce6Q5xLWphvSorUbtYBgzmpLFw==}
@@ -995,8 +995,8 @@ packages:
       typescript:
         optional: true
 
-  '@eslint-react/eslint-plugin@1.12.1':
-    resolution: {integrity: sha512-BxkalSLCoRr9YwcYuJa5jtkDzI2FLO4eHjnkjBph8+lmAg7Zc3AV8ztuYUhnwZE4JzC6PaFmltd+qggKQxOKgA==}
+  '@eslint-react/eslint-plugin@1.14.2':
+    resolution: {integrity: sha512-q8bIJYfMr4YBfLlqG+cIStp+8/J1trgSqkbZQy6C6+DVP/AtWB+Gqq3a5qshpbJ0WVbtbZ4Yed61hxhZCnxsZA==}
     engines: {bun: '>=1.0.15', node: '>=18.18.0'}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
@@ -1008,32 +1008,32 @@ packages:
   '@eslint-react/jsx@1.10.1':
     resolution: {integrity: sha512-ddItN4nCgBKewfiV0thzu5vMi6s3SXOTrfrk1Jw5ncbbMebaTGNowMnc5jNHL2Z6ITP0ftoB6mqylBnFV/pUcA==}
 
-  '@eslint-react/jsx@1.12.1':
-    resolution: {integrity: sha512-PsnHG2R1gWI2ECKD6xQbQMto3vQYR3GKq6fdDu1W2iP81Ff+KmMB9Sw2tx+cHquwqYjFGefNrU2oqa/MZG0e2g==}
+  '@eslint-react/jsx@1.14.2':
+    resolution: {integrity: sha512-Uu2URP5q935fK2NK59BZqjIwrRkD3zarCqmlZfig0Hy2vrllf8mileKkC7kAoIFhc8A6ilGLwaRdMWvEAVbR2A==}
 
   '@eslint-react/shared@1.10.1':
     resolution: {integrity: sha512-4E3OEep4oSB4h5T4pzmgvqjTru7FVG7LX2gP1WcXLV9Ne+ukMOts+RVnLj/FSpnIqZ+EU07tOuCGSm/Qc6n8Pw==}
 
-  '@eslint-react/shared@1.12.1':
-    resolution: {integrity: sha512-6H12k+Aq6Ibv+OUKsvSp+wUeK77l0yEZKvhKIOAQtVtEWHbd+acdwh8+hKQ1FMOyIYKXKMRFQurR7Fnh2/mqzA==}
+  '@eslint-react/shared@1.14.2':
+    resolution: {integrity: sha512-VTN5QflFLgFHWKgnWwt/8sMedeT+7mn4/yrQ6ZrHhia95hDAW9fprMJtNR3AkJ30vnc/1x9I0KUisEvT1u3Cgw==}
 
   '@eslint-react/tools@1.10.1':
     resolution: {integrity: sha512-z+oy+ETIRQaJvfi59gXB9jhkhoCFNaHo7QRLiERK/kx0mQ+1KeWXAQvvSSoTgClM5WL8Z4Ma3EM8HbaHhYQMxA==}
 
-  '@eslint-react/tools@1.12.1':
-    resolution: {integrity: sha512-PiR6fpRsqXVQt+RA/hz26gCQHaQp9UgPkIUbA4l7rw0yfCRxBixJ1Fsy3tiAA/v68aRWN+IDSRyECY/D9dBHVA==}
+  '@eslint-react/tools@1.14.2':
+    resolution: {integrity: sha512-AgtqWGZEywBfECIbmrtqLeJdPRQkCsfgUzmKxEjHTgMV4nqt5nKirYVnAUxS5/HSs/OqNUM6l+awFFCnCEuLjQ==}
 
   '@eslint-react/types@1.10.1':
     resolution: {integrity: sha512-1XadAq/QBdR3nIqCiJZErqs6L6WyrD7s7TXypPFoKlp0GKJpFAWeewIpHhEIZOiqFmt3qLG+0ruYSAnctRZ1MA==}
 
-  '@eslint-react/types@1.12.1':
-    resolution: {integrity: sha512-HdYNOHk6ROCDNiGnHKzDavQ8smASaZ/OS7cS66nBeSeJ24Xu2Fu+yaOl2PK7jE6iRToS4l6RzLsb5vcyjCaxcQ==}
+  '@eslint-react/types@1.14.2':
+    resolution: {integrity: sha512-YPfdPYUHTXw+5KT+WgLJrRQAJcTyQ2rzUDAUq7Cl2x71J88USXzja8D7KNDFA9S+eeF5eaUVc9LJo3Uz7eq4Dw==}
 
   '@eslint-react/var@1.10.1':
     resolution: {integrity: sha512-Ss3eDXrchEwIwgw9UX9mFg11v0eCtDx7klSuKLB0qzKnrtTDUOsSdjFvkApq3q7GFPETuESzvsYbfESAvCM1yg==}
 
-  '@eslint-react/var@1.12.1':
-    resolution: {integrity: sha512-4NMhJJNtAaW2sS1z5MdWANeh02xVvFQo4Ja/qNI0d9Y2SpCb5CTXRPBH78Dt+nJJiOAcbU9uF+qnCp4T40J8RA==}
+  '@eslint-react/var@1.14.2':
+    resolution: {integrity: sha512-OOxwTPcWoNJbpaWnULpq+QJzsdZveU/QCHZ6Lb1oNIdVPBc6nCKz3PH97hqYFpk3q+gnnNx2q6qhNIAfeu/8Ug==}
 
   '@eslint/eslintrc@2.1.4':
     resolution: {integrity: sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==}
@@ -1473,8 +1473,8 @@ packages:
     resolution: {integrity: sha512-DsuOZQji687sQUjm4N6c9xABJa7fjvfIdjqpSIIVOgaENf2jFXiM9hIBZOL3hb6DHK9Nvd2d7zZnoMLf9e0OtQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/scope-manager@8.2.0':
-    resolution: {integrity: sha512-OFn80B38yD6WwpoHU2Tz/fTz7CgFqInllBoC3WP+/jLbTb4gGPTy9HBSTsbDWkMdN55XlVU0mMDYAtgvlUspGw==}
+  '@typescript-eslint/scope-manager@8.7.0':
+    resolution: {integrity: sha512-87rC0k3ZlDOuz82zzXRtQ7Akv3GKhHs0ti4YcbAJtaomllXoSO8hi7Ix3ccEvCd824dy9aIX+j3d2UMAfCtVpg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/type-utils@7.18.0':
@@ -1496,8 +1496,8 @@ packages:
       typescript:
         optional: true
 
-  '@typescript-eslint/type-utils@8.2.0':
-    resolution: {integrity: sha512-g1CfXGFMQdT5S+0PSO0fvGXUaiSkl73U1n9LTK5aRAFnPlJ8dLKkXr4AaLFvPedW8lVDoMgLLE3JN98ZZfsj0w==}
+  '@typescript-eslint/type-utils@8.7.0':
+    resolution: {integrity: sha512-tl0N0Mj3hMSkEYhLkjREp54OSb/FI6qyCzfiiclvJvOqre6hsZTGSnHtmFLDU8TIM62G7ygEa1bI08lcuRwEnQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '*'
@@ -1513,8 +1513,8 @@ packages:
     resolution: {integrity: sha512-q2/Bxa0gMOu/2/AKALI0tCKbG2zppccnRIRCW6BaaTlRVaPKft4oVYPp7WOPpcnsgbr0qROAVCVKCvIQ0tbWog==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/types@8.2.0':
-    resolution: {integrity: sha512-6a9QSK396YqmiBKPkJtxsgZZZVjYQ6wQ/TlI0C65z7vInaETuC6HAHD98AGLC8DyIPqHytvNuS8bBVvNLKyqvQ==}
+  '@typescript-eslint/types@8.7.0':
+    resolution: {integrity: sha512-LLt4BLHFwSfASHSF2K29SZ+ZCsbQOM+LuarPjRUuHm+Qd09hSe3GCeaQbcCr+Mik+0QFRmep/FyZBO6fJ64U3w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/typescript-estree@7.18.0':
@@ -1535,8 +1535,8 @@ packages:
       typescript:
         optional: true
 
-  '@typescript-eslint/typescript-estree@8.2.0':
-    resolution: {integrity: sha512-kiG4EDUT4dImplOsbh47B1QnNmXSoUqOjWDvCJw/o8LgfD0yr7k2uy54D5Wm0j4t71Ge1NkynGhpWdS0dEIAUA==}
+  '@typescript-eslint/typescript-estree@8.7.0':
+    resolution: {integrity: sha512-MC8nmcGHsmfAKxwnluTQpNqceniT8SteVwd2voYlmiSWGOtjvGXdPl17dYu2797GVscK30Z04WRM28CrKS9WOg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '*'
@@ -1556,8 +1556,8 @@ packages:
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
 
-  '@typescript-eslint/utils@8.2.0':
-    resolution: {integrity: sha512-O46eaYKDlV3TvAVDNcoDzd5N550ckSe8G4phko++OCSC1dYIb9LTc3HDGYdWqWIAT5qDUKphO6sd9RrpIJJPfg==}
+  '@typescript-eslint/utils@8.7.0':
+    resolution: {integrity: sha512-ZbdUdwsl2X/s3CiyAu3gOlfQzpbuG3nTWKPoIvAu1pu5r8viiJvv2NPN2AqArL35NCYtw/lrPPfM4gxrMLNLPw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
@@ -1570,8 +1570,8 @@ packages:
     resolution: {integrity: sha512-ba0lNI19awqZ5ZNKh6wCModMwoZs457StTebQ0q1NP58zSi2F6MOZRXwfKZy+jB78JNJ/WH8GSh2IQNzXX8Nag==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/visitor-keys@8.2.0':
-    resolution: {integrity: sha512-sbgsPMW9yLvS7IhCi8IpuK1oBmtbWUNP+hBdwl/I9nzqVsszGnNGti5r9dUtF5RLivHUFFIdRvLiTsPhzSyJ3Q==}
+  '@typescript-eslint/visitor-keys@8.7.0':
+    resolution: {integrity: sha512-b1tx0orFCCh/THWPQa2ZwWzvOeyzzp36vkJYOpVg0u8UVOIsfVrnuC9FqAw9gRKn+rG2VmWQ/zDJZzkxUnj/XQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@uiw/codemirror-extensions-basic-setup@4.23.0':
@@ -1643,17 +1643,44 @@ packages:
   '@vitest/expect@2.0.5':
     resolution: {integrity: sha512-yHZtwuP7JZivj65Gxoi8upUN2OzHTi3zVfjwdpu2WrvCZPLwsJ2Ey5ILIPccoW23dd/zQBlJ4/dhi7DWNyXCpA==}
 
+  '@vitest/expect@2.1.1':
+    resolution: {integrity: sha512-YeueunS0HiHiQxk+KEOnq/QMzlUuOzbU1Go+PgAsHvvv3tUkJPm9xWt+6ITNTlzsMXUjmgm5T+U7KBPK2qQV6w==}
+
+  '@vitest/mocker@2.1.1':
+    resolution: {integrity: sha512-LNN5VwOEdJqCmJ/2XJBywB11DLlkbY0ooDJW3uRX5cZyYCrc4PI/ePX0iQhE3BiEGiQmK4GE7Q/PqCkkaiPnrA==}
+    peerDependencies:
+      '@vitest/spy': 2.1.1
+      msw: ^2.3.5
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
   '@vitest/pretty-format@2.0.5':
     resolution: {integrity: sha512-h8k+1oWHfwTkyTkb9egzwNMfJAEx4veaPSnMeKbVSjp4euqGSbQlm5+6VHwTr7u4FJslVVsUG5nopCaAYdOmSQ==}
+
+  '@vitest/pretty-format@2.1.1':
+    resolution: {integrity: sha512-SjxPFOtuINDUW8/UkElJYQSFtnWX7tMksSGW0vfjxMneFqxVr8YJ979QpMbDW7g+BIiq88RAGDjf7en6rvLPPQ==}
 
   '@vitest/runner@2.0.5':
     resolution: {integrity: sha512-TfRfZa6Bkk9ky4tW0z20WKXFEwwvWhRY+84CnSEtq4+3ZvDlJyY32oNTJtM7AW9ihW90tX/1Q78cb6FjoAs+ig==}
 
+  '@vitest/runner@2.1.1':
+    resolution: {integrity: sha512-uTPuY6PWOYitIkLPidaY5L3t0JJITdGTSwBtwMjKzo5O6RCOEncz9PUN+0pDidX8kTHYjO0EwUIvhlGpnGpxmA==}
+
   '@vitest/snapshot@2.0.5':
     resolution: {integrity: sha512-SgCPUeDFLaM0mIUHfaArq8fD2WbaXG/zVXjRupthYfYGzc8ztbFbu6dUNOblBG7XLMR1kEhS/DNnfCZ2IhdDew==}
 
+  '@vitest/snapshot@2.1.1':
+    resolution: {integrity: sha512-BnSku1WFy7r4mm96ha2FzN99AZJgpZOWrAhtQfoxjUU5YMRpq1zmHRq7a5K9/NjqonebO7iVDla+VvZS8BOWMw==}
+
   '@vitest/spy@2.0.5':
     resolution: {integrity: sha512-c/jdthAhvJdpfVuaexSrnawxZz6pywlTPe84LUB2m/4t3rl2fTo9NFGBG4oWgaD+FTgDDV8hJ/nibT7IfH3JfA==}
+
+  '@vitest/spy@2.1.1':
+    resolution: {integrity: sha512-ZM39BnZ9t/xZ/nF4UwRH5il0Sw93QnZXd9NAZGRpIgj0yvVwPpLd702s/Cx955rGaMlyBQkZJ2Ir7qyY48VZ+g==}
 
   '@vitest/ui@2.0.5':
     resolution: {integrity: sha512-m+ZpVt/PVi/nbeRKEjdiYeoh0aOfI9zr3Ria9LO7V2PlMETtAXJS3uETEZkc8Be2oOl8mhd7Ew+5SRBXRYncNw==}
@@ -1662,6 +1689,9 @@ packages:
 
   '@vitest/utils@2.0.5':
     resolution: {integrity: sha512-d8HKbqIcya+GR67mkZbrzhS5kKhtp8dQLcmRZLGTscGVg7yImT82cIrhtn2L8+VujWcy6KZweApgNmPsTAO/UQ==}
+
+  '@vitest/utils@2.1.1':
+    resolution: {integrity: sha512-Y6Q9TsI+qJ2CC0ZKj6VBb+T8UPz593N113nnUykqwANqhgf3QkZeHFlusgKLTqrnVHbj/XDKZcDHol+dxVT+rQ==}
 
   '@volar/language-core@2.3.4':
     resolution: {integrity: sha512-wXBhY11qG6pCDAqDnbBRFIDSIwbqkWI7no+lj5+L7IlA7HRIjRP7YQLGzT0LF4lS6eHkMSsclXqy9DwYJasZTQ==}
@@ -2003,7 +2033,6 @@ packages:
 
   bun@1.1.24:
     resolution: {integrity: sha512-vZt5zNVaoNTSlNprdVdQVZInBcGC2QSik6o9ZsMzuYiiUEAEqpRwwMXAYDUN85mt2FNnsGvmk/8xVlUXS7IzEw==}
-    cpu: [arm64, x64]
     os: [darwin, linux, win32]
     hasBin: true
 
@@ -2383,8 +2412,8 @@ packages:
       typescript:
         optional: true
 
-  eslint-plugin-react-debug@1.12.1:
-    resolution: {integrity: sha512-qEcsdHf+NYuKWQv6Bx8wRDKywDr5rftjgXdawEoKR7vViYOu/TgNLXbyGbxGTWurkqZy84z4MZon6qjbjqIs9A==}
+  eslint-plugin-react-debug@1.14.2:
+    resolution: {integrity: sha512-5DlSAx4dHhqbGpPMOyEu7lhdWExwxI1e/3MeKSJBfigQamdA0dIZi/K0ZkeVqbSS8ItU+G/Ba1ek6vYCtadNvA==}
     engines: {bun: '>=1.0.15', node: '>=18.18.0'}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
@@ -2403,8 +2432,8 @@ packages:
       typescript:
         optional: true
 
-  eslint-plugin-react-dom@1.12.1:
-    resolution: {integrity: sha512-/Z24ixu0M4XZy9lrXhPZgqzUa8Y22Z9zDycGMPtlwUbSG7LQvpJ+bYg5bX2u/4ckiW+nf3EO7FPyAftgPPX9pA==}
+  eslint-plugin-react-dom@1.14.2:
+    resolution: {integrity: sha512-qG1WqsOHj4BdoOBPt3gwtEbeTc43EKKqDzxcB4gRbT6euBxU0EluEMtcFO/bAy9950iehD7rRSvuLs7voE+bNg==}
     engines: {bun: '>=1.0.15', node: '>=18.18.0'}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
@@ -2423,8 +2452,8 @@ packages:
       typescript:
         optional: true
 
-  eslint-plugin-react-hooks-extra@1.12.1:
-    resolution: {integrity: sha512-J8NIB8kxaUoQ+OSZhTCNiD7V7XSXi9zLc/RB7a1lJQz8VAUjgvYjiKzLwsvSsqRepZ3kR5bRi+zIsjf89hma/A==}
+  eslint-plugin-react-hooks-extra@1.14.2:
+    resolution: {integrity: sha512-SMDEluUIFQMPksKtmHVT2etaKqGIN7Rvcp9R/MB1bFcO1sh5ON2dDHXcZUTomZHriTEn/fm6pANe44jk20l4jQ==}
     engines: {bun: '>=1.0.15', node: '>=18.18.0'}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
@@ -2449,8 +2478,8 @@ packages:
       typescript:
         optional: true
 
-  eslint-plugin-react-naming-convention@1.12.1:
-    resolution: {integrity: sha512-XravfJJwETtTVSlYYXQ1254Crh0O49t+F9wlRX5vFUg4wDIHzyuJsYPqDn+OiejMiqkmB1+DVYcAsHxBHal10g==}
+  eslint-plugin-react-naming-convention@1.14.2:
+    resolution: {integrity: sha512-LWJm5kF7hWL7OcJnn+dTmC/l75RV4n7gH5QRH4kjcsVRs/Ky/kTcmBQTlC+CsaMUsy9jro6VBzj7Rk9/IO5vcQ==}
     engines: {bun: '>=1.0.15', node: '>=18.18.0'}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
@@ -2464,8 +2493,8 @@ packages:
     peerDependencies:
       eslint: '>=7'
 
-  eslint-plugin-react-web-api@1.12.1:
-    resolution: {integrity: sha512-/DnoWFW2a6TzFfiQxknXsqweLI6y+pwdpH6CM536ydZsaZkikT+6MMEMKSSr+PDd8uOnizXmUw8l7P7v7d8xXA==}
+  eslint-plugin-react-web-api@1.14.2:
+    resolution: {integrity: sha512-Qq2AJmGsNaabYaWtZweLSTfVGoyPPrz+A7L+h4ecq0TzvnlfSPWFyfQF4biBsZt+V4RrkBpQ4cB9Cqn7TEsEMQ==}
     engines: {bun: '>=1.0.15', node: '>=18.18.0'}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
@@ -2484,8 +2513,8 @@ packages:
       typescript:
         optional: true
 
-  eslint-plugin-react-x@1.12.1:
-    resolution: {integrity: sha512-I9ZCp/QkmbiVJp7HvIXeWkJzVUjLVG4/tbrAjwmz9Z/C7rUwtPj5baRumvM1BGPotnxd2QO4fg0t3YxhUMQ10Q==}
+  eslint-plugin-react-x@1.14.2:
+    resolution: {integrity: sha512-iiizpXxc//MoOwOqk6J55BMuywrDhZW2wvdM1XK1H8D5OEekyEzZQLPtOaVT0WyO+6tCdvmegKaX/J+4mVcuAg==}
     engines: {bun: '>=1.0.15', node: '>=18.18.0'}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
@@ -4025,6 +4054,9 @@ packages:
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
+  tinyexec@0.3.0:
+    resolution: {integrity: sha512-tVGE0mVJPGb0chKhqmsoosjsS+qUnJVGJpZgsHYQcGoPlG3B51R3PouqTgEGH2Dc9jjFyOqOpix6ZHNMXp1FZg==}
+
   tinypool@1.0.0:
     resolution: {integrity: sha512-KIKExllK7jp3uvrNtvRBYBWBOAXSX8ZvoaD8T+7KB/QHIuoJW3Pmr60zucywjAlMb5TeXUkcs/MWeWLu0qvuAQ==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -4200,6 +4232,11 @@ packages:
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
 
+  vite-node@2.1.1:
+    resolution: {integrity: sha512-N/mGckI1suG/5wQI35XeR9rsMsPqKXzq1CdUndzVstBj/HvyxxGctwnK6WX43NGt5L3Z5tcRf83g4TITKJhPrA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
   vite-plugin-dts@4.0.2:
     resolution: {integrity: sha512-Ni3EPG8yeLc5ivEzT4szreJ0rXpEQgvdYq3PaZ7OMoHc8uET4/HRUfzVPejJaUAojbxsKgaZbp6Zgm41sxb86Q==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -4267,6 +4304,31 @@ packages:
       '@types/node': ^18.0.0 || >=20.0.0
       '@vitest/browser': 2.0.5
       '@vitest/ui': 2.0.5
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  vitest@2.1.1:
+    resolution: {integrity: sha512-97We7/VC0e9X5zBVkvt7SGQMGrRtn3KtySFQG5fpaMlS+l62eeXRQO633AYhSTC3z7IMebnPPNjGXVGNRFlxBA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.1
+      '@vitest/ui': 2.1.1
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
@@ -5033,7 +5095,7 @@ snapshots:
     transitivePeerDependencies:
       - '@algolia/client-search'
 
-  '@electric-sql/client@0.3.2':
+  '@electric-sql/client@0.5.1':
     optionalDependencies:
       '@rollup/rollup-darwin-arm64': 4.20.0
 
@@ -5224,13 +5286,13 @@ snapshots:
       - supports-color
       - typescript
 
-  '@eslint-react/ast@1.12.1(eslint@8.57.0)(typescript@5.5.4)':
+  '@eslint-react/ast@1.14.2(eslint@8.57.0)(typescript@5.5.4)':
     dependencies:
-      '@eslint-react/tools': 1.12.1
-      '@eslint-react/types': 1.12.1(eslint@8.57.0)(typescript@5.5.4)
-      '@typescript-eslint/types': 8.2.0
-      '@typescript-eslint/typescript-estree': 8.2.0(typescript@5.5.4)
-      '@typescript-eslint/utils': 8.2.0(eslint@8.57.0)(typescript@5.5.4)
+      '@eslint-react/tools': 1.14.2
+      '@eslint-react/types': 1.14.2(eslint@8.57.0)(typescript@5.5.4)
+      '@typescript-eslint/types': 8.7.0
+      '@typescript-eslint/typescript-estree': 8.7.0(typescript@5.5.4)
+      '@typescript-eslint/utils': 8.7.0(eslint@8.57.0)(typescript@5.5.4)
       birecord: 0.1.1
       string-ts: 2.2.0
       ts-pattern: 5.3.1
@@ -5258,18 +5320,18 @@ snapshots:
       - supports-color
       - typescript
 
-  '@eslint-react/core@1.12.1(eslint@8.57.0)(typescript@5.5.4)':
+  '@eslint-react/core@1.14.2(eslint@8.57.0)(typescript@5.5.4)':
     dependencies:
-      '@eslint-react/ast': 1.12.1(eslint@8.57.0)(typescript@5.5.4)
-      '@eslint-react/jsx': 1.12.1(eslint@8.57.0)(typescript@5.5.4)
-      '@eslint-react/shared': 1.12.1(eslint@8.57.0)(typescript@5.5.4)
-      '@eslint-react/tools': 1.12.1
-      '@eslint-react/types': 1.12.1(eslint@8.57.0)(typescript@5.5.4)
-      '@eslint-react/var': 1.12.1(eslint@8.57.0)(typescript@5.5.4)
-      '@typescript-eslint/scope-manager': 8.2.0
-      '@typescript-eslint/type-utils': 8.2.0(eslint@8.57.0)(typescript@5.5.4)
-      '@typescript-eslint/types': 8.2.0
-      '@typescript-eslint/utils': 8.2.0(eslint@8.57.0)(typescript@5.5.4)
+      '@eslint-react/ast': 1.14.2(eslint@8.57.0)(typescript@5.5.4)
+      '@eslint-react/jsx': 1.14.2(eslint@8.57.0)(typescript@5.5.4)
+      '@eslint-react/shared': 1.14.2(eslint@8.57.0)(typescript@5.5.4)
+      '@eslint-react/tools': 1.14.2
+      '@eslint-react/types': 1.14.2(eslint@8.57.0)(typescript@5.5.4)
+      '@eslint-react/var': 1.14.2(eslint@8.57.0)(typescript@5.5.4)
+      '@typescript-eslint/scope-manager': 8.7.0
+      '@typescript-eslint/type-utils': 8.7.0(eslint@8.57.0)(typescript@5.5.4)
+      '@typescript-eslint/types': 8.7.0
+      '@typescript-eslint/utils': 8.7.0(eslint@8.57.0)(typescript@5.5.4)
       birecord: 0.1.1
       short-unique-id: 5.2.0
       ts-pattern: 5.3.1
@@ -5298,22 +5360,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint-react/eslint-plugin@1.12.1(eslint@8.57.0)(typescript@5.5.4)':
+  '@eslint-react/eslint-plugin@1.14.2(eslint@8.57.0)(typescript@5.5.4)':
     dependencies:
-      '@eslint-react/shared': 1.12.1(eslint@8.57.0)(typescript@5.5.4)
-      '@eslint-react/tools': 1.12.1
-      '@eslint-react/types': 1.12.1(eslint@8.57.0)(typescript@5.5.4)
-      '@typescript-eslint/scope-manager': 8.2.0
-      '@typescript-eslint/type-utils': 8.2.0(eslint@8.57.0)(typescript@5.5.4)
-      '@typescript-eslint/types': 8.2.0
-      '@typescript-eslint/utils': 8.2.0(eslint@8.57.0)(typescript@5.5.4)
+      '@eslint-react/shared': 1.14.2(eslint@8.57.0)(typescript@5.5.4)
+      '@eslint-react/tools': 1.14.2
+      '@eslint-react/types': 1.14.2(eslint@8.57.0)(typescript@5.5.4)
+      '@typescript-eslint/scope-manager': 8.7.0
+      '@typescript-eslint/type-utils': 8.7.0(eslint@8.57.0)(typescript@5.5.4)
+      '@typescript-eslint/types': 8.7.0
+      '@typescript-eslint/utils': 8.7.0(eslint@8.57.0)(typescript@5.5.4)
       eslint: 8.57.0
-      eslint-plugin-react-debug: 1.12.1(eslint@8.57.0)(typescript@5.5.4)
-      eslint-plugin-react-dom: 1.12.1(eslint@8.57.0)(typescript@5.5.4)
-      eslint-plugin-react-hooks-extra: 1.12.1(eslint@8.57.0)(typescript@5.5.4)
-      eslint-plugin-react-naming-convention: 1.12.1(eslint@8.57.0)(typescript@5.5.4)
-      eslint-plugin-react-web-api: 1.12.1(eslint@8.57.0)(typescript@5.5.4)
-      eslint-plugin-react-x: 1.12.1(eslint@8.57.0)(typescript@5.5.4)
+      eslint-plugin-react-debug: 1.14.2(eslint@8.57.0)(typescript@5.5.4)
+      eslint-plugin-react-dom: 1.14.2(eslint@8.57.0)(typescript@5.5.4)
+      eslint-plugin-react-hooks-extra: 1.14.2(eslint@8.57.0)(typescript@5.5.4)
+      eslint-plugin-react-naming-convention: 1.14.2(eslint@8.57.0)(typescript@5.5.4)
+      eslint-plugin-react-web-api: 1.14.2(eslint@8.57.0)(typescript@5.5.4)
+      eslint-plugin-react-x: 1.14.2(eslint@8.57.0)(typescript@5.5.4)
     optionalDependencies:
       typescript: 5.5.4
     transitivePeerDependencies:
@@ -5334,15 +5396,15 @@ snapshots:
       - supports-color
       - typescript
 
-  '@eslint-react/jsx@1.12.1(eslint@8.57.0)(typescript@5.5.4)':
+  '@eslint-react/jsx@1.14.2(eslint@8.57.0)(typescript@5.5.4)':
     dependencies:
-      '@eslint-react/ast': 1.12.1(eslint@8.57.0)(typescript@5.5.4)
-      '@eslint-react/tools': 1.12.1
-      '@eslint-react/types': 1.12.1(eslint@8.57.0)(typescript@5.5.4)
-      '@eslint-react/var': 1.12.1(eslint@8.57.0)(typescript@5.5.4)
-      '@typescript-eslint/scope-manager': 8.2.0
-      '@typescript-eslint/types': 8.2.0
-      '@typescript-eslint/utils': 8.2.0(eslint@8.57.0)(typescript@5.5.4)
+      '@eslint-react/ast': 1.14.2(eslint@8.57.0)(typescript@5.5.4)
+      '@eslint-react/tools': 1.14.2
+      '@eslint-react/types': 1.14.2(eslint@8.57.0)(typescript@5.5.4)
+      '@eslint-react/var': 1.14.2(eslint@8.57.0)(typescript@5.5.4)
+      '@typescript-eslint/scope-manager': 8.7.0
+      '@typescript-eslint/types': 8.7.0
+      '@typescript-eslint/utils': 8.7.0(eslint@8.57.0)(typescript@5.5.4)
       ts-pattern: 5.3.1
     transitivePeerDependencies:
       - eslint
@@ -5359,10 +5421,10 @@ snapshots:
       - supports-color
       - typescript
 
-  '@eslint-react/shared@1.12.1(eslint@8.57.0)(typescript@5.5.4)':
+  '@eslint-react/shared@1.14.2(eslint@8.57.0)(typescript@5.5.4)':
     dependencies:
-      '@eslint-react/tools': 1.12.1
-      '@typescript-eslint/utils': 8.2.0(eslint@8.57.0)(typescript@5.5.4)
+      '@eslint-react/tools': 1.14.2
+      '@typescript-eslint/utils': 8.7.0(eslint@8.57.0)(typescript@5.5.4)
       picomatch: 4.0.2
     transitivePeerDependencies:
       - eslint
@@ -5371,7 +5433,7 @@ snapshots:
 
   '@eslint-react/tools@1.10.1': {}
 
-  '@eslint-react/tools@1.12.1': {}
+  '@eslint-react/tools@1.14.2': {}
 
   '@eslint-react/types@1.10.1(eslint@8.57.0)(typescript@5.5.4)':
     dependencies:
@@ -5383,11 +5445,11 @@ snapshots:
       - supports-color
       - typescript
 
-  '@eslint-react/types@1.12.1(eslint@8.57.0)(typescript@5.5.4)':
+  '@eslint-react/types@1.14.2(eslint@8.57.0)(typescript@5.5.4)':
     dependencies:
-      '@eslint-react/tools': 1.12.1
-      '@typescript-eslint/types': 8.2.0
-      '@typescript-eslint/utils': 8.2.0(eslint@8.57.0)(typescript@5.5.4)
+      '@eslint-react/tools': 1.14.2
+      '@typescript-eslint/types': 8.7.0
+      '@typescript-eslint/utils': 8.7.0(eslint@8.57.0)(typescript@5.5.4)
     transitivePeerDependencies:
       - eslint
       - supports-color
@@ -5407,14 +5469,14 @@ snapshots:
       - supports-color
       - typescript
 
-  '@eslint-react/var@1.12.1(eslint@8.57.0)(typescript@5.5.4)':
+  '@eslint-react/var@1.14.2(eslint@8.57.0)(typescript@5.5.4)':
     dependencies:
-      '@eslint-react/ast': 1.12.1(eslint@8.57.0)(typescript@5.5.4)
-      '@eslint-react/tools': 1.12.1
-      '@eslint-react/types': 1.12.1(eslint@8.57.0)(typescript@5.5.4)
-      '@typescript-eslint/scope-manager': 8.2.0
-      '@typescript-eslint/types': 8.2.0
-      '@typescript-eslint/utils': 8.2.0(eslint@8.57.0)(typescript@5.5.4)
+      '@eslint-react/ast': 1.14.2(eslint@8.57.0)(typescript@5.5.4)
+      '@eslint-react/tools': 1.14.2
+      '@eslint-react/types': 1.14.2(eslint@8.57.0)(typescript@5.5.4)
+      '@typescript-eslint/scope-manager': 8.7.0
+      '@typescript-eslint/types': 8.7.0
+      '@typescript-eslint/utils': 8.7.0(eslint@8.57.0)(typescript@5.5.4)
       ts-pattern: 5.3.1
     transitivePeerDependencies:
       - eslint
@@ -5993,10 +6055,10 @@ snapshots:
       '@typescript-eslint/types': 8.1.0
       '@typescript-eslint/visitor-keys': 8.1.0
 
-  '@typescript-eslint/scope-manager@8.2.0':
+  '@typescript-eslint/scope-manager@8.7.0':
     dependencies:
-      '@typescript-eslint/types': 8.2.0
-      '@typescript-eslint/visitor-keys': 8.2.0
+      '@typescript-eslint/types': 8.7.0
+      '@typescript-eslint/visitor-keys': 8.7.0
 
   '@typescript-eslint/type-utils@7.18.0(eslint@8.57.0)(typescript@5.5.4)':
     dependencies:
@@ -6022,10 +6084,10 @@ snapshots:
       - eslint
       - supports-color
 
-  '@typescript-eslint/type-utils@8.2.0(eslint@8.57.0)(typescript@5.5.4)':
+  '@typescript-eslint/type-utils@8.7.0(eslint@8.57.0)(typescript@5.5.4)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 8.2.0(typescript@5.5.4)
-      '@typescript-eslint/utils': 8.2.0(eslint@8.57.0)(typescript@5.5.4)
+      '@typescript-eslint/typescript-estree': 8.7.0(typescript@5.5.4)
+      '@typescript-eslint/utils': 8.7.0(eslint@8.57.0)(typescript@5.5.4)
       debug: 4.3.6
       ts-api-utils: 1.3.0(typescript@5.5.4)
     optionalDependencies:
@@ -6038,7 +6100,7 @@ snapshots:
 
   '@typescript-eslint/types@8.1.0': {}
 
-  '@typescript-eslint/types@8.2.0': {}
+  '@typescript-eslint/types@8.7.0': {}
 
   '@typescript-eslint/typescript-estree@7.18.0(typescript@5.5.4)':
     dependencies:
@@ -6070,12 +6132,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@8.2.0(typescript@5.5.4)':
+  '@typescript-eslint/typescript-estree@8.7.0(typescript@5.5.4)':
     dependencies:
-      '@typescript-eslint/types': 8.2.0
-      '@typescript-eslint/visitor-keys': 8.2.0
+      '@typescript-eslint/types': 8.7.0
+      '@typescript-eslint/visitor-keys': 8.7.0
       debug: 4.3.6
-      globby: 11.1.0
+      fast-glob: 3.3.2
       is-glob: 4.0.3
       minimatch: 9.0.5
       semver: 7.6.3
@@ -6107,12 +6169,12 @@ snapshots:
       - supports-color
       - typescript
 
-  '@typescript-eslint/utils@8.2.0(eslint@8.57.0)(typescript@5.5.4)':
+  '@typescript-eslint/utils@8.7.0(eslint@8.57.0)(typescript@5.5.4)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
-      '@typescript-eslint/scope-manager': 8.2.0
-      '@typescript-eslint/types': 8.2.0
-      '@typescript-eslint/typescript-estree': 8.2.0(typescript@5.5.4)
+      '@typescript-eslint/scope-manager': 8.7.0
+      '@typescript-eslint/types': 8.7.0
+      '@typescript-eslint/typescript-estree': 8.7.0(typescript@5.5.4)
       eslint: 8.57.0
     transitivePeerDependencies:
       - supports-color
@@ -6128,9 +6190,9 @@ snapshots:
       '@typescript-eslint/types': 8.1.0
       eslint-visitor-keys: 3.4.3
 
-  '@typescript-eslint/visitor-keys@8.2.0':
+  '@typescript-eslint/visitor-keys@8.7.0':
     dependencies:
-      '@typescript-eslint/types': 8.2.0
+      '@typescript-eslint/types': 8.7.0
       eslint-visitor-keys: 3.4.3
 
   '@uiw/codemirror-extensions-basic-setup@4.23.0(@codemirror/autocomplete@6.18.0(@codemirror/language@6.10.2)(@codemirror/state@6.4.1)(@codemirror/view@6.32.0)(@lezer/common@1.2.1))(@codemirror/commands@6.6.0)(@codemirror/language@6.10.2)(@codemirror/lint@6.8.1)(@codemirror/search@6.5.6)(@codemirror/state@6.4.1)(@codemirror/view@6.32.0)':
@@ -6236,7 +6298,27 @@ snapshots:
       chai: 5.1.1
       tinyrainbow: 1.2.0
 
+  '@vitest/expect@2.1.1':
+    dependencies:
+      '@vitest/spy': 2.1.1
+      '@vitest/utils': 2.1.1
+      chai: 5.1.1
+      tinyrainbow: 1.2.0
+
+  '@vitest/mocker@2.1.1(@vitest/spy@2.1.1)(msw@2.3.5(typescript@5.5.4))(vite@5.4.0(@types/node@22.4.1)(terser@5.31.6))':
+    dependencies:
+      '@vitest/spy': 2.1.1
+      estree-walker: 3.0.3
+      magic-string: 0.30.11
+    optionalDependencies:
+      msw: 2.3.5(typescript@5.5.4)
+      vite: 5.4.0(@types/node@22.4.1)(terser@5.31.6)
+
   '@vitest/pretty-format@2.0.5':
+    dependencies:
+      tinyrainbow: 1.2.0
+
+  '@vitest/pretty-format@2.1.1':
     dependencies:
       tinyrainbow: 1.2.0
 
@@ -6245,13 +6327,28 @@ snapshots:
       '@vitest/utils': 2.0.5
       pathe: 1.1.2
 
+  '@vitest/runner@2.1.1':
+    dependencies:
+      '@vitest/utils': 2.1.1
+      pathe: 1.1.2
+
   '@vitest/snapshot@2.0.5':
     dependencies:
       '@vitest/pretty-format': 2.0.5
       magic-string: 0.30.11
       pathe: 1.1.2
 
+  '@vitest/snapshot@2.1.1':
+    dependencies:
+      '@vitest/pretty-format': 2.1.1
+      magic-string: 0.30.11
+      pathe: 1.1.2
+
   '@vitest/spy@2.0.5':
+    dependencies:
+      tinyspy: 3.0.0
+
+  '@vitest/spy@2.1.1':
     dependencies:
       tinyspy: 3.0.0
 
@@ -6271,6 +6368,12 @@ snapshots:
     dependencies:
       '@vitest/pretty-format': 2.0.5
       estree-walker: 3.0.3
+      loupe: 3.1.1
+      tinyrainbow: 1.2.0
+
+  '@vitest/utils@2.1.1':
+    dependencies:
+      '@vitest/pretty-format': 2.1.1
       loupe: 3.1.1
       tinyrainbow: 1.2.0
 
@@ -7115,19 +7218,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-debug@1.12.1(eslint@8.57.0)(typescript@5.5.4):
+  eslint-plugin-react-debug@1.14.2(eslint@8.57.0)(typescript@5.5.4):
     dependencies:
-      '@eslint-react/ast': 1.12.1(eslint@8.57.0)(typescript@5.5.4)
-      '@eslint-react/core': 1.12.1(eslint@8.57.0)(typescript@5.5.4)
-      '@eslint-react/jsx': 1.12.1(eslint@8.57.0)(typescript@5.5.4)
-      '@eslint-react/shared': 1.12.1(eslint@8.57.0)(typescript@5.5.4)
-      '@eslint-react/tools': 1.12.1
-      '@eslint-react/types': 1.12.1(eslint@8.57.0)(typescript@5.5.4)
-      '@eslint-react/var': 1.12.1(eslint@8.57.0)(typescript@5.5.4)
-      '@typescript-eslint/scope-manager': 8.2.0
-      '@typescript-eslint/type-utils': 8.2.0(eslint@8.57.0)(typescript@5.5.4)
-      '@typescript-eslint/types': 8.2.0
-      '@typescript-eslint/utils': 8.2.0(eslint@8.57.0)(typescript@5.5.4)
+      '@eslint-react/ast': 1.14.2(eslint@8.57.0)(typescript@5.5.4)
+      '@eslint-react/core': 1.14.2(eslint@8.57.0)(typescript@5.5.4)
+      '@eslint-react/jsx': 1.14.2(eslint@8.57.0)(typescript@5.5.4)
+      '@eslint-react/shared': 1.14.2(eslint@8.57.0)(typescript@5.5.4)
+      '@eslint-react/tools': 1.14.2
+      '@eslint-react/types': 1.14.2(eslint@8.57.0)(typescript@5.5.4)
+      '@eslint-react/var': 1.14.2(eslint@8.57.0)(typescript@5.5.4)
+      '@typescript-eslint/scope-manager': 8.7.0
+      '@typescript-eslint/type-utils': 8.7.0(eslint@8.57.0)(typescript@5.5.4)
+      '@typescript-eslint/types': 8.7.0
+      '@typescript-eslint/utils': 8.7.0(eslint@8.57.0)(typescript@5.5.4)
       eslint: 8.57.0
       string-ts: 2.2.0
       ts-pattern: 5.3.1
@@ -7155,18 +7258,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-dom@1.12.1(eslint@8.57.0)(typescript@5.5.4):
+  eslint-plugin-react-dom@1.14.2(eslint@8.57.0)(typescript@5.5.4):
     dependencies:
-      '@eslint-react/ast': 1.12.1(eslint@8.57.0)(typescript@5.5.4)
-      '@eslint-react/core': 1.12.1(eslint@8.57.0)(typescript@5.5.4)
-      '@eslint-react/jsx': 1.12.1(eslint@8.57.0)(typescript@5.5.4)
-      '@eslint-react/shared': 1.12.1(eslint@8.57.0)(typescript@5.5.4)
-      '@eslint-react/tools': 1.12.1
-      '@eslint-react/types': 1.12.1(eslint@8.57.0)(typescript@5.5.4)
-      '@eslint-react/var': 1.12.1(eslint@8.57.0)(typescript@5.5.4)
-      '@typescript-eslint/scope-manager': 8.2.0
-      '@typescript-eslint/types': 8.2.0
-      '@typescript-eslint/utils': 8.2.0(eslint@8.57.0)(typescript@5.5.4)
+      '@eslint-react/ast': 1.14.2(eslint@8.57.0)(typescript@5.5.4)
+      '@eslint-react/core': 1.14.2(eslint@8.57.0)(typescript@5.5.4)
+      '@eslint-react/jsx': 1.14.2(eslint@8.57.0)(typescript@5.5.4)
+      '@eslint-react/shared': 1.14.2(eslint@8.57.0)(typescript@5.5.4)
+      '@eslint-react/tools': 1.14.2
+      '@eslint-react/types': 1.14.2(eslint@8.57.0)(typescript@5.5.4)
+      '@eslint-react/var': 1.14.2(eslint@8.57.0)(typescript@5.5.4)
+      '@typescript-eslint/scope-manager': 8.7.0
+      '@typescript-eslint/types': 8.7.0
+      '@typescript-eslint/utils': 8.7.0(eslint@8.57.0)(typescript@5.5.4)
       eslint: 8.57.0
       ts-pattern: 5.3.1
     optionalDependencies:
@@ -7194,19 +7297,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-hooks-extra@1.12.1(eslint@8.57.0)(typescript@5.5.4):
+  eslint-plugin-react-hooks-extra@1.14.2(eslint@8.57.0)(typescript@5.5.4):
     dependencies:
-      '@eslint-react/ast': 1.12.1(eslint@8.57.0)(typescript@5.5.4)
-      '@eslint-react/core': 1.12.1(eslint@8.57.0)(typescript@5.5.4)
-      '@eslint-react/jsx': 1.12.1(eslint@8.57.0)(typescript@5.5.4)
-      '@eslint-react/shared': 1.12.1(eslint@8.57.0)(typescript@5.5.4)
-      '@eslint-react/tools': 1.12.1
-      '@eslint-react/types': 1.12.1(eslint@8.57.0)(typescript@5.5.4)
-      '@eslint-react/var': 1.12.1(eslint@8.57.0)(typescript@5.5.4)
-      '@typescript-eslint/scope-manager': 8.2.0
-      '@typescript-eslint/type-utils': 8.2.0(eslint@8.57.0)(typescript@5.5.4)
-      '@typescript-eslint/types': 8.2.0
-      '@typescript-eslint/utils': 8.2.0(eslint@8.57.0)(typescript@5.5.4)
+      '@eslint-react/ast': 1.14.2(eslint@8.57.0)(typescript@5.5.4)
+      '@eslint-react/core': 1.14.2(eslint@8.57.0)(typescript@5.5.4)
+      '@eslint-react/jsx': 1.14.2(eslint@8.57.0)(typescript@5.5.4)
+      '@eslint-react/shared': 1.14.2(eslint@8.57.0)(typescript@5.5.4)
+      '@eslint-react/tools': 1.14.2
+      '@eslint-react/types': 1.14.2(eslint@8.57.0)(typescript@5.5.4)
+      '@eslint-react/var': 1.14.2(eslint@8.57.0)(typescript@5.5.4)
+      '@typescript-eslint/scope-manager': 8.7.0
+      '@typescript-eslint/type-utils': 8.7.0(eslint@8.57.0)(typescript@5.5.4)
+      '@typescript-eslint/types': 8.7.0
+      '@typescript-eslint/utils': 8.7.0(eslint@8.57.0)(typescript@5.5.4)
       eslint: 8.57.0
       ts-pattern: 5.3.1
     optionalDependencies:
@@ -7237,18 +7340,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-naming-convention@1.12.1(eslint@8.57.0)(typescript@5.5.4):
+  eslint-plugin-react-naming-convention@1.14.2(eslint@8.57.0)(typescript@5.5.4):
     dependencies:
-      '@eslint-react/ast': 1.12.1(eslint@8.57.0)(typescript@5.5.4)
-      '@eslint-react/core': 1.12.1(eslint@8.57.0)(typescript@5.5.4)
-      '@eslint-react/jsx': 1.12.1(eslint@8.57.0)(typescript@5.5.4)
-      '@eslint-react/shared': 1.12.1(eslint@8.57.0)(typescript@5.5.4)
-      '@eslint-react/tools': 1.12.1
-      '@eslint-react/types': 1.12.1(eslint@8.57.0)(typescript@5.5.4)
-      '@typescript-eslint/scope-manager': 8.2.0
-      '@typescript-eslint/type-utils': 8.2.0(eslint@8.57.0)(typescript@5.5.4)
-      '@typescript-eslint/types': 8.2.0
-      '@typescript-eslint/utils': 8.2.0(eslint@8.57.0)(typescript@5.5.4)
+      '@eslint-react/ast': 1.14.2(eslint@8.57.0)(typescript@5.5.4)
+      '@eslint-react/core': 1.14.2(eslint@8.57.0)(typescript@5.5.4)
+      '@eslint-react/jsx': 1.14.2(eslint@8.57.0)(typescript@5.5.4)
+      '@eslint-react/shared': 1.14.2(eslint@8.57.0)(typescript@5.5.4)
+      '@eslint-react/tools': 1.14.2
+      '@eslint-react/types': 1.14.2(eslint@8.57.0)(typescript@5.5.4)
+      '@typescript-eslint/scope-manager': 8.7.0
+      '@typescript-eslint/type-utils': 8.7.0(eslint@8.57.0)(typescript@5.5.4)
+      '@typescript-eslint/types': 8.7.0
+      '@typescript-eslint/utils': 8.7.0(eslint@8.57.0)(typescript@5.5.4)
       eslint: 8.57.0
       ts-pattern: 5.3.1
     optionalDependencies:
@@ -7260,18 +7363,18 @@ snapshots:
     dependencies:
       eslint: 8.57.0
 
-  eslint-plugin-react-web-api@1.12.1(eslint@8.57.0)(typescript@5.5.4):
+  eslint-plugin-react-web-api@1.14.2(eslint@8.57.0)(typescript@5.5.4):
     dependencies:
-      '@eslint-react/ast': 1.12.1(eslint@8.57.0)(typescript@5.5.4)
-      '@eslint-react/core': 1.12.1(eslint@8.57.0)(typescript@5.5.4)
-      '@eslint-react/jsx': 1.12.1(eslint@8.57.0)(typescript@5.5.4)
-      '@eslint-react/shared': 1.12.1(eslint@8.57.0)(typescript@5.5.4)
-      '@eslint-react/tools': 1.12.1
-      '@eslint-react/types': 1.12.1(eslint@8.57.0)(typescript@5.5.4)
-      '@eslint-react/var': 1.12.1(eslint@8.57.0)(typescript@5.5.4)
-      '@typescript-eslint/scope-manager': 8.2.0
-      '@typescript-eslint/types': 8.2.0
-      '@typescript-eslint/utils': 8.2.0(eslint@8.57.0)(typescript@5.5.4)
+      '@eslint-react/ast': 1.14.2(eslint@8.57.0)(typescript@5.5.4)
+      '@eslint-react/core': 1.14.2(eslint@8.57.0)(typescript@5.5.4)
+      '@eslint-react/jsx': 1.14.2(eslint@8.57.0)(typescript@5.5.4)
+      '@eslint-react/shared': 1.14.2(eslint@8.57.0)(typescript@5.5.4)
+      '@eslint-react/tools': 1.14.2
+      '@eslint-react/types': 1.14.2(eslint@8.57.0)(typescript@5.5.4)
+      '@eslint-react/var': 1.14.2(eslint@8.57.0)(typescript@5.5.4)
+      '@typescript-eslint/scope-manager': 8.7.0
+      '@typescript-eslint/types': 8.7.0
+      '@typescript-eslint/utils': 8.7.0(eslint@8.57.0)(typescript@5.5.4)
       birecord: 0.1.1
       eslint: 8.57.0
       ts-pattern: 5.3.1
@@ -7301,19 +7404,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-x@1.12.1(eslint@8.57.0)(typescript@5.5.4):
+  eslint-plugin-react-x@1.14.2(eslint@8.57.0)(typescript@5.5.4):
     dependencies:
-      '@eslint-react/ast': 1.12.1(eslint@8.57.0)(typescript@5.5.4)
-      '@eslint-react/core': 1.12.1(eslint@8.57.0)(typescript@5.5.4)
-      '@eslint-react/jsx': 1.12.1(eslint@8.57.0)(typescript@5.5.4)
-      '@eslint-react/shared': 1.12.1(eslint@8.57.0)(typescript@5.5.4)
-      '@eslint-react/tools': 1.12.1
-      '@eslint-react/types': 1.12.1(eslint@8.57.0)(typescript@5.5.4)
-      '@eslint-react/var': 1.12.1(eslint@8.57.0)(typescript@5.5.4)
-      '@typescript-eslint/scope-manager': 8.2.0
-      '@typescript-eslint/type-utils': 8.2.0(eslint@8.57.0)(typescript@5.5.4)
-      '@typescript-eslint/types': 8.2.0
-      '@typescript-eslint/utils': 8.2.0(eslint@8.57.0)(typescript@5.5.4)
+      '@eslint-react/ast': 1.14.2(eslint@8.57.0)(typescript@5.5.4)
+      '@eslint-react/core': 1.14.2(eslint@8.57.0)(typescript@5.5.4)
+      '@eslint-react/jsx': 1.14.2(eslint@8.57.0)(typescript@5.5.4)
+      '@eslint-react/shared': 1.14.2(eslint@8.57.0)(typescript@5.5.4)
+      '@eslint-react/tools': 1.14.2
+      '@eslint-react/types': 1.14.2(eslint@8.57.0)(typescript@5.5.4)
+      '@eslint-react/var': 1.14.2(eslint@8.57.0)(typescript@5.5.4)
+      '@typescript-eslint/scope-manager': 8.7.0
+      '@typescript-eslint/type-utils': 8.7.0(eslint@8.57.0)(typescript@5.5.4)
+      '@typescript-eslint/types': 8.7.0
+      '@typescript-eslint/utils': 8.7.0(eslint@8.57.0)(typescript@5.5.4)
       eslint: 8.57.0
       is-immutable-type: 5.0.0(eslint@8.57.0)(typescript@5.5.4)
       ts-pattern: 5.3.1
@@ -8851,6 +8954,8 @@ snapshots:
 
   tinybench@2.9.0: {}
 
+  tinyexec@0.3.0: {}
+
   tinypool@1.0.0: {}
 
   tinyrainbow@1.2.0: {}
@@ -9038,6 +9143,23 @@ snapshots:
       - supports-color
       - terser
 
+  vite-node@2.1.1(@types/node@22.4.1)(terser@5.31.6):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.3.6
+      pathe: 1.1.2
+      vite: 5.4.0(@types/node@22.4.1)(terser@5.31.6)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vite-plugin-dts@4.0.2(@types/node@20.14.15)(rollup@4.20.0)(typescript@5.5.4)(vite@5.4.0(@types/node@20.14.15)(terser@5.31.6)):
     dependencies:
       '@microsoft/api-extractor': 7.47.4(@types/node@20.14.15)
@@ -9196,6 +9318,41 @@ snapshots:
     transitivePeerDependencies:
       - less
       - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vitest@2.1.1(@types/node@22.4.1)(jsdom@24.1.1)(msw@2.3.5(typescript@5.5.4))(terser@5.31.6):
+    dependencies:
+      '@vitest/expect': 2.1.1
+      '@vitest/mocker': 2.1.1(@vitest/spy@2.1.1)(msw@2.3.5(typescript@5.5.4))(vite@5.4.0(@types/node@22.4.1)(terser@5.31.6))
+      '@vitest/pretty-format': 2.1.1
+      '@vitest/runner': 2.1.1
+      '@vitest/snapshot': 2.1.1
+      '@vitest/spy': 2.1.1
+      '@vitest/utils': 2.1.1
+      chai: 5.1.1
+      debug: 4.3.6
+      magic-string: 0.30.11
+      pathe: 1.1.2
+      std-env: 3.7.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.0
+      tinypool: 1.0.0
+      tinyrainbow: 1.2.0
+      vite: 5.4.0(@types/node@22.4.1)(terser@5.31.6)
+      vite-node: 2.1.1(@types/node@22.4.1)(terser@5.31.6)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.4.1
+      jsdom: 24.1.1
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
       - sass
       - sass-embedded
       - stylus

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -252,8 +252,8 @@ importers:
   packages/pglite-sync:
     dependencies:
       '@electric-sql/client':
-        specifier: ^0.5.1
-        version: 0.5.1
+        specifier: ^0.6.0
+        version: 0.6.0
     devDependencies:
       '@electric-sql/pglite':
         specifier: workspace:*
@@ -630,8 +630,8 @@ packages:
       search-insights:
         optional: true
 
-  '@electric-sql/client@0.5.1':
-    resolution: {integrity: sha512-7SBuZGVYxhdi8mOUN5SwP4lXXfEw/1E/MdPrLyOIjnrfG4AGftMNfCTWBQwHhErAVxKf34mqoAIkCpuIVL3jVA==}
+  '@electric-sql/client@0.6.0':
+    resolution: {integrity: sha512-azAnhA6MlYnlammL6GIZKiD5AYgk6/Il4HTHYfk8WUDMoLWeqit35Pm95WnzJ6suFkAyeLhCFM2LaaBzPBBIIQ==}
 
   '@embedded-postgres/darwin-arm64@15.5.1-beta.11':
     resolution: {integrity: sha512-5m96qe7TFR/wzL05fyl1TRKfm+I73gIdDea+vXh60MQzUUfX9FXSiR8id6TI4aRhomUrd/l8hLTq8E2ymTCIFw==}
@@ -5095,7 +5095,7 @@ snapshots:
     transitivePeerDependencies:
       - '@algolia/client-search'
 
-  '@electric-sql/client@0.5.1':
+  '@electric-sql/client@0.6.0':
     optionalDependencies:
       '@rollup/rollup-darwin-arm64': 4.20.0
 


### PR DESCRIPTION
Creates a meta table for storing shape subscription information - uses a provided `shapeKey` to determine whether it should persist things and how to index the persisted shapes.

I started by automatically persisting based on things like the shape definition and the table it syncs into, but like @samwillis  probably had already figured out there's complexities in mapping the shape etc that makes it hard to automatically infer how to persist it.

I propose keeping the option undocumented until we get reference counting as well, but for now adding a `shapeKey` would persist the shape and reset the table naively when needing to refetch.