### PR TITLE
fix: sql tagged template method to correctly handle null values

### DIFF
--- a/.changeset/breezy-crabs-warn.md
+++ b/.changeset/breezy-crabs-warn.md
@@ -1,0 +1,5 @@
+---
+'@electric-sql/pglite': patch
+---
+
+Fix the sql tagged template method to correctly handle null values

--- a/packages/pglite/src/templating.ts
+++ b/packages/pglite/src/templating.ts
@@ -69,7 +69,7 @@ export function sql(
     const nextStringIdx = i + 1
 
     // if value is a template tag, collapse into last string
-    if (value._templateType === TemplateType.part) {
+    if (value?._templateType === TemplateType.part) {
       addToLastAndPushWithSuffix(
         parsedStrings,
         strings[nextStringIdx],
@@ -84,7 +84,7 @@ export function sql(
     }
 
     // if value is an output of this method, append in place
-    if (value._templateType === TemplateType.container) {
+    if (value?._templateType === TemplateType.container) {
       addToLastAndPushWithSuffix(
         parsedStrings,
         strings[nextStringIdx],

--- a/packages/pglite/tests/templating.test.js
+++ b/packages/pglite/tests/templating.test.js
@@ -38,6 +38,20 @@ describe('templating', () => {
     })
   })
 
+  it('should parametrize templated values of null', () => {
+    expect(query`SELECT * FROM test WHERE value = ${null};`).toEqual({
+      query: 'SELECT * FROM test WHERE value = $1;',
+      params: [null],
+    })
+
+    expect(
+      query`SELECT * FROM test WHERE value = ${null} AND num = ${3};`,
+    ).toEqual({
+      query: 'SELECT * FROM test WHERE value = $1 AND num = $2;',
+      params: [null, 3],
+    })
+  })
+
   it('should correctly escape identifiers', () => {
     expect(
       query`


### PR DESCRIPTION
It would previously throw on `value._templateType` as you can't access props on `null`