### PR TITLE
feat(pglite-socket): handle CancelRequest wire protocol message

### DIFF
--- a/.changeset/cancel-request-handling.md
+++ b/.changeset/cancel-request-handling.md
@@ -1,0 +1,7 @@
+---
+'@electric-sql/pglite-socket': patch
+---
+
+Handle PostgreSQL CancelRequest wire protocol messages
+
+Added support for the CancelRequest message that some clients and connection proxies send during the connection startup phase. PGlite has no backend process to cancel, so the request is consumed and silently ignored (the protocol expects no response), which prevents it from being misinterpreted as a malformed startup/typed message. This complements the existing SSLRequest handling.

--- a/.changeset/ssl-cancel-request-handling.md
+++ b/.changeset/ssl-cancel-request-handling.md
@@ -1,0 +1,7 @@
+---
+'@electric-sql/pglite-socket': minor
+---
+
+Handle SSLRequest and CancelRequest wire protocol messages for proxy compatibility
+
+Added support for PostgreSQL SSLRequest and CancelRequest protocol messages that arrive during the connection startup phase. SSLRequest is answered with 'N' (no SSL), and CancelRequest is silently acknowledged. This enables pglite-socket to work behind connection proxies like Cloudflare Hyperdrive that send SSLRequest during connection negotiation.

--- a/packages/pglite-socket/src/index.ts
+++ b/packages/pglite-socket/src/index.ts
@@ -5,6 +5,8 @@ import { type Server, type Socket, createServer } from 'net'
 export const CONNECTION_QUEUE_TIMEOUT = 60000 // 60 seconds
 export const SSL_REQUEST_CODE = 80877103
 export const SSL_REQUEST_LENGTH = 8
+export const CANCEL_REQUEST_CODE = 80877102
+export const CANCEL_REQUEST_LENGTH = 16
 
 /**
  * Represents a queued query waiting for PGlite access
@@ -346,6 +348,26 @@ export class PGLiteSocketHandler extends EventTarget {
     return false
   }
 
+  // CancelRequest arrives on its own connection during startup, before any
+  // typed message. PGlite has no backend process to signal, so we consume the
+  // message and silently drop it (the wire protocol expects no response).
+  private handleCancelRequest(): boolean {
+    if (this.messageBuffer.length < CANCEL_REQUEST_LENGTH) {
+      return false
+    }
+
+    const len = this.messageBuffer.readInt32BE(0)
+    const code = this.messageBuffer.readInt32BE(4)
+
+    if (len === CANCEL_REQUEST_LENGTH && code === CANCEL_REQUEST_CODE) {
+      this.messageBuffer = this.messageBuffer.slice(CANCEL_REQUEST_LENGTH)
+      this.log('handleData: CancelRequest received, ignoring (not supported)')
+      return true
+    }
+
+    return false
+  }
+
   private async handleData(data: Buffer): Promise<number> {
     if (!this.socket || !this.active) {
       this.log(`handleData: no active socket, ignoring data`)
@@ -365,6 +387,10 @@ export class PGLiteSocketHandler extends EventTarget {
 
       while (this.messageBuffer.length > 0) {
         if (this.handleSslRequest()) {
+          continue
+        }
+
+        if (this.handleCancelRequest()) {
           continue
         }
 

--- a/packages/pglite-socket/tests/query-with-node-pg.test.ts
+++ b/packages/pglite-socket/tests/query-with-node-pg.test.ts
@@ -11,6 +11,7 @@ import { Client } from 'pg'
 import { PGlite } from '@electric-sql/pglite'
 import { PGLiteSocketServer } from '../src'
 import { spawn, ChildProcess } from 'node:child_process'
+import { createConnection } from 'node:net'
 import { fileURLToPath } from 'node:url'
 import { dirname, join } from 'node:path'
 import fs from 'fs'
@@ -792,6 +793,36 @@ describe(`PGLite Socket Server`, () => {
         // swallow
       }
     }, 30000)
+
+    it('should handle CancelRequest without crashing', async () => {
+      // Test raw CancelRequest wire protocol handling
+      const socket = createConnection({ host: '127.0.0.1', port: TEST_PORT })
+
+      await new Promise<void>((resolve, reject) => {
+        socket.on('connect', resolve)
+        socket.on('error', reject)
+      })
+
+      // Send CancelRequest: [length=16][code=80877102 (0x04D2162E)][processID=0][secretKey=0]
+      const cancelRequest = Buffer.alloc(16)
+      cancelRequest.writeInt32BE(16, 0)
+      cancelRequest.writeInt32BE(80877102, 4)
+      cancelRequest.writeInt32BE(0, 8) // processID
+      cancelRequest.writeInt32BE(0, 12) // secretKey
+      socket.write(cancelRequest)
+
+      // Wait briefly for server to process (no response expected)
+      await new Promise((resolve) => setTimeout(resolve, 200))
+
+      socket.destroy()
+
+      // Verify server still works after receiving CancelRequest
+      const testClient = new Client(connectionConfig)
+      await testClient.connect()
+      const result = await testClient.query('SELECT 1 as one')
+      expect(result.rows[0].one).toBe(1)
+      await testClient.end()
+    })
   })
 
   describe('with extensions via CLI', () => {


### PR DESCRIPTION
## Summary

Adds handling for the PostgreSQL **CancelRequest** wire protocol message to `pglite-socket`.

> **Note:** This PR was originally for both SSLRequest and CancelRequest. SSLRequest handling has since landed on `main` via #990 (replies `'N'`), so this PR has been **rebased** and now adds only the remaining **CancelRequest** handling, adapted to match that PR's style (named constants + an extracted method) per review feedback.

- **CancelRequest** (code `80877102`): consume the 16-byte message and silently ignore it. PGLite has no backend process to signal, and the wire protocol expects no response.

## Motivation

CancelRequest, SSLRequest, and StartupMessage are all "untyped" startup-phase messages in the PostgreSQL wire protocol — no type-byte prefix, just `[length (int32 BE)][code (int32 BE)][...]`. Connection proxies (e.g. Cloudflare Hyperdrive) and standard clients can open a separate connection that begins with a CancelRequest.

Without explicit handling, a CancelRequest falls through to the typed-message parser, which reads byte 0 as a message type and bytes 1–4 as a length. For the 16-byte CancelRequest (`00 00 00 10 04 D2 16 2E ...`) this yields a bogus oversized length, so the message is buffered indefinitely and the connection stalls / the stream is corrupted. Consuming it explicitly during startup keeps the parser in a sane state.

## Changes

| File | Change |
|------|--------|
| `packages/pglite-socket/src/index.ts` | Add `CANCEL_REQUEST_CODE` / `CANCEL_REQUEST_LENGTH` constants and an extracted `handleCancelRequest()` method, called from the `handleData()` loop alongside the existing `handleSslRequest()` |
| `packages/pglite-socket/tests/query-with-node-pg.test.ts` | Add a CancelRequest resilience test |

The implementation mirrors `handleSslRequest()` from #990 — no magic numbers in the loop, logic extracted into a dedicated method — as requested in review.

## Tests

- **CancelRequest resilience**: opens a raw TCP socket, sends the 16-byte CancelRequest, confirms the server doesn't crash and still accepts a normal `pg.Client` connection afterward.

(SSLRequest is now covered by `tests/ssl-request.test.ts` from #990, so the SSLRequest-specific tests from the original version of this PR were removed.)

## Testing done

- [x] `pnpm build` — full build passes (ESM + CJS + DTS)
- [x] `pnpm test` — 61/61 pass
