### PR TITLE
feat: add custom parser and serializer to PGlite options

### DIFF
--- a/.changeset/violet-peas-check.md
+++ b/.changeset/violet-peas-check.md
@@ -1,0 +1,5 @@
+---
+'@electric-sql/pglite': patch
+---
+
+Added custom parser and serializer options to `PGliteOptions`. Added custom serializer option to `QueryOptions`.

--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -62,6 +62,28 @@ Path to the directory for storing the Postgres database. You can provide a URI s
   A precompiled WASM module to use instead of downloading the default version, or when using a bundler that either can, or requires, loading the WASM module with a ESM import.
 - `fsBundle?: Blob | File`<br />
   A filesystem bundle to use instead of downloading the default version. This is useful if in a restricted environment such as an edge worker.
+- `parsers: ParserOptions` <br />
+  An object of type `{ [pgType: number]: (value: string) => any; }` mapping Postgres data type IDs to parser functions. For convenience, the `pglite` package exports a constant for most common Postgres types.
+  ```ts
+  import { PGlite, types } from '@electric-sql/pglite'
+
+  const pg = await PGlite.create({
+    parsers: {
+      [types.TEXT]: (value) => value.toUpperCase(),
+    },
+  })
+  ```
+- `serializers: SerializerOptions` <br />
+  An object of type `{ [pgType: number]: (value: any) => string; }` mapping Postgres data type IDs to serializer functions.
+  ```ts
+  import { PGlite, types } from '@electric-sql/pglite'
+
+  const pg = await PGlite.create({
+    serializers: {
+      [types.NUMERIC]: (value) => value.toString(),
+    },
+  })
+  ```
 
 #### `options.extensions`
 
@@ -114,25 +136,33 @@ The `query` and `exec` methods take an optional `options` objects with the follo
 - `rowMode: "object" | "array"` <br />
   The returned row object type, either an object of `fieldName: value` mappings or an array of positional values. Defaults to `"object"`.
 - `parsers: ParserOptions` <br />
-  An object of type `{[[pgType: number]: (value: string) => any;]}` mapping Postgres data type IDs to parser functions.  
-  For convenience, the `pglite` package exports a constant for most common Postgres types:
-
+  An object mapping Postgres data type IDs to parser functions. This option overrides any parsers set at the instance level.
   ```ts
   import { types } from '@electric-sql/pglite'
   await pg.query(
-    `
-    SELECT * FROM test WHERE name = $1;
-  `,
+    `SELECT * FROM test WHERE name = $1;`,
     ['test'],
     {
-      rowMode: 'array',
       parsers: {
         [types.TEXT]: (value) => value.toUpperCase(),
       },
     },
   )
   ```
