### PR TITLE
docs: add esbuild bundler support section

### DIFF
--- a/docs/docs/bundler-support.md
+++ b/docs/docs/bundler-support.md
@@ -56,6 +56,32 @@ export const pglite = new PGliteWorker(
 )
 ```
 
+## esbuild
+
+[esbuild](https://esbuild.github.io/) does not support `new URL('./file', import.meta.url)` pattern that PGlite uses to locate its WebAssembly and data files. This means the automatic file resolution won't work out of the box.
+
+### Workaround: manually provide `wasmModule` and `fsBundle`
+
+1. Copy `pglite.wasm` and `pglite.data` from `node_modules/@electric-sql/pglite/dist/` to your public/build directory so your web server can serve them.
+
+2. Pass them manually when creating a PGlite instance:
+
+```ts
+import { PGlite } from '@electric-sql/pglite'
+
+const [wasmModule, fsBundle] = await Promise.all([
+  WebAssembly.compileStreaming(fetch('/pglite.wasm')),
+  fetch('/pglite.data').then((response) => response.blob()),
+])
+
+const db = await PGlite.create({
+  wasmModule,
+  fsBundle,
+})
+```
+
+Alternatively, you can use an esbuild plugin like [`@chialab/esbuild-plugin-meta-url`](https://chialab.github.io/rna/guide/esbuild-plugin-meta-url) to handle `new URL()` imports automatically.
+
 ## Next.js
 
 When using [Next.js](https://nextjs.org/), make sure to add `@electric-sql/pglite` to the `transpilePackages` array in `next.config.js`:


### PR DESCRIPTION
## Summary

Adds documentation for using PGlite with esbuild to the bundler support page.

## Problem

esbuild does not support the `new URL('./file', import.meta.url)` pattern that PGlite uses to locate its WASM and data files. Users hitting this issue have no guidance in the docs.

## Changes

- Added an **esbuild** section to `docs/docs/bundler-support.md`
- Documents the workaround of manually providing `wasmModule` and `fsBundle`
- Mentions the `@chialab/esbuild-plugin-meta-url` plugin as an alternative