### PR TITLE
fix(pglite/live) handle race condition in live query unsubscription

### DIFF
--- a/.changeset/strange-news-burn.md
+++ b/.changeset/strange-news-burn.md
@@ -1,0 +1,5 @@
+---
+'@electric-sql/pglite': patch
+---
+
+Fix a race condition in live query unsubscription that could result in live queries failing to update.


### PR DESCRIPTION
This fixes a race condition in live query unsubscription that could result in live queries failing to update.

The accompanying test fails on the previous version, and passes with this change.

In essence, if you start crating a new live query, but don't await it's subscription - so don't await the query it runs internally at the end - you can interweave a unsubscription of a previous live query. This can result in the unsubscribe removing the listener that has just been added for the new live query.

Technically this is a bug not in the live query (or the react useLiveQuery), but in the `listen` and `unlisted` methods, but it makes sense to test via a live query.