-
+- `serializers: SerializerOptions` <br />
+  An object mapping Postgres data type IDs to serializer functions. This option overrides any serializers set at the instance level.
+  ```ts
+  import { types } from '@electric-sql/pglite'
+  await pg.query(
+    `INSERT INTO test (numeric) VALUES ($1);`,
+    [100n],
+    {
+      serializers: {
+        [types.NUMERIC]: (value: number | bigint) => value.toString(),
+      },
+    },
+  )
+  ```
 - `blob: Blob | File` <br />
   Attach a `Blob` or `File` object to the query that can used with a `COPY FROM` command by using the virtual `/dev/blob` device, see [importing and exporting](#dev-blob).
 

--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -64,6 +64,7 @@ Path to the directory for storing the Postgres database. You can provide a URI s
   A filesystem bundle to use instead of downloading the default version. This is useful if in a restricted environment such as an edge worker.
 - `parsers: ParserOptions` <br />
   An object of type `{ [pgType: number]: (value: string) => any; }` mapping Postgres data type IDs to parser functions. For convenience, the `pglite` package exports a constant for most common Postgres types.
+
   ```ts
   import { PGlite, types } from '@electric-sql/pglite'
 
@@ -73,8 +74,10 @@ Path to the directory for storing the Postgres database. You can provide a URI s
     },
   })
   ```
+
 - `serializers: SerializerOptions` <br />
   An object of type `{ [pgType: number]: (value: any) => string; }` mapping Postgres data type IDs to serializer functions.
+
   ```ts
   import { PGlite, types } from '@electric-sql/pglite'
 
@@ -139,29 +142,21 @@ The `query` and `exec` methods take an optional `options` objects with the follo
   An object mapping Postgres data type IDs to parser functions. This option overrides any parsers set at the instance level.
   ```ts
   import { types } from '@electric-sql/pglite'
-  await pg.query(
-    `SELECT * FROM test WHERE name = $1;`,
-    ['test'],
-    {
-      parsers: {
-        [types.TEXT]: (value) => value.toUpperCase(),
-      },
+  await pg.query(`SELECT * FROM test WHERE name = $1;`, ['test'], {
+    parsers: {
+      [types.TEXT]: (value) => value.toUpperCase(),
     },
-  )
+  })
   ```
 - `serializers: SerializerOptions` <br />
   An object mapping Postgres data type IDs to serializer functions. This option overrides any serializers set at the instance level.
   ```ts
   import { types } from '@electric-sql/pglite'
-  await pg.query(
-    `INSERT INTO test (numeric) VALUES ($1);`,
-    [100n],
-    {
-      serializers: {
-        [types.NUMERIC]: (value: number | bigint) => value.toString(),
-      },
+  await pg.query(`INSERT INTO test (numeric) VALUES ($1);`, [100n], {
+    serializers: {
+      [types.NUMERIC]: (value: number | bigint) => value.toString(),
     },
-  )
+  })
   ```
 - `blob: Blob | File` <br />
   Attach a `Blob` or `File` object to the query that can used with a `COPY FROM` command by using the virtual `/dev/blob` device, see [importing and exporting](#dev-blob).

--- a/packages/pglite/src/base.ts
+++ b/packages/pglite/src/base.ts
@@ -226,7 +226,7 @@ export abstract class BasePGlite
           if (param === null || param === undefined) {
             return null
           }
-          const serialize = this.serializers[oid]
+          const serialize = options?.serializers?.[oid] ?? this.serializers[oid]
           if (serialize) {
             return serialize(param)
           } else {

--- a/packages/pglite/src/interface.ts
+++ b/packages/pglite/src/interface.ts
@@ -15,9 +15,14 @@ export interface ParserOptions {
   [pgType: number]: (value: string) => any
 }
 
+export interface SerializerOptions {
+  [pgType: number]: (value: any) => string
+}
+
 export interface QueryOptions {
   rowMode?: RowMode
   parsers?: ParserOptions
+  serializers?: SerializerOptions
   blob?: Blob | File
   onNotice?: (notice: NoticeMessage) => void
   paramTypes?: number[]
@@ -75,6 +80,8 @@ export interface PGliteOptions {
   initialMemory?: number
   wasmModule?: WebAssembly.Module
   fsBundle?: Blob | File
+  parsers?: ParserOptions
+  serializers?: SerializerOptions
 }
 
 export type PGliteInterface = {

--- a/packages/pglite/src/pglite.ts
+++ b/packages/pglite/src/pglite.ts
@@ -93,6 +93,14 @@ export class PGlite
     }
     this.dataDir = options.dataDir
 
+    // Override default parsers and serializers if requested
+    if (options.parsers !== undefined) {
+      this.parsers = { ...this.parsers, ...options.parsers }
+    }
+    if (options.serializers !== undefined) {
+      this.serializers = { ...this.serializers, ...options.serializers }
+    }
+
     // Enable debug logging if requested
     if (options?.debug !== undefined) {
       this.debug = options.debug

--- a/packages/pglite/tests/basic.test.js
+++ b/packages/pglite/tests/basic.test.js
@@ -271,6 +271,44 @@ await testEsmAndCjs(async (importType) => {
       )
     })
 
+    it('custom parser and serializer', async () => {
+      const db = new PGlite({
+        serializers: { 1700: (x) => x.toString() },
+        parsers: { 1700: (x) => BigInt(x) },
+      })
+      await db.query(`
+        CREATE TABLE IF NOT EXISTS test (
+          id SERIAL PRIMARY KEY,
+          numeric NUMERIC
+        );
+      `)
+      await db.query('INSERT INTO test (numeric) VALUES ($1);', [100n])
+      const res = await db.query(`
+        SELECT * FROM test;
+      `)
+
+      expect(res).toEqual({
+        rows: [
+          {
+            id: 1,
+            numeric: 100n,
+          },
+        ],
+        fields: [
+          {
+            name: 'id',
+            dataTypeID: 23,
+          },
+          {
+            name: 'numeric',
+            dataTypeID: 1700,
+          },
+        ],
+        affectedRows: 0,
+      })
+    })
+
+
     it('params', async () => {
       const db = new PGlite()
       await db.query(`

--- a/packages/pglite/tests/basic.test.js
+++ b/packages/pglite/tests/basic.test.js
@@ -308,7 +308,6 @@ await testEsmAndCjs(async (importType) => {
       })
     })
 
-
     it('params', async () => {
       const db = new PGlite()
       await db.query(`


### PR DESCRIPTION
This PR adds support for custom serializers to `QueryOptions`, and adds support for custom parsers and serializers to `PGliteOptions`. The change is non-breaking.

Our use case is using NUMERIC columns to store integers too large for BIGINT. We'd like these values to use the JS native BigInt rather than String, and it's easiest if this happens at the driver layer.

```ts
import { NUMERIC, PGlite, type PGliteOptions } from "@electric-sql/pglite";

export function createPglite(options: PGliteOptions) {
  return new PGlite({
    serializers: { [NUMERIC]: (x: string | number | bigint) => x.toString() },
    parsers: { [NUMERIC]: (x: string) => BigInt(x) },
    ...options,
  });
}
```

Verified locally in an integration test with our framework.