### PR TITLE
fix: add `fs/promises: false` to the browser config in package.json to exclude it from browser builds

### DIFF
--- a/.changeset/funny-candles-warn.md
+++ b/.changeset/funny-candles-warn.md
@@ -1,0 +1,5 @@
+---
+'@electric-sql/pglite': patch
+---
+
+Add `fs/promises: false` to the browser config in package.json to exclude it from browser builds.

--- a/packages/pglite/package.json
+++ b/packages/pglite/package.json
@@ -106,6 +106,7 @@
   },
   "browser": {
     "fs": false,
+    "fs/promises": false,
     "path": false,
     "url": false,
     "zlib": false,


### PR DESCRIPTION
Should fix #355

Regression was introduced here https://github.com/electric-sql/pglite/commit/2831c3401ae146702106c64a8bb25f2bbcfd8b14 with the use of `const fs = await import('fs/promises')`