### PR TITLE
Add singleTab option for Worker in tab-less contexts like Capacitor apps

### DIFF
--- a/docs/docs/multi-tab-worker.md
+++ b/docs/docs/multi-tab-worker.md
@@ -53,6 +53,8 @@ In addition to having all the standard methods of the [`PGlite` interface](./api
 - `id: string`<br>
   This is an optional `id` to group your PGlite workers. The leader election is run between all `PGliteWorker`s with the same `id`.<br>
   If not provided, the url to the worker is concatenated with the `dataDir` option to create an id.
+- `singleTab: boolean`<br>
+  Set to `true` if using `PGliteWorker` in an environment without `navigator.locks` support, such as a Capacitor app. These webviews have no tabs so there is no need to run a leader election. Defaults to `false`.
 - `meta: any`<br>
   Any additional metadata you would like to pass to the worker process `init` function.
 


### PR DESCRIPTION
Capacitor apps use an instance of webview that don't have the `navigator.locks` API, thus the PGlite worker doesn't work in these contexts. It throws an error: "Cannot read properties of undefined (reading 'request')."

I propose updating the code to allow for singleTab worker usage. I would say that 90% of the benefit of the worker is the background thread ability and only 10% is multi-tab stuff. This allows us to still use the worker in apps built using Capacitor and other similar frameworks.