### PR TITLE
fix: string passed as param expecting JSON should be treated as string encoded JSON

### DIFF
--- a/.changeset/sharp-wolves-protect.md
+++ b/.changeset/sharp-wolves-protect.md
@@ -1,0 +1,5 @@
+---
+'@electric-sql/pglite': patch
+---
+
+Fix issue where a string passed as a parameter expecting JSON would not treat the string as a json encoded string

--- a/packages/pglite/examples/basic.html
+++ b/packages/pglite/examples/basic.html
@@ -17,67 +17,37 @@
 <div class="script-plus-log">
 <script type="module">
 import { PGlite } from "@electric-sql/pglite";
-// import { PGlite } from "https://cdn.jsdelivr.net/npm/@electric-sql/pglite@0.2.8/dist/index.js";
 
 console.log("Starting...");
 
 // In-memory database:
-const pg = await PGlite.create();
+const pg = new PGlite();
 // Or, stored in indexedDB:
 // const pg = new PGlite('pgdata');
 
-// Create a table with JSON and JSONB columns
-await pg.query(`
-  CREATE TABLE json_test (
+console.log("Ready!");
+
+console.log("Creating table...");
+await pg.exec(`
+  CREATE TABLE IF NOT EXISTS test (
     id SERIAL PRIMARY KEY,
-    json_data JSON,
-    jsonb_data JSONB
+    name TEXT
   );
 `);
 
-// Insert a row with JSON object
-const jsonObject = { text: "Hello", number: 42 };
-await pg.query(`
-  INSERT INTO json_test (json_data, jsonb_data)
-  VALUES ($1, $2);
-`, [JSON.stringify(jsonObject), JSON.stringify(jsonObject)]);
+console.log("Inserting data...");
 
-// Query and extract values using the -> operator
-const result = await pg.query(`
-  SELECT 
-    json_data->'text' AS json_text,
-    json_data->'number' AS json_number,
-    jsonb_data->'text' AS jsonb_text,
-    jsonb_data->'number' AS jsonb_number
-  FROM json_test;
+await pg.exec("INSERT INTO test (name) VALUES ('test');");
+
+console.log("Selecting data...");
+
+const res = await pg.exec(`
+  SELECT * FROM test;
 `);
 
-console.log("Extracted values:");
-console.log("JSON text:", result.rows[0].json_text);
-console.log("JSON number:", result.rows[0].json_number);
-console.log("JSONB text:", result.rows[0].jsonb_text);
-console.log("JSONB number:", result.rows[0].jsonb_number);
+console.log(res);
 
-// console.log(await pg.query("SELECT * FROM json_test;"));
-
-// const result2 = await pg.query(`
-//   SELECT
-//     '{"text": "Hello", "number": 42}'::json AS json,
-//     '{"text": "Hello", "number": 42}'::jsonb AS jsonb,
-//     '{"text": "Hello", "number": 42}'::json -> 'text' AS json_text,
-//     '{"text": "Hello", "number": 42}'::jsonb -> 'text' AS jsonb_text,
-//     '{"text": "Hello", "number": 42}'::json -> 'number' AS json_number,
-//     '{"text": "Hello", "number": 42}'::jsonb -> 'number' AS jsonb_number
-// `);
-
-// console.log("Extracted values 2:");
-// console.log("JSON:", result2.rows[0].json);
-// console.log("JSONB:", result2.rows[0].jsonb);
-// console.log("JSON text:", result2.rows[0].json_text);
-// console.log("JSON number:", result2.rows[0].json_number);
-// console.log("JSONB text:", result2.rows[0].jsonb_text);
-// console.log("JSONB number:", result2.rows[0].jsonb_number);
-
+console.log(await pg.exec("SELECT * FROM test;"));
 </script>
 <div id="log"></div>
 </div>

--- a/packages/pglite/examples/basic.html
+++ b/packages/pglite/examples/basic.html
@@ -17,37 +17,67 @@
 <div class="script-plus-log">
 <script type="module">
 import { PGlite } from "@electric-sql/pglite";
+// import { PGlite } from "https://cdn.jsdelivr.net/npm/@electric-sql/pglite@0.2.8/dist/index.js";
 
 console.log("Starting...");
 
 // In-memory database:
-const pg = new PGlite();
+const pg = await PGlite.create();
 // Or, stored in indexedDB:
 // const pg = new PGlite('pgdata');
 
-console.log("Ready!");
-
-console.log("Creating table...");
-await pg.exec(`
-  CREATE TABLE IF NOT EXISTS test (
+// Create a table with JSON and JSONB columns
+await pg.query(`
+  CREATE TABLE json_test (
     id SERIAL PRIMARY KEY,
-    name TEXT
+    json_data JSON,
+    jsonb_data JSONB
   );
 `);
 
-console.log("Inserting data...");
+// Insert a row with JSON object
+const jsonObject = { text: "Hello", number: 42 };
+await pg.query(`
+  INSERT INTO json_test (json_data, jsonb_data)
+  VALUES ($1, $2);
+`, [JSON.stringify(jsonObject), JSON.stringify(jsonObject)]);
 
-await pg.exec("INSERT INTO test (name) VALUES ('test');");
-
-console.log("Selecting data...");
-
-const res = await pg.exec(`
-  SELECT * FROM test;
+// Query and extract values using the -> operator
+const result = await pg.query(`
+  SELECT 
+    json_data->'text' AS json_text,
+    json_data->'number' AS json_number,
+    jsonb_data->'text' AS jsonb_text,
+    jsonb_data->'number' AS jsonb_number
+  FROM json_test;
 `);
 
-console.log(res);
+console.log("Extracted values:");
+console.log("JSON text:", result.rows[0].json_text);
+console.log("JSON number:", result.rows[0].json_number);
+console.log("JSONB text:", result.rows[0].jsonb_text);
+console.log("JSONB number:", result.rows[0].jsonb_number);
 
-console.log(await pg.exec("SELECT * FROM test;"));
+// console.log(await pg.query("SELECT * FROM json_test;"));
+
+// const result2 = await pg.query(`
+//   SELECT
+//     '{"text": "Hello", "number": 42}'::json AS json,
+//     '{"text": "Hello", "number": 42}'::jsonb AS jsonb,
+//     '{"text": "Hello", "number": 42}'::json -> 'text' AS json_text,
+//     '{"text": "Hello", "number": 42}'::jsonb -> 'text' AS jsonb_text,
+//     '{"text": "Hello", "number": 42}'::json -> 'number' AS json_number,
+//     '{"text": "Hello", "number": 42}'::jsonb -> 'number' AS jsonb_number
+// `);
+
+// console.log("Extracted values 2:");
+// console.log("JSON:", result2.rows[0].json);
+// console.log("JSONB:", result2.rows[0].jsonb);
+// console.log("JSON text:", result2.rows[0].json_text);
+// console.log("JSON number:", result2.rows[0].json_number);
+// console.log("JSONB text:", result2.rows[0].jsonb_text);
+// console.log("JSONB number:", result2.rows[0].jsonb_number);
+
 </script>
 <div id="log"></div>
 </div>

--- a/packages/pglite/src/types.ts
+++ b/packages/pglite/src/types.ts
@@ -108,7 +108,13 @@ export const types = {
   json: {
     to: JSON,
     from: [JSON, JSONB],
-    serialize: (x: any) => JSON_stringify(x),
+    serialize: (x: any) => {
+      if (typeof x === 'string') {
+        return x
+      } else {
+        return JSON_stringify(x)
+      }
+    },
     parse: (x: string) => JSON_parse(x),
   },
   boolean: {

--- a/packages/pglite/tests/types.test.ts
+++ b/packages/pglite/tests/types.test.ts
@@ -132,6 +132,12 @@ describe('serialize', () => {
     expect(types.serializers[114]({ test: 1 })).toEqual('{"test":1}')
   })
 
+  it('json from string', () => {
+    expect(types.serializers[114](JSON.stringify({ test: 1 }))).toEqual(
+      '{"test":1}',
+    )
+  })
+
   it('blob', () => {
     expect(types.serializers[17](Uint8Array.from([1, 2, 3]))).toEqual(
       '\\x010203',


### PR DESCRIPTION
We changed how we chose the method to encode parameters from being inferred from the JS type, to using the Postgres "Describe" wire protocol message to ask what types Postgres is expecting for each parameter. This is how postgres.js does it, rather than node-postgres.

What this meant was that if you manually ran JSON.stringify on a JS object and passed it as a parameter to PGlite it was inserted into the JSON(B) column as a JSON string (think stringifying twice)  not a JSON object. If you then tried to extract vales from it, they would be null.

This is obv not the expected behavour, a user would want to be able to pass a string thats already JSON encoded to as a param.
