### PR TITLE
Single command to build everything; minor fixes to build.

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,14 +126,14 @@ Fortunately, PostgreSQL includes a "single user mode" primarily intended for com
 
 ## How to contribute
 
-You will need [pnpm](https://pnpm.io/) installed, and a recent version of Node.js (v20 and above).
+You will need [pnpm](https://pnpm.io/) installed, and a recent version of Node.js (v20 and above). Docker is also needed to build PGlite.
 
-You will also need the Postgres WASM build files, which you download from a comment under the most recently merged PR, labeled as _interim build files_, and place them under `packages/pglite/release`. These are necessary to build PGlite and the dependent workspace projects. We plan to enable a local build in the future to streamline this step.
+~~You will also need the Postgres WASM build files, which you download from a comment under the most recently merged PR, labeled as _interim build files_, and place them under `packages/pglite/release`. These are necessary to build PGlite and the dependent workspace projects. We plan to enable a local build in the future to streamline this step.~~
 
 Once the requirements are met, you can install dependencies and build the workspace projects:
 ```bash
 pnpm install
-pnpm wasm:build
+pnpm build:all
 ```
 
 This will build all packages in the correct order based on their dependency relationships. You can now develop any individual package using the `build` and `test` scripts, as well as the `stylecheck` and `typecheck` scripts to ensure style and type validity.

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ You will also need the Postgres WASM build files, which you download from a comm
 Once the requirements are met, you can install dependencies and build the workspace projects:
 ```bash
 pnpm install
-pnpm build
+pnpm wasm:build
 ```
 
 This will build all packages in the correct order based on their dependency relationships. You can now develop any individual package using the `build` and `test` scripts, as well as the `stylecheck` and `typecheck` scripts to ensure style and type validity.

--- a/cibuild/build-with-docker.sh
+++ b/cibuild/build-with-docker.sh
@@ -18,10 +18,11 @@ IMG_TAG="${PG_VERSION}_${SDK_VERSION}"
 docker run \
   --rm \
   -e OBJDUMP=${OBJDUMP:-true} \
-  -v ./cibuild.sh:/workspace/cibuild.sh \
-  -v ./cibuild:/workspace/cibuild \
-  -v ./patches:/opt/patches \
-  -v ./tests:/workspace/tests \
-  -v ./packages/pglite:/workspace/packages/pglite \
+  -v ./cibuild.sh:/workspace/cibuild.sh:ro \
+  -v ./extra:/workspace/extra:ro \
+  -v ./cibuild:/workspace/cibuild:ro \
+  -v ./patches:/opt/patches:ro \
+  -v ./tests:/workspace/tests:ro \
+  -v ./packages/pglite:/workspace/packages/pglite:rw \
   $IMG_NAME:$IMG_TAG \
   bash ./cibuild/build-all.sh

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
   "scripts": {
     "ci:version": "pnpm exec changeset version",
     "ci:publish": "pnpm changeset publish",
+    "build:all": "pnpm wasm:build && pnpm ts:build",
+    "ts:build": "pnpm --dir ./packages/pglite build",
     "wasm:build": "bash ./cibuild/build-with-docker.sh"
   },
   "devDependencies": {


### PR DESCRIPTION
I thought it would be good to have a single command to build "everything" (as I understand it right now):

`$ pnpm run build:all`

Small fix to make building with docker work again. 

Mapped the docker volumes with `ro` or `rw` hoping to make it clearer where the docker build output goes.

I updated the main `README.md` but unsure about it - please review.

2 tests in `packages/pglite` fail - help needed.

```
⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Failed Suites 2 ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯

 FAIL  |pglite| tests/exec-protocol.test.ts [ tests/exec-protocol.test.ts ]
Error: Failed to resolve entry for package "@electric-sql/pg-protocol". The package may have incorrect main/module/exports specified in its package.json.
 ❯ packageEntryFailure ../../node_modules/.pnpm/vite@5.4.8_@types+node@20.16.11_terser@5.34.1/node_modules/vite/dist/node/chunks/dep-CDnG8rE7.js:46575:15
 ❯ resolvePackageEntry ../../node_modules/.pnpm/vite@5.4.8_@types+node@20.16.11_terser@5.34.1/node_modules/vite/dist/node/chunks/dep-CDnG8rE7.js:46572:3
 ❯ tryNodeResolve ../../node_modules/.pnpm/vite@5.4.8_@types+node@20.16.11_terser@5.34.1/node_modules/vite/dist/node/chunks/dep-CDnG8rE7.js:46388:16
 ❯ ResolveIdContext.resolveId ../../node_modules/.pnpm/vite@5.4.8_@types+node@20.16.11_terser@5.34.1/node_modules/vite/dist/node/chunks/dep-CDnG8rE7.js:46138:19
 ❯ PluginContainer.resolveId ../../node_modules/.pnpm/vite@5.4.8_@types+node@20.16.11_terser@5.34.1/node_modules/vite/dist/node/chunks/dep-CDnG8rE7.js:48953:17
 ❯ TransformPluginContext.resolve ../../node_modules/.pnpm/vite@5.4.8_@types+node@20.16.11_terser@5.34.1/node_modules/vite/dist/node/chunks/dep-CDnG8rE7.js:49113:15
 ❯ normalizeUrl ../../node_modules/.pnpm/vite@5.4.8_@types+node@20.16.11_terser@5.34.1/node_modules/vite/dist/node/chunks/dep-CDnG8rE7.js:63977:26
 ❯ ../../node_modules/.pnpm/vite@5.4.8_@types+node@20.16.11_terser@5.34.1/node_modules/vite/dist/node/chunks/dep-CDnG8rE7.js:64116:39

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/2]⎯

 FAIL  |pglite| tests/utils.test.ts [ tests/utils.test.ts ]
Error: Failed to resolve entry for package "@electric-sql/pg-protocol". The package may have incorrect main/module/exports specified in its package.json.
 ❯ packageEntryFailure ../../node_modules/.pnpm/vite@5.4.8_@types+node@20.16.11_terser@5.34.1/node_modules/vite/dist/node/chunks/dep-CDnG8rE7.js:46575:15
 ❯ resolvePackageEntry ../../node_modules/.pnpm/vite@5.4.8_@types+node@20.16.11_terser@5.34.1/node_modules/vite/dist/node/chunks/dep-CDnG8rE7.js:46572:3
 ❯ tryNodeResolve ../../node_modules/.pnpm/vite@5.4.8_@types+node@20.16.11_terser@5.34.1/node_modules/vite/dist/node/chunks/dep-CDnG8rE7.js:46388:16
 ❯ ResolveIdContext.resolveId ../../node_modules/.pnpm/vite@5.4.8_@types+node@20.16.11_terser@5.34.1/node_modules/vite/dist/node/chunks/dep-CDnG8rE7.js:46138:19
 ❯ PluginContainer.resolveId ../../node_modules/.pnpm/vite@5.4.8_@types+node@20.16.11_terser@5.34.1/node_modules/vite/dist/node/chunks/dep-CDnG8rE7.js:48953:17
 ❯ TransformPluginContext.resolve ../../node_modules/.pnpm/vite@5.4.8_@types+node@20.16.11_terser@5.34.1/node_modules/vite/dist/node/chunks/dep-CDnG8rE7.js:49113:15
 ❯ normalizeUrl ../../node_modules/.pnpm/vite@5.4.8_@types+node@20.16.11_terser@5.34.1/node_modules/vite/dist/node/chunks/dep-CDnG8rE7.js:63977:26
 ❯ ../../node_modules/.pnpm/vite@5.4.8_@types+node@20.16.11_terser@5.34.1/node_modules/vite/dist/node/chunks/dep-CDnG8rE7.js:64116:39

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/2]⎯

 Test Files  2 failed | 38 passed (40)
      Tests  164 passed (164)
Type Errors  no errors
   Start at  09:20:20
   Duration  36.93s (transform 1.66s, setup 0ms, collect 6.99s, tests 190.47s, environment 12ms, prepare 5.23s)

 ELIFECYCLE  Command failed with exit code 1.
```
