### PR TITLE
docs: fix X social link

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@
   <a href="https://github.com/electric-sql/pglite/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-Apache_2.0-green" alt="License - Apache 2.0"></a>
   <a href="#roadmap"><img src="https://img.shields.io/badge/status-alpha-orange" alt="Status - Alpha"></a>
   <a href="https://discord.electric-sql.com"><img src="https://img.shields.io/discord/933657521581858818?color=5969EA&label=discord" alt="Chat - Discord"></a>
-  <a href="https://twitter.com/ElectricSQL" target="_blank"><img src="https://img.shields.io/twitter/follow/nestframework.svg?style=social&label=Follow @ElectricSQL"></a>
-  <a href="https://fosstodon.org/@electric" target="_blank"><img src="https://img.shields.io/mastodon/follow/109599644322136925.svg?domain=https%3A%2F%2Ffosstodon.org"></a>
+  <a href="https://x.com/ElectricSQL"><img src="https://img.shields.io/twitter/follow/nestframework.svg?style=social&label=Follow%20@ElectricSQL"></a>
+  <a href="https://fosstodon.org/@electric"><img src="https://img.shields.io/mastodon/follow/109599644322136925.svg?domain=https%3A%2F%2Ffosstodon.org"></a>
 </p>
 
 # PGlite - Postgres in WASM


### PR DESCRIPTION
## Summary

Documentation:
- Replace Twitter badge URL with X badge URL in README
- Show X badge correctly
- Remove unmeaningful `target=_blank`

## Before

![スクリーンショット 2025-07-03 095218](https://github.com/user-attachments/assets/f3b4808d-e8f2-41d3-9927-f0ebac052788)

## after

![スクリーンショット 2025-07-03 095241](https://github.com/user-attachments/assets/29bda33f-6921-437b-a80c-8e349fabec2d)

## Description

`target=_blank` is forbidden in GitHub Markdown.