### PR TITLE
fix(pglite/live): Fix querying views, and extend the return value to allow late attachment of a callback

### DIFF
--- a/.changeset/chilled-tomatoes-whisper.md
+++ b/.changeset/chilled-tomatoes-whisper.md
@@ -1,0 +1,5 @@
+---
+'@electric-sql/pglite': patch
+---
+
+Fix live queries can query a view by recursively finding all tables they depend on.

--- a/.changeset/smooth-badgers-move.md
+++ b/.changeset/smooth-badgers-move.md
@@ -1,0 +1,5 @@
+---
+'@electric-sql/pglite': patch
+---
+
+Extend the return value of live queries to be subscribed to multiple times, and make the callback optional on initiation.

--- a/packages/pglite/src/live/interface.ts
+++ b/packages/pglite/src/live/interface.ts
@@ -1,5 +1,28 @@
 import type { Results } from '../interface'
 
+export interface LiveQueryOptions<T = { [key: string]: any }> {
+  query: string
+  params?: any[] | null
+  callback?: (results: Results<T>) => void
+  signal?: AbortSignal
+}
+
+export interface LiveChangesOptions<T = { [key: string]: any }> {
+  query: string
+  params?: any[] | null
+  key: string
+  callback?: (changes: Array<Change<T>>) => void
+  signal?: AbortSignal
+}
+
+export interface LiveIncrementalQueryOptions<T = { [key: string]: any }> {
+  query: string
+  params?: any[] | null
+  key: string
+  callback?: (results: Results<T>) => void
+  signal?: AbortSignal
+}
+
 export interface LiveNamespace {
   /**
    * Create a live query
@@ -11,9 +34,19 @@ export interface LiveNamespace {
    */
   query<T = { [key: string]: any }>(
     query: string,
-    params: any[] | undefined | null,
-    callback: (results: Results<T>) => void,
-  ): Promise<LiveQueryReturn<T>>
+    params?: any[] | null,
+    callback?: (results: Results<T>) => void,
+  ): Promise<LiveQuery<T>>
+
+  /**
+   * Create a live query
+   * @param options - The options to pass to the query
+   * @returns A promise that resolves to an object with the initial results,
+   * an unsubscribe function, and a refresh function
+   */
+  query<T = { [key: string]: any }>(
+    options: LiveQueryOptions<T>,
+  ): Promise<LiveQuery<T>>
 
   /**
    * Create a live query that returns the changes to the query results
@@ -28,7 +61,17 @@ export interface LiveNamespace {
     params: any[] | undefined | null,
     key: string,
     callback: (changes: Array<Change<T>>) => void,
-  ): Promise<LiveChangesReturn<T>>
+  ): Promise<LiveChanges<T>>
+
+  /**
+   * Create a live query that returns the changes to the query results
+   * @param options - The options to pass to the query
+   * @returns A promise that resolves to an object with the initial changes,
+   * an unsubscribe function, and a refresh function
+   */
+  changes<T = { [key: string]: any }>(
+    options: LiveChangesOptions<T>,
+  ): Promise<LiveChanges<T>>
 
   /**
    * Create a live query with incremental updates
@@ -43,19 +86,31 @@ export interface LiveNamespace {
     params: any[] | undefined | null,
     key: string,
     callback: (results: Results<T>) => void,
-  ): Promise<LiveQueryReturn<T>>
+  ): Promise<LiveQuery<T>>
+
+  /**
+   * Create a live query with incremental updates
+   * @param options - The options to pass to the query
+   * @returns A promise that resolves to an object with the initial results,
+   * an unsubscribe function, and a refresh function
+   */
+  incrementalQuery<T = { [key: string]: any }>(
+    options: LiveIncrementalQueryOptions<T>,
+  ): Promise<LiveQuery<T>>
 }
 
-export interface LiveQueryReturn<T> {
+export interface LiveQuery<T> {
   initialResults: Results<T>
-  unsubscribe: () => Promise<void>
+  subscribe: (callback: (results: Results<T>) => void) => void
+  unsubscribe: (callback?: (results: Results<T>) => void) => Promise<void>
   refresh: () => Promise<void>
 }
 
-export interface LiveChangesReturn<T = { [key: string]: any }> {
+export interface LiveChanges<T = { [key: string]: any }> {
   fields: { name: string; dataTypeID: number }[]
   initialChanges: Array<Change<T>>
-  unsubscribe: () => Promise<void>
+  subscribe: (callback: (changes: Array<Change<T>>) => void) => void
+  unsubscribe: (callback?: (changes: Array<Change<T>>) => void) => Promise<void>
   refresh: () => Promise<void>
 }
 

--- a/packages/pglite/src/live/interface.ts
+++ b/packages/pglite/src/live/interface.ts
@@ -60,7 +60,7 @@ export interface LiveNamespace {
     query: string,
     params: any[] | undefined | null,
     key: string,
-    callback: (changes: Array<Change<T>>) => void,
+    callback?: (changes: Array<Change<T>>) => void,
   ): Promise<LiveChanges<T>>
 
   /**
@@ -85,7 +85,7 @@ export interface LiveNamespace {
     query: string,
     params: any[] | undefined | null,
     key: string,
-    callback: (results: Results<T>) => void,
+    callback?: (results: Results<T>) => void,
   ): Promise<LiveQuery<T>>
 
   /**


### PR DESCRIPTION
This fixes live queries when they are querying a view rather than a table. It now recursively introspects the dependencies of the query to find all tables it depends on.

It also extends the live query return values to allow subscribing with a callback after creating the live query. This enables crating a live query in a React router loader, then passing it to a view to use with `useLiveQuery`.

See also #375