### PR TITLE
Make pglite compatible with @jest-environment: node

### DIFF
--- a/packages/pglite/src/postgresMod.ts
+++ b/packages/pglite/src/postgresMod.ts
@@ -1,4 +1,4 @@
-import PostgresModFactory from '../release/postgres.js'
+import PostgresModFactory from '../release/postgres'
 
 type IDBFS = Emscripten.FileSystemType & {
   quit: () => void


### PR DESCRIPTION
Makes pglite compatible with Jest when run in the 'node' environment. Does _not_ fix issues when run with Jest's 'jsdom' environment. Updates #224.