### PR TITLE
fix(pglite/tools): add node imports to the package.json browser excludes

### DIFF
--- a/.changeset/fifty-beers-swim.md
+++ b/.changeset/fifty-beers-swim.md
@@ -1,0 +1,5 @@
+---
+'@electric-sql/pglite-tools': patch
+---
+
+add node imports to the package.json browser excludes

--- a/packages/pglite-tools/package.json
+++ b/packages/pglite-tools/package.json
@@ -35,6 +35,10 @@
     "stylecheck": "pnpm lint && prettier --check ./src ./tests",
     "test": "vitest"
   },
+  "browser": {
+    "fs": false,
+    "fs/promises": false
+  },
   "devDependencies": {
     "@electric-sql/pglite": "workspace:*",
     "@types/emscripten": "^1.39.13",


### PR DESCRIPTION
Next.js, and other bundlers, inspects the `browser` option in package.json to decide what to exclude from a browser bundle. This odds the node fs apis so that it doesnt try and bundle them for the browser.