### PR TITLE
fix(Vue): nullish params

### DIFF
--- a/packages/pglite-vue/src/hooks.ts
+++ b/packages/pglite-vue/src/hooks.ts
@@ -44,7 +44,7 @@ function useLiveQueryImpl<T = { [key: string]: unknown }>(
 
   const querySource = typeof query === 'string' ? ref(query) : query
   const paramsSources = !params
-    ? [ref(params)]
+    ? []
     : Array.isArray(params)
       ? params.map(ref)
       : [params]
@@ -74,7 +74,7 @@ function useLiveQueryImpl<T = { [key: string]: unknown }>(
           ? params()
           : Array.isArray(params)
             ? params.map(unref)
-            : [params]
+            : null
 
       const key = isRef(keySource) ? keySource.value : keySource?.()
 


### PR DESCRIPTION
Fixes a small oversight on `useLiveQuery` and `useLiveIncrementalQuery` when `params` are nullish.

Eg. if we want to go _brrr_ and subscribe to all updates to a particular table like:
```vue
<script setup lang="ts">
const items = useLiveQuery('SELECT * FROM my_table;')
</script>
```