### PR TITLE
Fix typo in CHANGELOG.md, default database 'postgres'

### DIFF
--- a/packages/pglite/CHANGELOG.md
+++ b/packages/pglite/CHANGELOG.md
@@ -7,7 +7,7 @@
 - d848955: New simplified PGlite with separate initdb.
   New included extension: pg_textsearch (experimental).
   New package for postgis (experimental) as extension.
-  Breaking changes: 'postgis' is the default database instead of 'template1'.
+  Breaking changes: 'postgres' is the default database instead of 'template1'.
 
 ## 0.3.16
 


### PR DESCRIPTION
Fix typo in CHANGELOG.md, default database 'postgres', not 'postgis'.