### PR TITLE
feat(react): add usePGliteOptional for use outside a provider

### DIFF
--- a/.changeset/usepglite-optional.md
+++ b/.changeset/usepglite-optional.md
@@ -1,0 +1,5 @@
+---
+'@electric-sql/pglite-react': minor
+---
+
+Add a `usePGliteOptional` hook that returns `null` instead of throwing when no `PGliteProvider` is mounted, for lazy, async, or conditional database loading (issue #878). The string-query form of the live query hooks (`useLiveQuery`, `useLiveIncrementalQuery`) now tolerates a not-yet-mounted provider, returning `undefined` until one is available instead of throwing. The existing `usePGlite()` fail-fast behavior and its return type are unchanged.

--- a/docs/docs/framework-hooks/react.md
+++ b/docs/docs/framework-hooks/react.md
@@ -54,6 +54,33 @@ const MyComponent = () => {
 }
 ```
 
+### usePGliteOptional
+
+`usePGlite` throws if it is called without a `PGliteProvider` ancestor. When the
+database is loaded lazily or asynchronously, components can render before the
+provider mounts. Use `usePGliteOptional` in that case: it returns `null` instead
+of throwing, so the UI can render a loading state until the database is ready.
+
+```ts
+import { usePGliteOptional } from "@electric-sql/pglite-react"
+
+const MyComponent = () => {
+  const db = usePGliteOptional()
+
+  if (!db) {
+    return <p>Loading database...</p>
+  }
+
+  return <button onClick={() => db.query("SELECT 1;")}>Run</button>
+}
+```
+
+The string-query form of the live query hooks (`useLiveQuery('SELECT ...')`,
+`useLiveIncrementalQuery`) is also safe to call before the provider mounts: it
+returns `undefined` until a `PGliteProvider` is available, then resolves to
+results automatically. (Passing a `LiveQuery` instance or promise directly does
+not depend on the provider and is unaffected.)
+
 ### makePGliteProvider
 
 The `makePGliteProvider` function returns a `PGliteProvider` component and a `usePGlite` hook with the specified type, which enables you to provide a PGlite instance with all added extensions and retain then namespaces and types added to it.

--- a/packages/pglite-react/README.md
+++ b/packages/pglite-react/README.md
@@ -12,6 +12,7 @@ The hooks this package provides are:
 
 - [PGliteProvider](https://pglite.dev/docs/framework-hooks/react#pgliteprovider): A Provider component to pass a PGlite instance to all child components for use with the other hooks.
 - [usePGlite](https://pglite.dev/docs/framework-hooks/react#usepglite): Retrieve the provided PGlite instance.
+- [usePGliteOptional](https://pglite.dev/docs/framework-hooks/react#usepgliteoptional): Retrieve the provided PGlite instance, or `null` when no provider is mounted yet.
 - [makePGliteProvider](https://pglite.dev/docs/framework-hooks/react#makepgliteprovider): Create typed instances of `PGliteProvider` and `usePGlite`.
 - [useLiveQuery](https://pglite.dev/docs/framework-hooks/react#uselivequery): Reactively re-render your component whenever the results of a live query change
 - [useLiveIncrementalQuery](https://pglite.dev/docs/framework-hooks/react#useliveincrementalquery): Reactively re-render your component whenever the results of a live query change by offloading the diff to PGlite

--- a/packages/pglite-react/src/hooks.ts
+++ b/packages/pglite-react/src/hooks.ts
@@ -1,7 +1,7 @@
 import type { LiveQuery, LiveQueryResults } from '@electric-sql/pglite/live'
 import { query as buildQuery } from '@electric-sql/pglite/template'
 import { useEffect, useRef, useState } from 'react'
-import { usePGlite } from './provider'
+import { usePGliteOptional } from './provider'
 
 function paramsEqual(
   a1: unknown[] | undefined | null,
@@ -22,7 +22,9 @@ function useLiveQueryImpl<T = { [key: string]: unknown }>(
   params: unknown[] | undefined | null,
   key?: string,
 ): Omit<LiveQueryResults<T>, 'affectedRows'> | undefined {
-  const db = usePGlite()
+  // Optional lookup: db is null when no PGliteProvider is mounted yet (e.g. the
+  // database is still loading). The string-query branch below guards on it.
+  const db = usePGliteOptional()
   const paramsRef = useRef(params)
   const liveQueryRef = useRef<LiveQuery<T> | undefined>(undefined)
   let liveQuery: LiveQuery<T> | undefined
@@ -50,6 +52,15 @@ function useLiveQueryImpl<T = { [key: string]: unknown }>(
       setResults(results)
     }
     if (typeof query === 'string') {
+      // No PGliteProvider mounted (db is null): clear any prior results and
+      // skip subscription, so the hook reports undefined rather than stale
+      // rows. The effect re-runs once a provider appears because db is in the
+      // dependency array.
+      if (!db) {
+        setResults(undefined)
+        return
+      }
+
       const ret =
         key !== undefined
           ? db.live.incrementalQuery<T>(query, currentParams, key, cb)

--- a/packages/pglite-react/src/provider.tsx
+++ b/packages/pglite-react/src/provider.tsx
@@ -10,37 +10,58 @@ type PGliteProvider<T extends PGliteWithLive> = (
   props: Props<T>,
 ) => React.JSX.Element
 type UsePGlite<T extends PGliteWithLive> = (db?: T) => T
+type UsePGliteOptional<T extends PGliteWithLive> = (db?: T) => T | null
 
 interface PGliteProviderSet<T extends PGliteWithLive> {
   PGliteProvider: PGliteProvider<T>
   usePGlite: UsePGlite<T>
+  usePGliteOptional: UsePGliteOptional<T>
 }
 
 /**
- * Create a typed set of {@link PGliteProvider} and {@link usePGlite}.
+ * Create a typed set of {@link PGliteProvider}, {@link usePGlite}, and
+ * {@link usePGliteOptional}.
  */
 function makePGliteProvider<T extends PGliteWithLive>(): PGliteProviderSet<T> {
   const ctx = createContext<T | undefined>(undefined)
+
+  // Returns the provided PGlite instance, or null when no PGliteProvider is
+  // mounted. Use this when a missing provider is an expected state, e.g. lazy,
+  // async, or conditional database loading (see issue #878). An explicit db
+  // argument always takes precedence.
+  const usePGliteOptional = ((db?: T) => {
+    const dbProvided = useContext(ctx)
+
+    // allow providing a db explicitly
+    if (db !== undefined) return db
+
+    return dbProvided ?? null
+  }) as UsePGliteOptional<T>
+
+  // Returns the provided PGlite instance, throwing if no PGliteProvider is
+  // mounted. This fail-fast behavior is the default; reach for
+  // usePGliteOptional when the provider may legitimately be absent.
+  const usePGlite = ((db?: T) => {
+    const dbProvided = usePGliteOptional(db)
+
+    if (!dbProvided)
+      throw new Error(
+        'No PGlite instance found, use PGliteProvider to provide one',
+      )
+
+    return dbProvided
+  }) as UsePGlite<T>
+
   return {
-    usePGlite: ((db?: T) => {
-      const dbProvided = useContext(ctx)
-
-      // allow providing a db explicitly
-      if (db !== undefined) return db
-
-      if (!dbProvided)
-        throw new Error(
-          'No PGlite instance found, use PGliteProvider to provide one',
-        )
-
-      return dbProvided
-    }) as UsePGlite<T>,
+    usePGlite,
+    usePGliteOptional,
     PGliteProvider: ({ children, db }: Props<T>) => {
       return <ctx.Provider value={db}>{children}</ctx.Provider>
     },
   }
 }
 
-const { PGliteProvider, usePGlite } = makePGliteProvider<PGliteWithLive>()
+const { PGliteProvider, usePGlite, usePGliteOptional } =
+  makePGliteProvider<PGliteWithLive>()
 
-export { makePGliteProvider, PGliteProvider, usePGlite }
+export { makePGliteProvider, PGliteProvider, usePGlite, usePGliteOptional }

--- a/packages/pglite-react/test/provider.test-d.tsx
+++ b/packages/pglite-react/test/provider.test-d.tsx
@@ -18,7 +18,7 @@ describe('provider', () => {
       },
     })
 
-    const { PGliteProvider, usePGlite } = makePGliteProvider<
+    const { PGliteProvider, usePGlite, usePGliteOptional } = makePGliteProvider<
       PGlite &
         PGliteInterfaceExtensions<{
           live: typeof live
@@ -33,6 +33,12 @@ describe('provider', () => {
     // @ts-expect-error cannot pass wrong type db to typed hook
     usePGlite(dbLive)
 
+    // @ts-expect-error cannot pass wrong type db to typed optional hook
+    usePGliteOptional(dbLive)
+
     expectTypeOf(usePGlite()).toEqualTypeOf<typeof dbLiveVector>()
+    expectTypeOf(usePGliteOptional()).toEqualTypeOf<
+      typeof dbLiveVector | null
+    >()
   })
 })

--- a/packages/pglite-react/test/provider.test.tsx
+++ b/packages/pglite-react/test/provider.test.tsx
@@ -4,7 +4,12 @@ import { waitFor } from '@testing-library/dom'
 import React from 'react'
 import { PGlite } from '@electric-sql/pglite'
 import { live, PGliteWithLive } from '@electric-sql/pglite/live'
-import { makePGliteProvider, PGliteProvider, usePGlite } from '../src'
+import {
+  makePGliteProvider,
+  PGliteProvider,
+  usePGlite,
+  usePGliteOptional,
+} from '../src'
 
 describe('provider', () => {
   it('can receive PGlite', async () => {
@@ -39,5 +44,28 @@ describe('provider', () => {
     const { result } = renderHook(() => usePGliteTyped(), { wrapper })
 
     await waitFor(() => expect(result.current).toBe(db))
+  })
+})
+
+describe('usePGlite / usePGliteOptional outside a provider', () => {
+  it('usePGlite() throws when no PGliteProvider is mounted', () => {
+    expect(() => renderHook(() => usePGlite())).toThrow(
+      'No PGlite instance found',
+    )
+  })
+
+  it('usePGliteOptional() returns null when no PGliteProvider is mounted', () => {
+    const { result } = renderHook(() => usePGliteOptional())
+    expect(result.current).toBeNull()
+  })
+
+  it('usePGliteOptional() does not throw when no PGliteProvider is mounted', () => {
+    expect(() => renderHook(() => usePGliteOptional())).not.toThrow()
+  })
+
+  it('usePGliteOptional(db) returns the db when one is passed directly', async () => {
+    const db = await PGlite.create({ extensions: { live } })
+    const { result } = renderHook(() => usePGliteOptional(db as PGliteWithLive))
+    expect(result.current).toBe(db)
   })
 })


### PR DESCRIPTION
## Problem

Calling `usePGlite()` without a `<PGliteProvider>` ancestor throws:

```
Error: No PGlite instance found, use PGliteProvider to provide one
```

When the database is created asynchronously (lazy load, code-split, optional feature), components can render before the provider mounts, and the throw crashes the tree. This is issue #878, with a second report in the thread.

## Approach

This revision keeps `usePGlite()` exactly as-is instead of changing its return type. `usePGlite(): T` still throws when no provider is mounted, so:

- every existing call site keeps working,
- the documented `const db = usePGlite(); db.query(...)` pattern still type-checks,
- the existing `provider.test-d.tsx` contract `expectTypeOf(usePGlite()).toEqualTypeOf<T>()` stays green.

It adds an opt-in escape hatch instead:

- **`usePGliteOptional(): T | null`** returns `null` rather than throwing when there is no provider. `makePGliteProvider()` returns it too, so typed providers get a typed optional hook.
- **Live query hooks**: `useLiveQueryImpl` now resolves the db with `usePGliteOptional()`. The string-query branch clears results and skips the subscription (reporting `undefined`) until a provider mounts, then subscribes automatically since `db` is in the effect deps. The `LiveQuery` and promise overloads are unchanged; they never needed the context db.

## Tests / docs

- `provider.test.tsx`: `usePGlite()` still throws outside a provider; `usePGliteOptional()` returns `null`, does not throw, and honors an explicit `db` argument.
- `provider.test-d.tsx`: adds `expectTypeOf(usePGliteOptional()).toEqualTypeOf<T | null>()` plus the wrong-extension `@ts-expect-error`, alongside the unchanged `usePGlite()` assertion.
- Docs + README: new `usePGliteOptional` section.
- Changeset: minor bump for `@electric-sql/pglite-react`.

Closes #878.
