### PR TITLE
docs: expand framework hooks in the side nav.

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -102,7 +102,7 @@ export default defineConfig({
             text: 'Framework Hooks',
             link: '/react',
             base: '/docs/framework-hooks',
-            collapsed: true,
+            collapsed: false,
             items: [
               { text: 'React', link: '/react' },
               { text: 'Vue', link: '/vue' },


### PR DESCRIPTION
It's better to show what's there. Otherwise one of the main DX points is hidden.