### PR TITLE
fix: added listen to transaction object

### DIFF
--- a/packages/pglite/src/interface.ts
+++ b/packages/pglite/src/interface.ts
@@ -129,6 +129,7 @@ export type PGliteInterface<T extends Extensions = Extensions> =
     listen(
       channel: string,
       callback: (payload: string) => void,
+      tx?: Transaction,
     ): Promise<() => Promise<void>>
     unlisten(
       channel: string,
@@ -175,6 +176,10 @@ export interface Transaction {
   ): Promise<Results<T>>
   exec(query: string, options?: QueryOptions): Promise<Array<Results>>
   rollback(): Promise<void>
+  listen(
+    channel: string,
+    callback: (payload: string) => void,
+  ): Promise<() => Promise<void>>
   get closed(): boolean
 }
 

--- a/packages/pglite/src/worker/index.ts
+++ b/packages/pglite/src/worker/index.ts
@@ -6,6 +6,7 @@ import type {
   PGliteInterface,
   PGliteInterfaceExtensions,
   PGliteOptions,
+  Transaction,
 } from '../interface.js'
 import type { PGlite } from '../pglite.js'
 import { BasePGlite } from '../base.js'
@@ -359,14 +360,15 @@ export class PGliteWorker
   async listen(
     channel: string,
     callback: (payload: string) => void,
+    tx?: Transaction,
   ): Promise<() => Promise<void>> {
     const pgChannel = toPostgresName(channel)
-
+    const pg = tx ?? this
     if (!this.#notifyListeners.has(pgChannel)) {
       this.#notifyListeners.set(pgChannel, new Set())
     }
     this.#notifyListeners.get(pgChannel)!.add(callback)
-    await this.exec(`LISTEN ${channel}`)
+    await pg.exec(`LISTEN ${channel}`)
     return async () => {
       await this.unlisten(pgChannel, callback)
     }


### PR DESCRIPTION
When creating a new live query, we make a `LISTEN` call that is not scoped to the transaction that creates the live query. This can lead to race conditions with other concurrent transactions.

One notable occurrence happens during live query creation with initial shape syncing. The `LISTEN` call can be interleaved with shape data being applied resulting in some changes being missed from by the live query resulting in inconsistent UI rendering.

This PR exposes the `listen()` method on the transaction object, allowing `LISTEN` calls to be properly scoped to their respective transactions. This ensures that the LISTEN call executes within the same transaction context as the live query creation and prevents the described race condition.

Potentially closes #641.