### PR TITLE
Fix PostGIS loading to use async WASM precompilation

### DIFF
--- a/packages/pglite/src/extensionUtils.ts
+++ b/packages/pglite/src/extensionUtils.ts
@@ -85,7 +85,7 @@ function loadExtension(
     if (!file.name.startsWith('.')) {
       const filePath = mod.WASM_PREFIX + '/' + file.name
       if (file.name.endsWith('.so')) {
-        const soName = file.name.split('/').pop()!  // e.g. 'postgis-3.so'
+        const soName = file.name.split('/').pop()! // e.g. 'postgis-3.so'
         const dirPath = dirname(filePath)
         // Wrap createPreloadedFile in a Promise so loadExtensions can await the
         // async WASM compilation done by Emscripten's wasm preload plugin.


### PR DESCRIPTION
This aims to fix loading of PostGIS in Chrome using async wasm precompilation to get around the 8mb browser limit.

Problem seemed to be that `createPreloadedFile` was called with the filename stripped of .so. Emscripten's wasm preload plugin checks `name.endsWith('.so')` in `canHandle()`, so it never activated. That's the main fix applied here and in the accompanying PR: https://github.com/electric-sql/postgres-pglite/pull/63

With the pglite-socket fix applied from https://github.com/electric-sql/pglite/pull/807 and muting the DEBUG messages as per same PR, I get the following test results:

```
packages/pglite-postgis:

  ✓ tests/postgis.test.ts       (5 tests)

  Test Files: 1 passed / Tests: 5 passed

PostGIS regression suite:  
   regress/core/regress  .. ok in 220 ms
   regress/core/wkt      .. ok in 37 ms
   regress/core/measures .. ok in 117 ms
   regress/core/geography.. ok in 124 ms
   regress/core/operators.. ok in 71 ms
   regress/uninstall     .. failed (Object count pre-install 5456 != post-uninstall 5458)

  Run tests: 6 / Failed: 1
```

The failing uninstall test is pre-existing *I believe*, as per similar comment in https://github.com/electric-sql/pglite/pull/807, though I can't get it to pass by turning off the DEBUG messages (seems to work for the other tests), but let me know if you think this might be related to this change.

As a test, this works in Chrome:

```html
<!DOCTYPE html>
<html lang="en">
<head>
  <meta charset="UTF-8">
  <title>PostGIS Chrome Test</title>
  <style>
    body { font-family: monospace; padding: 20px; background: #1a1a1a; color: #eee; }
    h1 { color: #aaa; font-size: 1.2em; }
    #log { white-space: pre-wrap; font-size: 13px; }
    .ok  { color: #4caf50; }
    .err { color: #f44336; }
    .inf { color: #64b5f6; }
    .dim { color: #888; }
  </style>
</head>
<body>
  <h1>PostGIS async preload plugin test</h1>
  <div id="log"></div>
  <script type="module">
    const log = document.getElementById('log')
    const append = (cls, msg) => {
      const span = document.createElement('span')
      span.className = cls
      span.textContent = msg + '\n'
      log.appendChild(span)
    }
    const info = m => append('inf', m)
    const ok   = m => append('ok',  '✓ ' + m)
    const err  = m => append('err', '✗ ' + m)
    const dim  = m => append('dim', m)

    info('Importing pglite…')
    try {
      // Import pglite and postgis from their dist directories
      const { PGlite } = await import('./pglite/dist/index.js')
      const { postgis }  = await import('./pglite-postgis/dist/index.js')

      info('Creating PGlite instance with postgis extension…')
      const db = new PGlite({ extensions: { postgis } })

      info('Waiting for db.ready…')
      await db.waitReady

      ok('PGlite ready')

      info('Running: CREATE EXTENSION postgis;')
      await db.exec('CREATE EXTENSION postgis;')
      ok('CREATE EXTENSION postgis succeeded')

      info('Running: SELECT postgis_full_version();')
      const result = await db.query('SELECT postgis_full_version() AS v;')
      ok('postgis_full_version: ' + result.rows[0].v)

      info('Running: SELECT ST_AsText(ST_MakePoint(1,2));')
      const pt = await db.query("SELECT ST_AsText(ST_MakePoint(1,2)) AS wkt;")
      ok('ST_MakePoint: ' + pt.rows[0].wkt)

      ok('All tests passed')
    } catch (e) {
      err('Error: ' + e.message)
      dim(e.stack || '')
      console.error(e)
    }
  </script>
</body>
</html>
```