### PR TITLE
fix(pglite-socket): propagate server startup errors from start()

### DIFF
--- a/packages/pglite-socket/src/index.ts
+++ b/packages/pglite-socket/src/index.ts
@@ -607,16 +607,19 @@ export class PGLiteSocketServer extends EventTarget {
     return new Promise<void>((resolve, reject) => {
       if (!this.server) return reject(new Error('Server not initialized'))
 
+      let listening = false
+
       this.server.on('error', (err) => {
         this.log(`start: server error:`, err)
         this.dispatchEvent(new CustomEvent('error', { detail: err }))
-        if (!this.active) {
+        if (!listening) {
           reject(err)
         }
       })
 
       if (this.path) {
         this.server.listen(this.path, () => {
+          listening = true
           this.log(`start: server listening on ${this.getServerConn()}`)
           this.dispatchEvent(
             new CustomEvent('listening', {
@@ -628,6 +631,7 @@ export class PGLiteSocketServer extends EventTarget {
       } else {
         const server = this.server
         server.listen(this.port, this.host, () => {
+          listening = true
           const address = server.address()
           // We are not using pipes, so return type should be AddressInfo
           if (address === null || typeof address !== 'object') {


### PR DESCRIPTION
## Summary

Fixes #964

`PGLiteSocketServer.start()` hangs forever when the underlying server fails to start (e.g. `EACCES`, `EADDRINUSE`). The error is logged and emitted via `CustomEvent`, but the Promise never rejects.

## Root Cause

The error handler checks `if (!this.active)` before calling `reject()`, but `this.active` is set to `true` at line 601 — **before** `server.listen()` is called. When `listen` emits an error, `!this.active` is `false`, so `reject()` is never reached.

## Fix

Replace the `this.active` check with a local `listening` flag that is only set to `true` inside the `listen` callback:

```ts
let listening = false

this.server.on('error', (err) => {
  // ...
  if (!listening) {
    reject(err)  // Always rejects for startup errors
  }
})

this.server.listen(this.path, () => {
  listening = true  // Only set after successful listen
  resolve()
})
```