### PR TITLE
feat: Add a describeQuery method

### DIFF
--- a/.changeset/dull-items-greet.md
+++ b/.changeset/dull-items-greet.md
@@ -1,0 +1,5 @@
+---
+'@electric-sql/pglite': patch
+---
+
+Add a new `describeQuery` method to get type information about a query's parameters and result fields without executing it.

--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -304,6 +304,32 @@ transactions, and notification listeners. Only use if you need to bypass these w
 
 :::
 
+### describeQuery
+
+`.describeQuery(query: string, options?: QueryOptions): Promise<DescribeQueryResult>`
+
+Get type information about a query's parameters and result fields without executing it. This is useful for understanding the expected parameter types and the structure of the results that would be returned. It can be used to build a type inference system for queries using PGlite.
+
+Returns an object with:
+
+- `queryParams: Array<{ dataTypeID: number, serializer: Function }>` <br/>
+  Information about each parameter's Postgres type ID and the serializer function used to convert JavaScript values to Postgres format.
+
+- `resultFields: Array<{ name: string, dataTypeID: number, parser: Function }>` <br/>
+  Information about each result field including its name, Postgres type ID, and the parser function used to convert Postgres values to JavaScript format.
+
+##### Example
+
+```ts
+await pg.describeQuery('SELECT * FROM test WHERE name = $1', ['test'])
+
+// returns:
+{
+  queryParams: [{ dataTypeID: 25, serializer: Function }],
+  resultFields: [{ name: "id", dataTypeID: 23, parser: Function }],
+}
+```
+
 ## Properties
 
 ### ready

--- a/packages/pglite/examples/basic.html
+++ b/packages/pglite/examples/basic.html
@@ -47,9 +47,7 @@ const res = await pg.exec(`
 
 console.log(res);
 
-console.log(await pg.query("SELECT * FROM test WHERE id >= $1;", [1]));
-
-console.log(await pg.describeQuery("SELECT * FROM test WHERE id >= $1;"));
+console.log(await pg.exec("SELECT * FROM test;"));
 </script>
 <div id="log"></div>
 </div>

--- a/packages/pglite/examples/basic.html
+++ b/packages/pglite/examples/basic.html
@@ -47,7 +47,9 @@ const res = await pg.exec(`
 
 console.log(res);
 
-console.log(await pg.exec("SELECT * FROM test;"));
+console.log(await pg.query("SELECT * FROM test WHERE id >= $1;", [1]));
+
+console.log(await pg.describeQuery("SELECT * FROM test WHERE id >= $1;"));
 </script>
 <div id="log"></div>
 </div>

--- a/packages/pglite/src/base.ts
+++ b/packages/pglite/src/base.ts
@@ -16,9 +16,14 @@ import type {
   QueryOptions,
   ExecProtocolOptions,
   ExecProtocolResult,
+  DescribeQueryResult,
 } from './interface.js'
 
 import { serialize as serializeProtocol } from '@electric-sql/pg-protocol'
+import {
+  RowDescriptionMessage,
+  ParameterDescriptionMessage,
+} from '@electric-sql/pg-protocol/messages'
 
 export abstract class BasePGlite
   implements Pick<PGliteInterface, 'query' | 'sql' | 'exec' | 'transaction'>
@@ -308,6 +313,52 @@ export abstract class BasePGlite
         blob,
       ) as Array<Results>
     })
