### PR TITLE
fix: Fix refetch clearing aggregation

### DIFF
--- a/.changeset/purple-sheep-whisper.md
+++ b/.changeset/purple-sheep-whisper.md
@@ -1,0 +1,5 @@
+---
+'@electric-sql/pglite-sync': patch
+---
+
+Clear uncommitted aggregated messages upon receiving `must-refetch` message

--- a/packages/pglite-sync/src/index.ts
+++ b/packages/pglite-sync/src/index.ts
@@ -106,6 +106,8 @@ async function createPlugin(
             case 'must-refetch':
               if (debug) console.log('refetching shape')
               truncateNeeded = true
+              messageAggregator = []
+
               break
 
             // perform all accumulated changes and store stream state

--- a/packages/pglite-sync/test/sync.test.ts
+++ b/packages/pglite-sync/test/sync.test.ts
@@ -301,7 +301,18 @@ describe('pglite-sync', () => {
     })
 
     // feed a must-refetch message that should clear the table
+    // and any aggregated messages
     await feedMessages([
+      {
+        headers: { operation: 'insert' },
+        offset: `1_${numInserts}`,
+        key: `id${numInserts}`,
+        value: {
+          id: numInserts,
+          task: `task`,
+          done: false,
+        },
+      },
       { headers: { control: 'must-refetch' } },
       {
         headers: { operation: 'insert' },


### PR DESCRIPTION
Refetch message would not clear in memory aggregated changes, and thus would still commit them afterwards