### PR TITLE
feat: add support for loading compressed dumps via loadDataDir that are not marked as compressed

### DIFF
--- a/.changeset/witty-spiders-type.md
+++ b/.changeset/witty-spiders-type.md
@@ -1,0 +1,5 @@
+---
+'@electric-sql/pglite': patch
+---
+
+feat: add support for loading compressed dumps via loadDataDir that are not labeled with mimetype

--- a/packages/pglite/src/fs/tarUtils.ts
+++ b/packages/pglite/src/fs/tarUtils.ts
@@ -47,7 +47,19 @@ export async function loadTar(
     tarball = await unzip(tarball)
   }
 
-  const files = untar(tarball)
+  let files
+  try {
+    files = untar(tarball)
+  } catch (e) {
+    if (e instanceof Error && e.message.includes('File is corrupted')) {
+      // The file may be compressed, but had the wrong mime type, try unzipping it
+      tarball = await unzip(tarball)
+      files = untar(tarball)
+    } else {
+      throw e
+    }
+  }
+
   for (const file of files) {
     const filePath = pgDataDir + file.name
 

--- a/packages/pglite/tests/dump.test.js
+++ b/packages/pglite/tests/dump.test.js
@@ -78,4 +78,32 @@ describe('dump', () => {
 
     expect(ret1).toEqual(ret2)
   })
+
+  it('dump data dir and load it - compressed but not specified', async () => {
+    const pg1 = new PGlite()
+    await pg1.exec(`
+      CREATE TABLE IF NOT EXISTS test (
+        id SERIAL PRIMARY KEY,
+        name TEXT
+      );
+    `)
+    pg1.exec("INSERT INTO test (name) VALUES ('test');")
+
+    const ret1 = await pg1.query('SELECT * FROM test;')
+
+    const file = await pg1.dumpDataDir()
+
+    // remove the mime type from the file
+    const file2 = new Blob([file])
+
+    expect(typeof file2).toBe('object')
+
+    const pg2 = new PGlite({
+      loadDataDir: file2,
+    })
+
+    const ret2 = await pg2.query('SELECT * FROM test;')
+
+    expect(ret1).toEqual(ret2)
+  })
 })


### PR DESCRIPTION
Fixes #402

Logic now:
- if it looks like a gzip from mine type or filename, unzip it
- then try and untar
- if there is an error, try and unzip then untar