### PR TITLE
Use PG "WITH RECURSIVE" to traverse the live query dependencies: http…

### DIFF
--- a/.changeset/unlucky-ties-admire.md
+++ b/.changeset/unlucky-ties-admire.md
@@ -1,0 +1,5 @@
+---
+'@electric-sql/pglite': patch
+---
+
+Use PG "WITH RECURSIVE" to traverse the live query dependencies

--- a/packages/pglite/src/live/index.ts
+++ b/packages/pglite/src/live/index.ts
@@ -715,8 +715,8 @@ async function getTablesForView(
   viewName: string,
 ): Promise<{ table_name: string; schema_name: string }[]> {
   const result = await tx.query<{
-    table_name: string;
-    schema_name: string;
+    table_name: string
+    schema_name: string
   }>(
     `
       WITH RECURSIVE view_dependencies AS (

--- a/packages/pglite/src/live/index.ts
+++ b/packages/pglite/src/live/index.ts
@@ -758,14 +758,13 @@ async function getTablesForView(
       WHERE NOT is_view; -- Exclude intermediate views
     `,
     [viewName],
-  );
+  )
 
   return result.rows.map((row) => ({
     table_name: row.table_name,
     schema_name: row.schema_name,
-  }));
+  }))
 }
-
 
 /**
  * Add triggers to tables to notify when they change

--- a/packages/pglite/src/live/index.ts
+++ b/packages/pglite/src/live/index.ts
@@ -714,17 +714,15 @@ async function getTablesForView(
   tx: Transaction | PGliteInterface,
   viewName: string,
 ): Promise<{ table_name: string; schema_name: string }[]> {
-  const tables = new Map<string, { table_name: string; schema_name: string }>()
-
-  async function getTablesRecursive(currentViewName: string) {
-    const result = await tx.query<{
-      table_name: string
-      schema_name: string
-      is_view: boolean
-    }>(
-      `
+  const result = await tx.query<{
+    table_name: string;
+    schema_name: string;
+  }>(
+    `
+      WITH RECURSIVE view_dependencies AS (
+        -- Base case: Get the initial view's dependencies
         SELECT DISTINCT
-          cl.relname AS table_name,
+          cl.relname AS dependent_name,
           n.nspname AS schema_name,
           cl.relkind = 'v' AS is_view
         FROM pg_rewrite r
@@ -732,33 +730,42 @@ async function getTablesForView(
         JOIN pg_class cl ON d.refobjid = cl.oid
         JOIN pg_namespace n ON cl.relnamespace = n.oid
         WHERE
-        r.ev_class = (
-            SELECT oid FROM pg_class WHERE relname = $1 AND relkind = 'v'
+          r.ev_class = (
+              SELECT oid FROM pg_class WHERE relname = $1 AND relkind = 'v'
+          )
+          AND d.deptype = 'n'
+
+        UNION ALL
+
+        -- Recursive case: Traverse dependencies for views
+        SELECT DISTINCT
+          cl.relname AS dependent_name,
+          n.nspname AS schema_name,
+          cl.relkind = 'v' AS is_view
+        FROM view_dependencies vd
+        JOIN pg_rewrite r ON vd.dependent_name = (
+          SELECT relname FROM pg_class WHERE oid = r.ev_class AND relkind = 'v'
         )
-        AND d.deptype = 'n';
-      `,
-      [currentViewName],
-    )
+        JOIN pg_depend d ON r.oid = d.objid
+        JOIN pg_class cl ON d.refobjid = cl.oid
+        JOIN pg_namespace n ON cl.relnamespace = n.oid
+        WHERE d.deptype = 'n'
+      )
+      SELECT DISTINCT
+        dependent_name AS table_name,
+        schema_name
+      FROM view_dependencies
+      WHERE NOT is_view; -- Exclude intermediate views
+    `,
+    [viewName],
+  );
 
-    for (const row of result.rows) {
-      if (row.table_name !== currentViewName && !row.is_view) {
-        const tableKey = `"${row.schema_name}"."${row.table_name}"`
-        if (!tables.has(tableKey)) {
-          tables.set(tableKey, {
-            table_name: row.table_name,
-            schema_name: row.schema_name,
-          })
-        }
-      } else if (row.is_view) {
-        await getTablesRecursive(row.table_name)
-      }
-    }
-  }
-
-  await getTablesRecursive(viewName)
-
-  return Array.from(tables.values())
+  return result.rows.map((row) => ({
+    table_name: row.table_name,
+    schema_name: row.schema_name,
+  }));
 }
+
 
 /**
  * Add triggers to tables to notify when they change


### PR DESCRIPTION
This is a minor thing, so not urgent. 

I thought it would be cool to use Postgres' `WITH RECURSIVE` functionality for the live queries implementation.

See https://www.postgresql.org/docs/current/queries-with.html#QUERIES-WITH-RECURSIVE

This PR refactors the `getTablesRecursive(...)` to use Postgres' `WITH RECURSIVE`.
