### PR TITLE
chore: Stop stylecheck blocking build

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -38,6 +38,7 @@ jobs:
     name: Build and Test PGLite dependencies
     runs-on: ubuntu-22.04
     needs: [stylecheck]
+    if: ${{ always() }}
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -65,7 +66,7 @@ jobs:
     defaults:
       run:
         working-directory: ./packages/pglite
-    needs: [stylecheck, build-wasm-postgres, build-and-test-pglite-dependencies]
+    needs: [build-wasm-postgres, build-and-test-pglite-dependencies]
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -149,7 +150,7 @@ jobs:
   build-and-test-pglite-dependents:
     name: Build and Test packages dependent on PGlite
     runs-on: ubuntu-22.04
-    needs: [stylecheck, build-and-test-pglite]
+    needs: [build-and-test-pglite]
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -37,8 +37,6 @@ jobs:
   build-and-test-pglite-dependencies:
     name: Build and Test PGLite dependencies
     runs-on: ubuntu-22.04
-    needs: [stylecheck]
-    if: ${{ always() }}
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4

--- a/packages/pglite/src/pglite.ts
+++ b/packages/pglite/src/pglite.ts
@@ -142,10 +142,12 @@ export class PGlite
     options?: O,
   ): Promise<PGlite & PGliteInterfaceExtensions<O['extensions']>> {
     const resolvedOpts: PGliteOptions =
-      typeof dataDirOrPGliteOptions === 'string' ? {
+      typeof dataDirOrPGliteOptions === 'string'
+        ? {
             dataDir: dataDirOrPGliteOptions,
             ...(options ?? {}),
-          } : (dataDirOrPGliteOptions ?? {})
+          }
+        : (dataDirOrPGliteOptions ?? {})
 
     const pg = new PGlite(resolvedOpts)
     await pg.waitReady

--- a/packages/pglite/src/pglite.ts
+++ b/packages/pglite/src/pglite.ts
@@ -142,12 +142,10 @@ export class PGlite
     options?: O,
   ): Promise<PGlite & PGliteInterfaceExtensions<O['extensions']>> {
     const resolvedOpts: PGliteOptions =
-      typeof dataDirOrPGliteOptions === 'string'
-        ? {
+      typeof dataDirOrPGliteOptions === 'string' ? {
             dataDir: dataDirOrPGliteOptions,
             ...(options ?? {}),
-          }
-        : (dataDirOrPGliteOptions ?? {})
+          } : (dataDirOrPGliteOptions ?? {})
 
     const pg = new PGlite(resolvedOpts)
     await pg.waitReady


### PR DESCRIPTION
Pulls the style check out into separate task so that it doesn't block builds. Very useful for testing ideas without jumping through the style check hoops.

<img width="1183" alt="image" src="https://github.com/user-attachments/assets/5cd63c0e-06be-4f59-90d9-cf21c4b25e85">
