### PR TITLE
fix: exclude Electron renderer from IN_NODE detection

### DIFF
--- a/packages/pglite-utils/src/utils.ts
+++ b/packages/pglite-utils/src/utils.ts
@@ -1,7 +1,8 @@
 export const IN_NODE =
   typeof process === 'object' &&
   typeof process.versions === 'object' &&
-  typeof process.versions.node === 'string'
+  typeof process.versions.node === 'string' &&
+  !process.versions.electron
 
 const wasmDownloadPromises = new Map<URL, Promise<Response>>()
 


### PR DESCRIPTION
## Problem

`IN_NODE` is currently defined as:

```ts
export const IN_NODE =
  typeof process === 'object' &&
  typeof process.versions === 'object' &&
  typeof process.versions.node === 'string'
```

Electron exposes a full Node.js `process` object in renderer processes, including `process.versions.node` as a string. This causes `IN_NODE` to evaluate `true` in Electron renderers, which triggers the Node.js worker/filesystem code path instead of the browser WASM path — crashing the renderer.

Fixes #813

## Fix

Add a `!process.versions.electron` guard:

```ts
export const IN_NODE =
  typeof process === 'object' &&
  typeof process.versions === 'object' &&
  typeof process.versions.node === 'string' &&
  !process.versions.electron
```

In Electron, `process.versions.electron` is a version string (e.g. `"27.0.0"`), which is truthy, so `!process.versions.electron` is `false`. In a real Node.js process, `process.versions.electron` is `undefined`, so the guard passes.

This is a purely additive one-line change with no effect on any non-Electron environment.