### PR TITLE
Sync v2 fixed

### DIFF
--- a/packages/pglite-sync/src/index.ts
+++ b/packages/pglite-sync/src/index.ts
@@ -159,9 +159,12 @@ async function createPlugin(
         Object.keys(shapes).map((shapeName) => [shapeName, []]),
       )
       for (const [shapeName, shapeChanges] of changes.entries()) {
+        const m2c = messagesToCommit.get(shapeName)!
         for (const lsn of shapeChanges.keys()) {
           if (lsn <= targetLsn) {
-            messagesToCommit.get(shapeName)!.push(...shapeChanges.get(lsn)!)
+            for (const message of shapeChanges.get(lsn)!) {
+              m2c.push(message)
+            }
             shapeChanges.delete(lsn)
           }
         }

--- a/packages/pglite-sync/test-e2e/sync-e2e.test.ts
+++ b/packages/pglite-sync/test-e2e/sync-e2e.test.ts
@@ -2262,8 +2262,8 @@ newline', false);
     await pg.electric.deleteSubscription('large_todo_sync_test')
   }, 60000)
 
-  it('handles initial sync of 100,000 rows with COPY', async () => {
-    const numTodos = 100000
+  it('handles initial sync of 150,000 rows with COPY', async () => {
+    const numTodos = 150000
 
     // Batch the inserts to Postgres
     const batchSize = 1000


### PR DESCRIPTION
Fixes OOM when relying on JS spread operator to add more than ~123k values to an array.