### PR TITLE
fix: `PGliteWorkerOptions` `Extensions` type

### DIFF
--- a/packages/pglite/src/worker/index.ts
+++ b/packages/pglite/src/worker/index.ts
@@ -10,7 +10,7 @@ import type { PGlite } from '../pglite.js'
 import { BasePGlite } from '../base.js'
 import { uuid } from '../utils.js'
 
-export type PGliteWorkerOptions = PGliteOptions & {
+export type PGliteWorkerOptions<E extends Extensions = Extensions> = PGliteOptions<E> & {
   meta?: any
   id?: string
 }


### PR DESCRIPTION
Small fix for a missing generic in `PGliteWorkerOptions` type