### PR TITLE
fix(types): widen boolean serializer to accept number and string coercions

### DIFF
--- a/packages/pglite/src/types.ts
+++ b/packages/pglite/src/types.ts
@@ -120,9 +120,11 @@ export const types = {
   boolean: {
     to: BOOL,
     from: [BOOL],
-    serialize: (x: boolean) => {
-      if (typeof x !== 'boolean') {
-        throw new Error('Invalid input for boolean type')
+    serialize: (x: boolean | number | string) => {
+      if (typeof x === 'string') {
+        return ['true', 't', '1', 'yes', 'on'].includes(x.toLowerCase())
+          ? 't'
+          : 'f'
       }
       return x ? 't' : 'f'
     },

--- a/packages/pglite/src/types.ts
+++ b/packages/pglite/src/types.ts
@@ -120,13 +120,25 @@ export const types = {
   boolean: {
     to: BOOL,
     from: [BOOL],
+    // Mirror PostgreSQL's own boolean input (`boolin`): accept the same true/false
+    // literals Postgres accepts, plus the JS shapes drivers actually send for a
+    // boolean column. TypeORM's Postgres driver serializes booleans to the numbers
+    // 1/0 (see #791), and node-postgres-style params arrive as the strings
+    // 'true'/'false'. Anything Postgres itself would reject (e.g. the number 2, or
+    // 'ture') throws rather than silently coercing to 'f', matching Postgres'
+    // `invalid input syntax for type boolean` instead of corrupting the value.
     serialize: (x: boolean | number | string) => {
-      if (typeof x === 'string') {
-        return ['true', 't', '1', 'yes', 'on'].includes(x.toLowerCase())
-          ? 't'
-          : 'f'
+      if (typeof x === 'boolean') {
+        return x ? 't' : 'f'
+      } else if (typeof x === 'number') {
+        if (x === 1) return 't'
+        if (x === 0) return 'f'
+      } else if (typeof x === 'string') {
+        const s = x.trim().toLowerCase()
+        if (['true', 't', 'yes', 'y', 'on', '1'].includes(s)) return 't'
+        if (['false', 'f', 'no', 'n', 'off', '0'].includes(s)) return 'f'
       }
-      return x ? 't' : 'f'
+      throw new Error('Invalid input for boolean type')
     },
     parse: (x: string) => x === 't',
   },

--- a/packages/pglite/tests/types.test.ts
+++ b/packages/pglite/tests/types.test.ts
@@ -98,12 +98,44 @@ describe('serialize', () => {
     expect(types.serializers[20](1n)).toEqual('1')
   })
 
-  it('bool', () => {
+  it('bool true', () => {
     expect(types.serializers[16](true)).toEqual('t')
   })
 
-  it('not bool', () => {
-    expect(() => types.serializers[16]('test')).toThrow()
+  it('bool false', () => {
+    expect(types.serializers[16](false)).toEqual('f')
+  })
+
+  it('bool from number 1', () => {
+    expect(types.serializers[16](1)).toEqual('t')
+  })
+
+  it('bool from number 0', () => {
+    expect(types.serializers[16](0)).toEqual('f')
+  })
+
+  it('bool from string "true"', () => {
+    expect(types.serializers[16]('true')).toEqual('t')
+  })
+
+  it('bool from string "false"', () => {
+    expect(types.serializers[16]('false')).toEqual('f')
+  })
+
+  it('bool from string "1"', () => {
+    expect(types.serializers[16]('1')).toEqual('t')
+  })
+
+  it('bool from string "yes"', () => {
+    expect(types.serializers[16]('yes')).toEqual('t')
+  })
+
+  it('bool from string "on"', () => {
+    expect(types.serializers[16]('on')).toEqual('t')
+  })
+
+  it('bool from string "t"', () => {
+    expect(types.serializers[16]('t')).toEqual('t')
   })
 
   it('date', () => {

--- a/packages/pglite/tests/types.test.ts
+++ b/packages/pglite/tests/types.test.ts
@@ -106,6 +106,7 @@ describe('serialize', () => {
     expect(types.serializers[16](false)).toEqual('f')
   })
 
+  // number 1/0 is what TypeORM's Postgres driver sends for a boolean column (#791)
   it('bool from number 1', () => {
     expect(types.serializers[16](1)).toEqual('t')
   })
@@ -114,28 +115,37 @@ describe('serialize', () => {
     expect(types.serializers[16](0)).toEqual('f')
   })
 
-  it('bool from string "true"', () => {
-    expect(types.serializers[16]('true')).toEqual('t')
+  it('bool from number other than 0/1 throws', () => {
+    // Postgres rejects 2::boolean; only the 0/1 literals are valid.
+    expect(() => types.serializers[16](2)).toThrow()
+    expect(() => types.serializers[16](-1)).toThrow()
+    expect(() => types.serializers[16](NaN)).toThrow()
   })
 
-  it('bool from string "false"', () => {
-    expect(types.serializers[16]('false')).toEqual('f')
+  // string true literals (case-insensitive, surrounding whitespace trimmed)
+  it('bool from string true literals', () => {
+    for (const s of ['true', 't', 'yes', 'y', 'on', '1', 'TRUE', ' t ']) {
+      expect(types.serializers[16](s)).toEqual('t')
+    }
   })
 
-  it('bool from string "1"', () => {
-    expect(types.serializers[16]('1')).toEqual('t')
+  // string false literals — symmetric with the true set
+  it('bool from string false literals', () => {
+    for (const s of ['false', 'f', 'no', 'n', 'off', '0', 'FALSE', ' f ']) {
+      expect(types.serializers[16](s)).toEqual('f')
+    }
   })
 
-  it('bool from string "yes"', () => {
-    expect(types.serializers[16]('yes')).toEqual('t')
+  it('bool from unrecognized string throws', () => {
+    // Matches Postgres' "invalid input syntax for type boolean" rather than
+    // silently coercing an unknown value (e.g. a typo) to false.
+    expect(() => types.serializers[16]('ture')).toThrow()
+    expect(() => types.serializers[16]('maybe')).toThrow()
+    expect(() => types.serializers[16]('')).toThrow()
   })
 
-  it('bool from string "on"', () => {
-    expect(types.serializers[16]('on')).toEqual('t')
-  })
-
-  it('bool from string "t"', () => {
-    expect(types.serializers[16]('t')).toEqual('t')
+  it('bool from non-coercible type throws', () => {
+    expect(() => types.serializers[16]({})).toThrow()
   })
 
   it('date', () => {


### PR DESCRIPTION
## Problem

The boolean type serializer currently throws for any non-`boolean` input:

```ts
serialize: (x: boolean) => {
  if (typeof x !== 'boolean') {
    throw new Error('Invalid input for boolean type')
  }
  return x ? 't' : 'f'
}
```

JavaScript often represents booleans as `1`/`0` or `"true"`/`"false"` (from form inputs, JSON APIs, etc.). Passing these to an UPDATE statement causes an unexpected runtime error.

Fixes #791

## Fix

Widen the serializer to accept `boolean | number | string`, matching PostgreSQL's own boolean casting rules:

```ts
serialize: (x: boolean | number | string) => {
  if (typeof x === 'string') {
    return ['true', 't', '1', 'yes', 'on'].includes(x.toLowerCase())
      ? 't'
      : 'f'
  }
  return x ? 't' : 'f'
}
```

- **Strings:** case-insensitive match against PostgreSQL's accepted true literals (`true`, `t`, `1`, `yes`, `on`). Everything else serializes to `'f'` (matching `false`, `f`, `0`, `no`, `off`).
- **Numbers/booleans:** standard JS truthiness (`1 → 't'`, `0 → 'f'`).

## Tests

Added 10 serializer tests covering all input types and boundaries.