### PR TITLE
Add 'await this._checkReady()' to dumpDataDir

### DIFF
--- a/packages/pglite/src/pglite.ts
+++ b/packages/pglite/src/pglite.ts
@@ -810,6 +810,7 @@ export class PGlite
   async dumpDataDir(
     compression?: DumpTarCompressionOptions,
   ): Promise<File | Blob> {
+    await this._checkReady()
     const dbname = this.dataDir?.split('/').pop() ?? 'pgdata'
     return this.fs!.dumpTar(dbname, compression)
   }


### PR DESCRIPTION
I get `TypeError: Cannot read properties of undefined (reading 'dumpTar')` when running the following code:

```typescript
import { PGlite } from "@electric-sql/pglite";

(async () => {
  const client = new PGlite("./data");
  await client.dumpDataDir()
})();
```

The code assumes the `this.fs` var is initialized while running `dumpDataDir`:

https://github.com/electric-sql/pglite/blob/1777894f4dd4ec9060af3bcbdfd11ae03112f263/packages/pglite/src/pglite.ts#L814

But `this.fs` is not defined when the database is immediately initialized and dumped.

The docs says that:

> Query methods will wait for the waitReady promise to resolve if called before the database has fully initialised, and so it is not necessary to wait for it explicitly.

I think it would be inline with the query methods and close method to wait for the database to be ready implicitly. 
