### PR TITLE
fix(pglite-sync): don't filter move-in messages by LSN

### DIFF
--- a/.changeset/fix-move-in-lsn-filtering.md
+++ b/.changeset/fix-move-in-lsn-filtering.md
@@ -1,0 +1,9 @@
+---
+"@electric-sql/pglite-sync": patch
+---
+
+Fix move-in messages being incorrectly skipped due to LSN filtering
+
+Move-in messages from Electric's tagged_subqueries feature don't include an LSN header because they originate from direct database queries rather than the PostgreSQL replication stream. Previously, these messages were being filtered out as "already seen" because the missing LSN defaulted to 0, which was less than or equal to the last committed LSN.
+
+This fix checks for the `is_move_in` header and bypasses LSN filtering for move-in messages, ensuring that rows moving into a shape due to subquery condition changes are properly synced to the client.

--- a/.changeset/fix-move-in-lsn-filtering.md
+++ b/.changeset/fix-move-in-lsn-filtering.md
@@ -2,8 +2,10 @@
 "@electric-sql/pglite-sync": patch
 ---
 
-Fix move-in messages being incorrectly skipped due to LSN filtering
+Fix move-in messages from tagged_subqueries not being synced
 
-Move-in messages from Electric's tagged_subqueries feature don't include an LSN header because they originate from direct database queries rather than the PostgreSQL replication stream. Previously, these messages were being filtered out as "already seen" because the missing LSN defaulted to 0, which was less than or equal to the last committed LSN.
+This fixes two issues with move-in messages from Electric's `tagged_subqueries` feature:
 
-This fix checks for the `is_move_in` header and bypasses LSN filtering for move-in messages, ensuring that rows moving into a shape due to subquery condition changes are properly synced to the client.
+1. **LSN filtering bypass**: Move-in messages don't include an LSN header because they originate from direct database queries rather than the PostgreSQL replication stream. Previously, these messages were being filtered out as "already seen" because the missing LSN defaulted to 0. This fix checks for the `is_move_in` header and bypasses LSN filtering for these messages.
+
+2. **Duplicate key handling**: Move-in data can overlap with data from the initial sync (e.g., when a row "moves in" to match a subquery that it already matched during initial sync). This fix uses `ON CONFLICT DO UPDATE` for move-in inserts to handle these duplicates gracefully, updating the row with the latest data instead of erroring.

