### PR TITLE
fix: in some cases , params can end up having null or undefined items…

### DIFF
--- a/packages/pglite/src/utils.ts
+++ b/packages/pglite/src/utils.ts
@@ -135,7 +135,11 @@ export async function formatQuery(
   params?: any[] | null,
   tx?: Transaction | PGliteInterface,
 ) {
-  if (!params || params.length === 0) {
+  if (Array.isArray(params)) {
+    params = params.filter(p => typeof p !== "undefined" && p !== null)
+  }
+
+  if (!params?.length) {
     // no params so no formatting needed
     return query
   }

--- a/packages/pglite/src/utils.ts
+++ b/packages/pglite/src/utils.ts
@@ -136,7 +136,7 @@ export async function formatQuery(
   tx?: Transaction | PGliteInterface,
 ) {
   if (Array.isArray(params)) {
-    params = params.filter(p => typeof p !== "undefined" && p !== null)
+    params = params.filter((p) => typeof p !== 'undefined' && p !== null)
   }
 
   if (!params?.length) {


### PR DESCRIPTION
… if it's an array. added a skip to make paramtrized queries formatting more robust