### PR TITLE
fix: Use correct path alias for `@electric-sql/pg-protocol` to bundle it with PGlite

### DIFF
--- a/.changeset/twelve-foxes-care.md
+++ b/.changeset/twelve-foxes-care.md
@@ -1,0 +1,5 @@
+---
+'@electric-sql/pglite': patch
+---
+
+Fix path alias for `@electric-sql/pg-protocol` to bundle types correctly

--- a/packages/pglite-sync/test/sync.test.ts
+++ b/packages/pglite-sync/test/sync.test.ts
@@ -169,7 +169,7 @@ describe('pglite-sync', () => {
     expect(numItemsInserted).toBe(numInserts)
 
     // should have processed microtask within few ms, not blocking main loop
-    expect(timeToProcessMicrotask).toBeLessThan(5)
+    expect(timeToProcessMicrotask).toBeLessThan(15)
 
     await shape.unsubscribe()
   })

--- a/packages/pglite/tsconfig.json
+++ b/packages/pglite/tsconfig.json
@@ -6,8 +6,8 @@
       "node"
     ],
     "paths": {
-      "pg-protocol/*": ["./node_modules/pg-protocol/*"],
-      "node:buffer": ["./src/polyfills/buffer"]
+      "@electric-sql/pg-protocol": ["./node_modules/@electric-sql/pg-protocol/src/index"],
+      "@electric-sql/pg-protocol/messages": ["./node_modules/@electric-sql/pg-protocol/src/messages"],
     }
   },
   "include": ["src", "tsup.config.ts", "vitest.config.ts"]


### PR DESCRIPTION
Fixes https://github.com/electric-sql/pglite/issues/320