+  }
+
+  /**
+   * Describe a query
+   * @param query The query to describe
+   * @returns A description of the result types for the query
+   */
+  async describeQuery(
+    query: string,
+    options?: QueryOptions,
+  ): Promise<DescribeQueryResult> {
+    try {
+      await this.#execProtocolNoSync(
+        serializeProtocol.parse({ text: query, types: options?.paramTypes }),
+        options,
+      )
+
+      const describeResults = await this.#execProtocolNoSync(
+        serializeProtocol.describe({ type: 'S' }),
+        options,
+      )
+      const paramDescription = describeResults.messages.find(
+        (msg): msg is ParameterDescriptionMessage =>
+          msg.name === 'parameterDescription',
+      )
+      const resultDescription = describeResults.messages.find(
+        (msg): msg is RowDescriptionMessage => msg.name === 'rowDescription',
+      )
+
+      const queryParams =
+        paramDescription?.dataTypeIDs.map((dataTypeID) => ({
+          dataTypeID,
+          serializer: this.serializers[dataTypeID],
+        })) ?? []
+
+      const resultFields =
+        resultDescription?.fields.map((field) => ({
+          name: field.name,
+          dataTypeID: field.dataTypeID,
+          parser: this.parsers[field.dataTypeID],
+        })) ?? []
+
+      return { queryParams, resultFields }
+    } finally {
+      await this.#execProtocolNoSync(serializeProtocol.sync(), options)
+    }
   }
 
   /**

--- a/packages/pglite/src/interface.ts
+++ b/packages/pglite/src/interface.ts
@@ -4,6 +4,7 @@ import type {
 } from '@electric-sql/pg-protocol/messages'
 import type { Filesystem } from './fs/base.js'
 import type { DumpTarCompressionOptions } from './fs/tarUtils.js'
+import type { Parser, Serializer } from './types.js'
 
 export type FilesystemType = 'nodefs' | 'idbfs' | 'memoryfs'
 
@@ -94,6 +95,7 @@ export type PGliteInterface = {
     ...params: any[]
   ): Promise<Results<T>>
   exec(query: string, options?: QueryOptions): Promise<Array<Results>>
+  describeQuery(query: string): Promise<DescribeQueryResult>
   transaction<T>(
     callback: (tx: Transaction) => Promise<T>,
   ): Promise<T | undefined>
@@ -151,4 +153,9 @@ export interface Transaction {
   exec(query: string, options?: QueryOptions): Promise<Array<Results>>
   rollback(): Promise<void>
   get closed(): boolean
+}
+
+export type DescribeQueryResult = {
+  queryParams: { dataTypeID: number; serializer: Serializer }[]
+  resultFields: { name: string; dataTypeID: number; parser: Parser }[]
 }

--- a/packages/pglite/tests/describe-query.test.ts
+++ b/packages/pglite/tests/describe-query.test.ts
@@ -1,0 +1,71 @@
+import { test, expect } from 'vitest'
+import { PGlite } from '../dist/index.js'
+
+test('describeQuery returns parameter and result types', async () => {
+  const db = await PGlite.create()
+  await db.query(`
+    CREATE TABLE users (
+      id INTEGER PRIMARY KEY,
+      name TEXT,
+      age INTEGER,
+      active BOOLEAN
+    )
+  `)
+
+  const description = await db.describeQuery(
+    'SELECT name, age FROM users WHERE id = $1 AND active = $2'
+  )
+
+  // Check parameter types
+  expect(description.queryParams).toHaveLength(2)
+  expect(description.queryParams[0].dataTypeID).toBe(23) // INTEGER
+  expect(description.queryParams[1].dataTypeID).toBe(16) // BOOLEAN
+  expect(description.queryParams[0].serializer).toBeDefined()
+  expect(description.queryParams[1].serializer).toBeDefined()
+
+  // Check result field types
+  expect(description.resultFields).toHaveLength(2)
+  expect(description.resultFields[0].name).toBe('name')
+  expect(description.resultFields[0].dataTypeID).toBe(25) // TEXT
+  expect(description.resultFields[1].name).toBe('age')
+  expect(description.resultFields[1].dataTypeID).toBe(23) // INTEGER
+  expect(description.resultFields[0].parser).toBeDefined()
+  expect(description.resultFields[1].parser).toBeDefined()
+})
+
+test('describeQuery handles queries with no parameters or results', async () => {
+  const db = await PGlite.create()
+  
+  const description = await db.describeQuery('SELECT 1')
+
+  expect(description.queryParams).toHaveLength(0)
+  expect(description.resultFields).toHaveLength(1)
+  expect(description.resultFields[0].dataTypeID).toBe(23) // INTEGER
+})
+
+test('describeQuery handles INSERT queries', async () => {
+  const db = await PGlite.create()
+  await db.query(`
+    CREATE TABLE test (
+      id INTEGER PRIMARY KEY,
+      value TEXT
+    )
+  `)
+
+  const description = await db.describeQuery(
+    'INSERT INTO test (id, value) VALUES ($1, $2)'
+  )
+
+  expect(description.queryParams).toHaveLength(2)
+  expect(description.queryParams[0].dataTypeID).toBe(23) // INTEGER
+  expect(description.queryParams[1].dataTypeID).toBe(25) // TEXT
+  expect(description.resultFields).toHaveLength(0) // INSERT typically returns no fields
+})
+
+test('describeQuery handles invalid queries', async () => {
+  const db = await PGlite.create()
+
+  await expect(db.describeQuery('SELECT * FROM nonexistent_table'))
+    .rejects
+    .toThrow(/relation "nonexistent_table" does not exist/)
+}) 

--- a/packages/pglite/tests/describe-query.test.ts
+++ b/packages/pglite/tests/describe-query.test.ts
@@ -13,7 +13,7 @@ test('describeQuery returns parameter and result types', async () => {
   `)
 
   const description = await db.describeQuery(
-    'SELECT name, age FROM users WHERE id = $1 AND active = $2'
+    'SELECT name, age FROM users WHERE id = $1 AND active = $2',
   )
 
   // Check parameter types
@@ -35,7 +35,7 @@ test('describeQuery returns parameter and result types', async () => {
 
 test('describeQuery handles queries with no parameters or results', async () => {
   const db = await PGlite.create()
-  
+
   const description = await db.describeQuery('SELECT 1')
 
   expect(description.queryParams).toHaveLength(0)
@@ -53,7 +53,7 @@ test('describeQuery handles INSERT queries', async () => {
   `)
 
   const description = await db.describeQuery(
-    'INSERT INTO test (id, value) VALUES ($1, $2)'
+    'INSERT INTO test (id, value) VALUES ($1, $2)',
   )
 
   expect(description.queryParams).toHaveLength(2)
@@ -65,7 +65,7 @@ test('describeQuery handles INSERT queries', async () => {
 test('describeQuery handles invalid queries', async () => {
   const db = await PGlite.create()
 
-  await expect(db.describeQuery('SELECT * FROM nonexistent_table'))
-    .rejects
-    .toThrow(/relation "nonexistent_table" does not exist/)
-}) 
+  await expect(
+    db.describeQuery('SELECT * FROM nonexistent_table'),
+  ).rejects.toThrow(/relation "nonexistent_table" does not exist/)
+})


### PR DESCRIPTION
This new `describeQuery` method returns the parameter and returns types for a sql query. It can be used to build a type inference system on top of PGlite.

See an example of how to use it here: https://github.com/samwillis/pglite-type-inference

https://github.com/user-attachments/assets/53c45387-7abd-405f-9012-1a590c15c18b

