### PR TITLE
feat: enable npm trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -352,7 +352,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24  # Required for npm trusted publishing (npm 11.5.1+)
           cache: pnpm
 
       - name: Download PGlite WASM build artifacts


### PR DESCRIPTION
## Summary

- Configure the `changesets-release` job to use npm's Trusted Publishing feature instead of long-lived npm tokens
- Uses OpenID Connect (OIDC) for authentication, providing better security through short-lived, workflow-specific credentials
- Removes dependency on `NPM_TOKEN` secret

## Why Trusted Publishing?

Trusted publishing eliminates the security risks associated with long-lived npm tokens:

- **No token exposure risk** - Tokens can be accidentally exposed in logs or compromised; OIDC uses short-lived, cryptographically-signed credentials
- **No manual rotation needed** - Each publish uses automatically-generated, workflow-specific credentials
- **Scoped access** - Credentials are specific to the configured workflow and cannot be extracted or reused
- **Automatic provenance** - npm automatically generates provenance attestations when publishing via trusted publishing

## Changes

- Added `id-token: write` permission to the `changesets-release` job (required for GitHub Actions to generate OIDC tokens)
- Removed `NPM_TOKEN` secret from the workflow (no longer needed with trusted publishing)
- Upgraded to Node.js 24 for the changesets-release job (npm trusted publishing requires npm 11.5.1+, which is bundled with Node.js 24)

## Configuration

Trusted publishers have been configured on npmjs.com for all packages with:
- **Publisher**: GitHub Actions
- **Organization**: electric-sql
- **Repository**: pglite
- **Workflow filename**: build_and_test.yml

<img width="818" height="392" alt="image" src="https://github.com/user-attachments/assets/785438ac-5d72-4e5b-b2fc-86330b825eb2" />

## Documentation

- [npm Trusted Publishing docs](https://docs.npmjs.com/trusted-publishers)
- [GitHub Actions OIDC documentation](https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/about-security-hardening-with-openid-connect)
- [OpenSSF Trusted Publishers specification](https://repos.openssf.org/trusted-publishers-for-all-package-repositories)

## Test plan

- [ ] Merge and trigger a release via changesets
- [ ] Verify packages publish successfully using OIDC authentication
- [ ] Confirm provenance attestations are generated on published packages

## Post-merge recommendation

After verifying trusted publishing works correctly, consider restricting token-based publishing access on npmjs.com by navigating to each package's **Settings → Publishing access** and selecting **"Require two-factor authentication and disallow tokens"** for maximum security.