### PR TITLE
fix(live): prevent double deallocate of live query prepared statment

### DIFF
--- a/.changeset/tall-otters-thank.md
+++ b/.changeset/tall-otters-thank.md
@@ -1,0 +1,5 @@
+---
+'@electric-sql/pglite': patch
+---
+
+Fix a bug in the live plugin that could result in an error when unsubscribing from a live query

--- a/packages/pglite/src/live/index.ts
+++ b/packages/pglite/src/live/index.ts
@@ -244,7 +244,7 @@ const setup = async (pg: PGliteInterface, _emscriptenOpts: any) => {
         } else {
           callbacks = []
         }
-        if (callbacks.length === 0) {
+        if (callbacks.length === 0 && !dead) {
           dead = true
           await Promise.all(unsubList.map((unsub) => unsub()))
           await pg.exec(`
@@ -502,7 +502,7 @@ const setup = async (pg: PGliteInterface, _emscriptenOpts: any) => {
         } else {
           callbacks = []
         }
-        if (callbacks.length === 0) {
+        if (callbacks.length === 0 && !dead) {
           dead = true
           await Promise.all(unsubList.map((unsub) => unsub()))
           await pg.exec(`


### PR DESCRIPTION
This bug can be seen when navigating *away* from the kanban board on [Linearlite example](https://linearlite.examples.electric-sql.com/) - check the console.
