### PR TITLE
test and docs: restore search path after dump

### DIFF
--- a/packages/pglite-tools/README.md
+++ b/packages/pglite-tools/README.md
@@ -68,5 +68,5 @@ const restoredPG = await PGlite.create()
 await restoredPG.exec(dumpContent)
 
 // optional - after importing, set search path back to the initial one
-await pg2.query(`SET search_path TO ${initialSearchPath};`);
+await restoredPG.query(`SET search_path TO ${initialSearchPath};`);
 ```

--- a/packages/pglite-tools/README.md
+++ b/packages/pglite-tools/README.md
@@ -68,5 +68,5 @@ const restoredPG = await PGlite.create()
 await restoredPG.exec(dumpContent)
 
 // optional - after importing, set search path back to the initial one
-await restoredPG.query(`SET search_path TO ${initialSearchPath};`);
+await restoredPG.exec(`SET search_path TO ${initialSearchPath};`);
 ```

--- a/packages/pglite-tools/README.md
+++ b/packages/pglite-tools/README.md
@@ -31,6 +31,10 @@ There are a number of arguments that are automatically added to the end of the c
 
 - A `File` object containing the dump.
 
+### Caveats
+
+- After restoring a dump, you might want to set the same search path as the initial db.
+
 ### Example
 
 ```typescript
@@ -50,6 +54,19 @@ await pg.exec(`
   INSERT INTO test (name) VALUES ('test');
 `)
 
+// store the current search path so it can be used in the restored db
+const initialSearchPath = (await pg1.query<{ search_path: string }>('SHOW SEARCH_PATH;')).rows[0].search_path
+
 // Dump the database to a file
 const dump = await pgDump({ pg })
+// Get the dump text - used for restore
+const dumpContent = await dump.text()
+
+// Create a new database 
+const restoredPG = await PGlite.create()
+// ... and restore it using the dump
+await restoredPG.exec(dumpContent)
+
+// optional - after importing, set search path back to the initial one
+await pg2.query(`SET search_path TO ${initialSearchPath};`);
 ```

--- a/packages/pglite-tools/tests/pg_dump.test.ts
+++ b/packages/pglite-tools/tests/pg_dump.test.ts
@@ -103,7 +103,7 @@ describe('pgDump', () => {
     await pg2.exec(dumpContent)
 
     // after importing, set search path back to the initial one
-    await pg2.query(`SET search_path TO ${initialSearchPath};`);
+    await pg2.exec(`SET search_path TO ${initialSearchPath};`);
 
     // Verify data
     const result = await pg2.query<{ name: string }>(

--- a/packages/pglite-tools/tests/pg_dump.test.ts
+++ b/packages/pglite-tools/tests/pg_dump.test.ts
@@ -92,7 +92,9 @@ describe('pgDump', () => {
       INSERT INTO test (name) VALUES ('row1'), ('row2');
     `)
 
-    const initialSearchPath = (await pg1.query<{ search_path: string }>('SHOW SEARCH_PATH;')).rows[0].search_path
+    const initialSearchPath = (
+      await pg1.query<{ search_path: string }>('SHOW SEARCH_PATH;')
+    ).rows[0].search_path
 
     // Dump database
     const dump = await pgDump({ pg: pg1 })
@@ -103,7 +105,7 @@ describe('pgDump', () => {
     await pg2.exec(dumpContent)
 
     // after importing, set search path back to the initial one
-    await pg2.exec(`SET search_path TO ${initialSearchPath};`);
+    await pg2.exec(`SET search_path TO ${initialSearchPath};`)
 
     // Verify data
     const result = await pg2.query<{ name: string }>(

--- a/packages/pglite/examples/pg_dump.html
+++ b/packages/pglite/examples/pg_dump.html
@@ -46,7 +46,7 @@
           await pg.exec(`INSERT INTO test2 (name) VALUES ('test2-${i}');`)
         }
 
-        const initialSearchPath = (await pg1.query<{ search_path: string }>('SHOW SEARCH_PATH;')).rows[0].search_path
+        const initialSearchPath = (await pg.query('SHOW SEARCH_PATH;')).rows[0].search_path
 
         console.log('Dumping database...')
         const dump = await pgDump({ pg })
@@ -66,8 +66,7 @@
         const sql = await dump.text()
         await pg2.exec(sql)
 
-        console.log('Setting the search path to', initialSearchPath)
-        // restore the initial search path
+        console.log('Restoring the initial search path to', initialSearchPath)
         await pg2.exec(`SET search_path TO ${initialSearchPath};`)
 
         console.log('Querying restored database...')

--- a/packages/pglite/examples/pg_dump.html
+++ b/packages/pglite/examples/pg_dump.html
@@ -46,6 +46,8 @@
           await pg.exec(`INSERT INTO test2 (name) VALUES ('test2-${i}');`)
         }
 
+        const initialSearchPath = (await pg1.query<{ search_path: string }>('SHOW SEARCH_PATH;')).rows[0].search_path
+
         console.log('Dumping database...')
         const dump = await pgDump({ pg })
         console.log(dump)
@@ -64,8 +66,12 @@
         const sql = await dump.text()
         await pg2.exec(sql)
 
+        console.log('Setting the search path to', initialSearchPath)
+        // restore the initial search path
+        await pg2.exec(`SET search_path TO ${initialSearchPath};`)
+
         console.log('Querying restored database...')
-        const rows = await pg2.query('SELECT * FROM public.test2')
+        const rows = await pg2.query('SELECT * FROM test2')
         console.log(rows)
       </script>
       <div id="log"></div>


### PR DESCRIPTION
Small improvements to the tests and docs related to `pg_dump` and `search_path`