### PR TITLE
chore: Export the base filesystem to enable creating custom file systems

### DIFF
--- a/.changeset/lovely-melons-perform.md
+++ b/.changeset/lovely-melons-perform.md
@@ -1,0 +1,5 @@
+---
+'@electric-sql/pglite': patch
+---
+
+Export the base filesystem to enable creating custom file systems. NOTE: This is a work-in-progress API and may change at any point in future.

--- a/.changeset/lovely-melons-perform.md
+++ b/.changeset/lovely-melons-perform.md
@@ -2,4 +2,4 @@
 '@electric-sql/pglite': patch
 ---
 
-Export the base filesystem to enable creating custom file systems. NOTE: This is a work-in-progress API and may change at any point in future.
+Export the base filesystem to enable creating custom file systems. NOTE: This is a work-in-progress API, it is not stable, and may change significantly in future!

--- a/packages/pglite/package.json
+++ b/packages/pglite/package.json
@@ -54,6 +54,11 @@
       "import": "./dist/fs/opfs-ahp.js",
       "require": "./dist/fs/opfs-ahp.cjs"
     },
+    "./basefs": {
+      "types": "./dist/fs/base.d.ts",
+      "import": "./dist/fs/base.js",
+      "require": "./dist/fs/base.cjs"
+    },
     "./contrib/*": {
       "types": "./dist/contrib/*.d.ts",
       "import": "./dist/contrib/*.js",

--- a/packages/pglite/tsup.config.ts
+++ b/packages/pglite/tsup.config.ts
@@ -20,6 +20,7 @@ const entryPoints = [
   'src/index.ts',
   'src/fs/nodefs.ts',
   'src/fs/opfs-ahp.ts',
+  'src/fs/base.ts',
   'src/templating.ts',
   'src/live/index.ts',
   'src/vector/index.ts',


### PR DESCRIPTION
This exports the base filesystem implementation so that it can be used to create custom filesystems.

See the OPFS-AHP (https://github.com/electric-sql/pglite/blob/main/packages/pglite/src/fs/opfs-ahp.ts) for an example of how to use this.

**NOTE:** This is a work in progress API, it is not stable, and change significantly in future!

Fixes: #481
