### PR TITLE
Disable building postgis on CI

### DIFF
--- a/.changeset/sweet-eagles-cross.md
+++ b/.changeset/sweet-eagles-cross.md
@@ -1,0 +1,5 @@
+---
+'@electric-sql/pglite': patch
+---
+
+Removes postgis extension which leads to a smaller build of the package

--- a/.github/workflows/build_wasm_postgres.yml
+++ b/.github/workflows/build_wasm_postgres.yml
@@ -25,7 +25,7 @@ jobs:
       OBJDUMP: true
       contrib: contrib
       extra: extra
-      EXTRA_EXT: vector postgis
+      EXTRA_EXT: vector
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Since we're focusing on other things at the moment, we can disable building `postgis`. Re-enable when when we have more time to invest in this.