### PR TITLE
Add `util` to package.json browser config to exclude it in browser builds

### DIFF
--- a/.changeset/cyan-dolls-double.md
+++ b/.changeset/cyan-dolls-double.md
@@ -1,0 +1,5 @@
+---
+'@electric-sql/pglite': patch
+---
+
+add `util` to package.json browser config to exclude it in browser builds

--- a/packages/pglite/package.json
+++ b/packages/pglite/package.json
@@ -115,6 +115,7 @@
     "crypto": false,
     "ws": false,
     "child_process": false,
-    "module": false
+    "module": false,
+    "util": false
   }
 }


### PR DESCRIPTION
Currently esbuild errors when targeting browser:

```
✘ [ERROR] Could not resolve "util"

    node_modules/.pnpm/@electric-sql+pglite@0.2.11/node_modules/@electric-sql/pglite/dist/chunk-SJVDOE3S.js:1:11418:
      1 │ ...r(r){let{promisify:e}=await import("util"),{gzip:t}=await import("zlib");ret...
        ╵                                       ~~~~~~

  The package "util" wasn't found on the file system but is built into node. Are you trying
  to bundle for node? You can use "platform: 'node'" to do that, which will remove this
  error.
```

This PR adds `util` to package.json browser configuration alongside existing node modules.