### PR TITLE
fix(pglite-sync): Filter out update messages that don't modify any columns

### DIFF
--- a/.changeset/big-wasps-thank.md
+++ b/.changeset/big-wasps-thank.md
@@ -1,0 +1,5 @@
+---
+'@electric-sql/pglite-sync': patch
+---
+
+Filter out update messages that don't modify any columns

--- a/packages/pglite-sync/src/index.ts
+++ b/packages/pglite-sync/src/index.ts
@@ -284,6 +284,7 @@ async function applyMessageToTable({
         // we don't update the primary key, they are used to identify the row
         (column) => !primaryKey.includes(column),
       )
+      if (columns.length === 0) return // nothing to update
       return await pg.query(
         `
             UPDATE "${schema}"."${table}"


### PR DESCRIPTION
Electric can emit updates with no columns to change, this resulted in invalid SQL in a query that would be redundant. This change skips those messages.