--- a/packages/pglite-sync/src/apply.ts
+++ b/packages/pglite-sync/src/apply.ts
@@ -24,7 +24,8 @@ export async function applyMessageToTable({
   const data = mapColumns ? doMapColumns(mapColumns, message) : message.value
 
   // Check if this is a move-in message (from subquery-based shapes)
-  const isMoveIn = (message.headers as Record<string, unknown>).is_move_in === true
+  const isMoveIn =
+    (message.headers as Record<string, unknown>).is_move_in === true
 
   switch (message.headers.operation) {
     case 'insert': {

--- a/packages/pglite-sync/src/index.ts
+++ b/packages/pglite-sync/src/index.ts
@@ -255,6 +255,7 @@ async function createPlugin(
                 schema: shape.schema,
                 messages: initialInserts as InsertChangeMessage[],
                 mapColumns: shape.mapColumns,
+                primaryKey: shape.primaryKey,
                 debug,
               })
 
@@ -282,6 +283,7 @@ async function createPlugin(
                   schema: shape.schema,
                   messages: bulkInserts as InsertChangeMessage[],
                   mapColumns: shape.mapColumns,
+                  primaryKey: shape.primaryKey,
                   debug,
                 })
                 bulkInserts.length = 0

--- a/packages/pglite-sync/src/index.ts
+++ b/packages/pglite-sync/src/index.ts
@@ -357,8 +357,8 @@ async function createPlugin(
           // Move-in messages from subquery-based shapes don't have an LSN
           // because they come from direct DB queries, not from replication.
           // We should never skip these based on LSN filtering.
-          const isMoveIn = (message.headers as Record<string, unknown>)
-            .is_move_in === true
+          const isMoveIn =
+            (message.headers as Record<string, unknown>).is_move_in === true
 
           if (!isMoveIn && lsn <= lastCommittedLsnForShape) {
             // We are replaying changes / have already seen this lsn

--- a/packages/pglite-sync/test/sync.test.ts
+++ b/packages/pglite-sync/test/sync.test.ts
@@ -172,6 +172,133 @@ describe('pglite-sync', () => {
     shape.unsubscribe()
   })
 
+  it('syncs move-in messages that have no lsn', async () => {
+    let feedMessage: (
+      lsn: number,
+      message: MultiShapeMessage,
+    ) => Promise<void> = async (_) => {}
+    MockMultiShapeStream.mockImplementation(() => ({
+      subscribe: vi.fn(
+        (cb: (messages: MultiShapeMessage[]) => Promise<void>) => {
+          feedMessage = (lsn, message) =>
+            cb([
+              message,
+              {
+                shape: 'shape',
+                headers: {
+                  control: 'up-to-date',
+                  global_last_seen_lsn: lsn.toString(),
+                },
+              },
+            ])
+        },
+      ),
+      unsubscribeAll: vi.fn(),
+      isUpToDate: true,
+      shapes: {
+        shape: {
+          subscribe: vi.fn(),
+          unsubscribeAll: vi.fn(),
+        },
+      },
+    }))
+
+    const shape = await pg.electric.syncShapeToTable({
+      shape: {
+        url: 'http://localhost:3000/v1/shape',
+        params: { table: 'todo' },
+      },
+      table: 'todo',
+      primaryKey: ['id'],
+      shapeKey: null,
+    })
+
+    // initial sync, commits past lsn 0
+    await feedMessage(5, {
+      headers: { operation: 'insert', lsn: '5' },
+      key: 'id1',
+      value: { id: 1, task: 'task1', done: false },
+      shape: 'shape',
+    })
+
+    // move-in has no lsn (defaults to 0), must not be skipped as already seen
+    await feedMessage(6, {
+      headers: { operation: 'insert', is_move_in: true },
+      key: 'id2',
+      value: { id: 2, task: 'task2', done: false },
+      shape: 'shape',
+    })
+    expect((await pg.sql`SELECT * FROM todo ORDER BY id;`).rows).toEqual([
+      { id: 1, task: 'task1', done: false },
+      { id: 2, task: 'task2', done: false },
+    ])
+
+    shape.unsubscribe()
+  })
+
+  it('upserts move-in messages that overlap with existing rows', async () => {
+    let feedMessage: (
+      lsn: number,
+      message: MultiShapeMessage,
+    ) => Promise<void> = async (_) => {}
+    MockMultiShapeStream.mockImplementation(() => ({
+      subscribe: vi.fn(
+        (cb: (messages: MultiShapeMessage[]) => Promise<void>) => {
+          feedMessage = (lsn, message) =>
+            cb([
+              message,
+              {
+                shape: 'shape',
+                headers: {
+                  control: 'up-to-date',
+                  global_last_seen_lsn: lsn.toString(),
+                },
+              },
+            ])
+        },
+      ),
+      unsubscribeAll: vi.fn(),
+      isUpToDate: true,
+      shapes: {
+        shape: {
+          subscribe: vi.fn(),
+          unsubscribeAll: vi.fn(),
+        },
+      },
+    }))
+
+    const shape = await pg.electric.syncShapeToTable({
+      shape: {
+        url: 'http://localhost:3000/v1/shape',
+        params: { table: 'todo' },
+      },
+      table: 'todo',
+      primaryKey: ['id'],
+      shapeKey: null,
+    })
+
+    // initial sync
+    await feedMessage(5, {
+      headers: { operation: 'insert', lsn: '5' },
+      key: 'id1',
+      value: { id: 1, task: 'task1', done: false },
+      shape: 'shape',
+    })
+
+    // move-in with an existing key must upsert, not error on duplicate key
+    await feedMessage(6, {
+      headers: { operation: 'insert', is_move_in: true },
+      key: 'id1',
+      value: { id: 1, task: 'task1-updated', done: true },
+      shape: 'shape',
+    })
+    expect((await pg.sql`SELECT * FROM todo;`).rows).toEqual([
+      { id: 1, task: 'task1-updated', done: true },
+    ])
+
+    shape.unsubscribe()
+  })
+
   it('performs operations within a transaction', async () => {
     let feedMessages: (
       lsn: number,


### PR DESCRIPTION
## Summary

Move-in messages from Electric's `tagged_subqueries` feature don't have an `lsn` header because they come from direct database queries, not from the PostgreSQL replication stream. Previously, these messages were incorrectly skipped as "already seen" because the missing LSN defaulted to 0.

This fix checks for the `is_move_in` header and bypasses LSN filtering for move-in messages, ensuring that rows moving into a shape due to subquery condition changes are properly synced to the client.

## Problem

When using shapes with subqueries (e.g., `WHERE id IN (SELECT user_id FROM workspace_members WHERE workspace_id = $1)`), new rows that "move in" to match the subquery weren't being synced:

1. Electric server correctly processes the move-in and sends an INSERT message
2. The INSERT message has `headers.is_move_in: true` but NO `headers.lsn` (since it's from a query, not replication)
3. pglite-sync defaults missing LSN to 0
4. The check `lsn <= lastCommittedLsnForShape` evaluates to `0 <= X` which is true after initial sync
5. The move-in message is skipped as "already seen"

## Solution

```typescript
const isMoveIn = (message.headers as Record<string, unknown>).is_move_in === true

if (!isMoveIn && lsn <= lastCommittedLsnForShape) {
  // Skip only if NOT a move-in message
  return
}
```

## Test case

1. Create a shape with a subquery WHERE clause (e.g., profiles where `id IN (SELECT user_id FROM workspace_members WHERE workspace_id = ...)`)
2. Complete initial sync
3. Add a new row to the inner table that causes a row to "move in" to the outer shape
4. Before fix: the moved-in row is not synced to PGlite
5. After fix: the moved-in row is correctly synced
