### PR TITLE
Fix missing extensions in cloned db instance

### DIFF
--- a/packages/pglite/src/pglite.ts
+++ b/packages/pglite/src/pglite.ts
@@ -992,7 +992,7 @@ export class PGlite
 
   async clone(): Promise<PGliteInterface> {
     const dump = await this.dumpDataDir('none')
-    return PGlite.create({ loadDataDir: dump })
+    return PGlite.create({ loadDataDir: dump, extensions: this.#extensions })
   }
 
   _runExclusiveListen<T>(fn: () => Promise<T>): Promise<T> {


### PR DESCRIPTION
I use clones for tests and expect the extensions to be present. Is there an argument against cloning them?

Related:
https://github.com/electric-sql/pglite/issues/697