### PR TITLE
refactor(parse): Simplify message filtering and processing logic `parseResult`

### DIFF
--- a/.changeset/twenty-eagles-pretend.md
+++ b/.changeset/twenty-eagles-pretend.md
@@ -1,0 +1,5 @@
+---
+'@electric-sql/pglite': patch
+---
+
+Refactor the protocol message parse code to be simpler and easer to follow

--- a/packages/pglite/src/parse.ts
+++ b/packages/pglite/src/parse.ts
@@ -27,7 +27,7 @@ export function parseResults(
 
   const filteredMessages = messages.filter(
       (msg) => VALID_MESSAGE_TYPES.has(msg.name)
-  );
+  )
 
   filteredMessages.forEach((message, index) => {
     switch (message.name) {

--- a/packages/pglite/src/parse.ts
+++ b/packages/pglite/src/parse.ts
@@ -22,53 +22,60 @@ export function parseResults(
   let currentResultSet: Results = { rows: [], fields: [] }
   let affectedRows = 0
   const parsers = { ...defaultParsers, ...options?.parsers }
+  
+  const VALID_MESSAGE_TYPES = new Set(['rowDescription', 'dataRow', 'commandComplete'])
 
   const filteredMessages = messages.filter(
-    (msg) =>
-      msg.name === 'rowDescription' ||
-      msg.name === 'dataRow' ||
-      msg.name === 'commandComplete',
-  )
+      (msg) => VALID_MESSAGE_TYPES.has(msg.name)
+  );
 
   filteredMessages.forEach((message, index) => {
-    if (message.name === 'rowDescription') {
-      const msg = message as RowDescriptionMessage
-      currentResultSet.fields = msg.fields.map((field) => ({
-        name: field.name,
-        dataTypeID: field.dataTypeID,
-      }))
-    } else if (message.name === 'dataRow' && currentResultSet) {
-      const msg = message as DataRowMessage
-      if (options?.rowMode === 'array') {
-        currentResultSet.rows.push(
-          msg.fields.map((field, i) =>
-            parseType(field, currentResultSet!.fields[i].dataTypeID, parsers),
-          ),
-        )
-      } else {
-        // rowMode === "object"
-        currentResultSet.rows.push(
-          Object.fromEntries(
-            msg.fields.map((field, i) => [
-              currentResultSet!.fields[i].name,
-              parseType(field, currentResultSet!.fields[i].dataTypeID, parsers),
-            ]),
-          ),
-        )
+    switch (message.name) {
+      case 'rowDescription': {
+        const msg = message as RowDescriptionMessage
+        currentResultSet.fields = msg.fields.map((field) => ({
+          name: field.name,
+          dataTypeID: field.dataTypeID,
+        }))
+        break
       }
-    } else if (message.name === 'commandComplete') {
-      const msg = message as CommandCompleteMessage
-      affectedRows += retrieveRowCount(msg)
+      case 'dataRow': {
+        if (!currentResultSet) break
+        const msg = message as DataRowMessage
+        if (options?.rowMode === 'array') {
+          currentResultSet.rows.push(
+            msg.fields.map((field, i) =>
+              parseType(field, currentResultSet!.fields[i].dataTypeID, parsers),
+            ),
+          )
+        } else {
+          // rowMode === "object"
+          currentResultSet.rows.push(
+            Object.fromEntries(
+              msg.fields.map((field, i) => [
+                currentResultSet!.fields[i].name,
+                parseType(field, currentResultSet!.fields[i].dataTypeID, parsers),
+              ]),
+            ),
+          )
+        }
+        break
+      }
+      case 'commandComplete': {
+        const msg = message as CommandCompleteMessage
+        affectedRows += retrieveRowCount(msg)
 
-      if (index === filteredMessages.length - 1)
-        resultSets.push({
-          ...currentResultSet,
-          affectedRows,
-          ...(blob ? { blob } : {}),
-        })
-      else resultSets.push(currentResultSet)
+        if (index === filteredMessages.length - 1)
+          resultSets.push({
+            ...currentResultSet,
+            affectedRows,
+            ...(blob ? { blob } : {}),
+          })
+        else resultSets.push(currentResultSet)
 
-      currentResultSet = { rows: [], fields: [] }
+        currentResultSet = { rows: [], fields: [] }
+        break
+      }
     }
   })
 

--- a/packages/pglite/src/parse.ts
+++ b/packages/pglite/src/parse.ts
@@ -22,11 +22,15 @@ export function parseResults(
   let currentResultSet: Results = { rows: [], fields: [] }
   let affectedRows = 0
   const parsers = { ...defaultParsers, ...options?.parsers }
-  
-  const VALID_MESSAGE_TYPES = new Set(['rowDescription', 'dataRow', 'commandComplete'])
 
-  const filteredMessages = messages.filter(
-      (msg) => VALID_MESSAGE_TYPES.has(msg.name)
+  const processMessageTypes = new Set([
+    'rowDescription',
+    'dataRow',
+    'commandComplete',
+  ])
+
+  const filteredMessages = messages.filter((msg) =>
+    processMessageTypes.has(msg.name),
   )
 
   filteredMessages.forEach((message, index) => {
@@ -54,7 +58,11 @@ export function parseResults(
             Object.fromEntries(
               msg.fields.map((field, i) => [
                 currentResultSet!.fields[i].name,
-                parseType(field, currentResultSet!.fields[i].dataTypeID, parsers),
+                parseType(
+                  field,
+                  currentResultSet!.fields[i].dataTypeID,
+                  parsers,
+                ),
               ]),
             ),
           )
@@ -65,13 +73,15 @@ export function parseResults(
         const msg = message as CommandCompleteMessage
         affectedRows += retrieveRowCount(msg)
 
-        if (index === filteredMessages.length - 1)
+        if (index === filteredMessages.length - 1) {
           resultSets.push({
             ...currentResultSet,
             affectedRows,
             ...(blob ? { blob } : {}),
           })
-        else resultSets.push(currentResultSet)
+        } else {
+          resultSets.push(currentResultSet)
+        }
 
         currentResultSet = { rows: [], fields: [] }
         break


### PR DESCRIPTION
This pull request includes changes to the `parseResults` function in the `packages/pglite/src/parse.ts` file. The main goal of these changes is to improve the readability and maintainability of the code by using a `Set` for valid message types and replacing conditional statements with a `switch` statement.

Code readability and maintainability improvements:

* Introduced a `Set` named `VALID_MESSAGE_TYPES` to store valid message types and used it in the `filter` method.
* Replaced multiple `if-else` statements with a `switch` statement to handle different message types more clearly. [[1]](diffhunk://#diff-4392d2058202843607c805897016649278df2f0d9c5e0b9b17b15b2d69e4c9b1R26-R43) [[2]](diffhunk://#diff-4392d2058202843607c805897016649278df2f0d9c5e0b9b17b15b2d69e4c9b1L59-R64) [[3]](diffhunk://#diff-4392d2058202843607c805897016649278df2f0d9c5e0b9b17b15b2d69e4c9b1R77-R78)