### PR TITLE
Fix of the pglite-sync plugin for latest electric

### DIFF
--- a/.changeset/beige-frogs-film.md
+++ b/.changeset/beige-frogs-film.md
@@ -1,0 +1,5 @@
+---
+'@electric-sql/pglite-sync': patch
+---
+
+Correctly persist the offset during initial sync

--- a/packages/pglite-sync/src/index.ts
+++ b/packages/pglite-sync/src/index.ts
@@ -253,6 +253,7 @@ async function createPlugin(
               shapeKey: options.shapeKey,
               shapeId: shapeHandle,
               lastOffset: getMessageOffset(
+                stream,
                 messageAggregator[messageAggregator.length - 1],
               ),
             })
@@ -673,10 +674,15 @@ function subscriptionMetadataTableName(metadatSchema: string) {
 
 const subscriptionTableName = `shape_subscriptions_metadata`
 
-function getMessageOffset(message: LegacyChangeMessage<any>): Offset {
+function getMessageOffset(
+  stream: ShapeStream,
+  message: LegacyChangeMessage<any>,
+): Offset {
   if (message.offset) {
     return message.offset
-  } else {
+  } else if (message.headers.lsn && message.headers.op_position) {
     return `${message.headers.lsn}_${message.headers.op_position}` as Offset
+  } else {
+    return stream.lastOffset
   }
 }

--- a/packages/pglite-sync/src/index.ts
+++ b/packages/pglite-sync/src/index.ts
@@ -680,7 +680,10 @@ function getMessageOffset(
 ): Offset {
   if (message.offset) {
     return message.offset
-  } else if (message.headers.lsn && message.headers.op_position) {
+  } else if (
+    message.headers.lsn !== undefined &&
+    message.headers.op_position !== undefined
+  ) {
     return `${message.headers.lsn}_${message.headers.op_position}` as Offset
   } else {
     return stream.lastOffset


### PR DESCRIPTION
During initial sync there is nigher the old `offset` or new `lsn` + `op_positon` on each message, we have to fallback to the `stream.lastOffset` value which is the last offset of the final messages in the stream (retrieved from the http header). This replicates the behaviour of the plugin from before the changes to the sync protocol and ensures it will continue to work.

However, we still need to make further changes, and the is likely to include changing the `commitGranularity` option. While this api is useful for incrementally inserting data during initial sync, it is not possible to actually resume from mid way in a snapshot.

The further changes to this api will come as part of a larger refactor to the plugin.