### PR TITLE
Fix extended-query isolation for pooled postgres.js clients in pglite-socket

### DIFF
--- a/packages/pglite-socket/src/index.ts
+++ b/packages/pglite-socket/src/index.ts
@@ -1,3 +1,4 @@
+import { Parser as ProtocolParser } from '@electric-sql/pg-protocol'
 import type { PGlite } from '@electric-sql/pglite'
 import { type Server, type Socket, createServer } from 'net'
 
@@ -25,7 +26,7 @@ class QueryQueueManager {
   private processing = false
   private db: PGlite
   private debug: boolean
-  private lastHandlerId: null | number = null
+  private activeHandlerId: null | number = null
 
   constructor(db: PGlite, debug = false) {
     this.db = db
@@ -65,6 +66,55 @@ class QueryQueueManager {
     })
   }
 
+  private dequeueNextQuery(): null | QueuedQuery {
+    if (this.activeHandlerId === null) {
+      return this.queue.shift() ?? null
+    }
+
+    const index = this.queue.findIndex(
+      (query) => query.handlerId === this.activeHandlerId,
+    )
+
+    if (index === -1) {
+      this.log(
+        `waiting for more protocol messages from handler #${this.activeHandlerId}`,
+      )
+      return null
+    }
+
+    return this.queue.splice(index, 1)[0]
+  }
+
+  private updateActiveHandler(
+    handlerId: number,
+    readyForQueryStatus: null | string,
+    message: Uint8Array,
+  ): void {
+    if (readyForQueryStatus === 'I') {
+      this.log(`handler #${handlerId} released protocol ownership`)
+      this.activeHandlerId = null
+      return
+    }
+
+    if (readyForQueryStatus === null && message[0] === 0x58) {
+      this.log(`handler #${handlerId} released protocol ownership on terminate`)
+      this.activeHandlerId = null
+      return
+    }
+
+    this.activeHandlerId = handlerId
+
+    if (readyForQueryStatus) {
+      this.log(
+        `handler #${handlerId} retained protocol ownership with ReadyForQuery status ${readyForQueryStatus}`,
+      )
+    } else {
+      this.log(
+        `handler #${handlerId} retained protocol ownership until ReadyForQuery`,
+      )
+    }
+  }
+
   private async processQueue(): Promise<void> {
     if (this.processing || this.queue.length === 0) {
       return
@@ -72,59 +122,59 @@ class QueryQueueManager {
 
     this.processing = true
 
-    while (this.queue.length > 0) {
-      let query
+    try {
+      while (this.queue.length > 0) {
+        const query = this.dequeueNextQuery()
+        if (!query) break
 
-      if (this.db.isInTransaction() && this.lastHandlerId) {
-        const i = this.queue.findIndex(
-          (q) => q.handlerId === this.lastHandlerId,
+        const waitTime = Date.now() - query.timestamp
+        this.log(
+          `processing query from handler #${query.handlerId} (waited ${waitTime}ms)`,
         )
-        if (i === -1) {
-          // we didn't find any other query from the same client!
-          this.log(
-            `transaction started, but no query from the same handler id found in queue`,
-            this.lastHandlerId,
-          )
-          query = null
-        } else {
-          query = this.queue.splice(i, 1)[0]
-        }
-      } else {
-        query = this.queue.shift()
-      }
-      if (!query) break
 
-      const waitTime = Date.now() - query.timestamp
-      this.log(
-        `processing query from handler #${query.handlerId} (waited ${waitTime}ms)`,
-      )
+        let result = 0
+        let readyForQueryStatus: null | string = null
+        const parser = new ProtocolParser()
 
-      let result = 0
-      try {
-        // Execute the query with exclusive access to PGlite
-        await this.db.runExclusive(async () => {
-          return await this.db.execProtocolRawStream(query.message, {
-            onRawData: (data) => {
-              result += data.length
-              query.onData(data)
-            },
+        try {
+          // Keep one handler attached to the backend until it reaches a
+          // ReadyForQuery boundary so extended-protocol state can't interleave.
+          await this.db.runExclusive(async () => {
+            return await this.db.execProtocolRawStream(query.message, {
+              onRawData: (data) => {
+                result += data.length
+                parser.parse(data, (message) => {
+                  if (message.name === 'readyForQuery') {
+                    readyForQueryStatus = message.status
+                  }
+                })
+                query.onData(data)
+              },
+            })
           })
-        })
-      } catch (error) {
-        this.log(`query from handler #${query.handlerId} failed:`, error)
-        query.reject(error as Error)
-        return
+        } catch (error) {
+          this.log(`query from handler #${query.handlerId} failed:`, error)
+          if (this.activeHandlerId === query.handlerId) {
+            this.activeHandlerId = null
+          }
+          query.reject(error as Error)
+          continue
+        }
+
+        this.log(
+          `query from handler #${query.handlerId} completed, ${result} bytes`,
+        )
+        this.updateActiveHandler(
+          query.handlerId,
+          readyForQueryStatus,
+          query.message,
+        )
+        query.resolve(result)
       }
-
-      this.log(
-        `query from handler #${query.handlerId} completed, ${result} bytes`,
-      )
-      this.lastHandlerId = query.handlerId
-      query.resolve(result)
+    } finally {
+      this.processing = false
+      this.log(`queue processing complete, queue length is`, this.queue.length)
     }
-
-    this.processing = false
-    this.log(`queue processing complete, queue length is`, this.queue.length)
   }
 
   getQueueLength(): number {
@@ -147,11 +197,16 @@ class QueryQueueManager {
   }
 
   async clearTransactionIfNeeded(handlerId: number): Promise<void> {
-    if (this.db.isInTransaction() && this.lastHandlerId === handlerId) {
-      await this.db.exec('ROLLBACK')
-      this.lastHandlerId = null
-      await this.processQueue()
+    if (this.activeHandlerId !== handlerId) {
+      return
     }
+
+    if (this.db.isInTransaction()) {
+      await this.db.exec('ROLLBACK')
+    }
+
+    this.activeHandlerId = null
+    await this.processQueue()
   }
 }
 

--- a/packages/pglite-socket/tests/query-with-postgres-js-concurrency.test.ts
+++ b/packages/pglite-socket/tests/query-with-postgres-js-concurrency.test.ts
@@ -1,0 +1,55 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import postgres from 'postgres'
+import { PGlite } from '@electric-sql/pglite'
+import { PGLiteSocketServer } from '../src'
+
+const TEST_PORT = 5435
+
+describe('PGLite Socket Server concurrency regression', () => {
+  let db: PGlite
+  let server: PGLiteSocketServer
+  let sql: ReturnType<typeof postgres>
+
+  beforeAll(async () => {
+    db = await PGlite.create()
+    await db.waitReady
+
+    server = new PGLiteSocketServer({
+      db,
+      host: '127.0.0.1',
+      port: TEST_PORT,
+      maxConnections: 10,
+    })
+
+    await server.start()
+
+    sql = postgres({
+      host: '127.0.0.1',
+      port: TEST_PORT,
+      database: 'postgres',
+      username: 'postgres',
+      password: 'postgres',
+      idle_timeout: 5,
+      connect_timeout: 10,
+      max: 10,
+    })
+  })
+
+  afterAll(async () => {
+    await sql?.end({ timeout: 1 }).catch(() => {})
+    await server?.stop().catch(() => {})
+    await db?.close().catch(() => {})
+  })
+
+  it('keeps extended protocol state isolated across pooled connections', async () => {
+    for (let i = 0; i < 20; i++) {
+      const [valueResult, timezoneResult] = await Promise.all([
+        sql.unsafe('select $1::int as value', [i]),
+        sql.unsafe("select current_setting('timezone') as timezone", []),
+      ])
+
+      expect(valueResult[0].value).toBe(i)
+      expect(typeof timezoneResult[0].timezone).toBe('string')
+    }
+  })
+})


### PR DESCRIPTION
## Summary

This fixes a protocol-isolation bug in `packages/pglite-socket` that shows up when a `postgres.js` pool uses multiple concurrent connections against `PGLiteSocketServer`.

The core problem was that the socket server queued and scheduled individual frontend protocol messages globally across handlers, but only pinned handler ownership while `db.isInTransaction()` was true. That is not enough for the PostgreSQL extended query protocol, because unnamed prepared-statement state lives until the backend reaches `ReadyForQuery`, not only while SQL transaction state is open.

In practice, message sequences like `Parse` / `Bind` / `Execute` / `Sync` from different logical clients could interleave against the same backend session state. That produced errors like:

- `PostgresError: unnamed prepared statement does not exist`
- `code: 26000`
- `routine: exec_bind_message`

## How we hit this

I ran into this while working on a Prisma Dev / Durable Streams demo that used a PGlite-backed Postgres runtime behind `pglite-socket`.

When opening Prisma Studio against that runtime, the first load would sometimes show a red `introspect` error and then succeed on refresh. Prisma Studio uses `postgres.js`, and its initial page load issues concurrent metadata/introspection-style queries. One of the concurrent queries is a timezone read:

```sql
select current_setting('timezone') as timezone
```

Against `pglite-socket`, that concurrent startup pattern could fail even though the same queries worked:

- sequentially
- or with a client pool forced to `max: 1`

That suggested the bug was below Prisma Dev and below the WAL/Streams layer.

## Reproduction

I isolated this down to plain `PGLiteSocketServer`, with no Prisma Dev and no WAL stream involved.

### Studio-shaped repro observed during investigation

The failure pattern that matched Prisma Studio was:

1. Start `PGLiteSocketServer({ maxConnections: 10 })`
2. Open `postgres(url, { max: 10 })`
3. Run concurrently from the same pool:
   - a metadata/catalog query
   - `select current_setting('timezone') as timezone`
4. Observe `26000 / exec_bind_message`

### Regression test added in this PR

For a stable package test, this PR adds a smaller repro that isolates the same protocol bug without depending on Prisma internals:

- `sql.unsafe('select $1::int as value', [i])`
- `sql.unsafe("select current_setting('timezone') as timezone", [])`

run concurrently through a `postgres.js` pool with `max: 10`.

Before this fix, that failed reliably in local verification. After this fix, it passes consistently.

## Root cause

`QueryQueueManager` was effectively serializing individual frontend messages, not whole extended-query exchanges.

That meant handler A could send `Parse` and then handler B could get scheduled before handler A reached `Sync` / `ReadyForQuery`. Because the backend session is shared, the unnamed statement/portal state could be overwritten or cleared before handler A's later `Bind` / `Execute`, which explains the `unnamed prepared statement does not exist` failure.

## Fix

This change introduces handler ownership at the protocol level:

- track an `activeHandlerId`
- once a handler starts an extended-protocol exchange, keep scheduling its queued protocol messages ahead of other handlers
- parse backend responses and retain ownership until the backend emits `ReadyForQuery`
- release ownership when `ReadyForQuery` returns to idle (`I`)
- also release ownership on `Terminate` packets so shutdown/connection close does not strand other queued work

This keeps logical client state isolated even though the underlying backend session is shared.

## Verification

Ran:

```sh
pnpm --filter @electric-sql/pglite-socket exec vitest tests/query-with-postgres-js-concurrency.test.ts
pnpm --filter @electric-sql/pglite-socket exec vitest
```

Result locally:

- new regression test passes
- full `pglite-socket` suite passes (`60` tests)

## Files

- `packages/pglite-socket/src/index.ts`
- `packages/pglite-socket/tests/query-with-postgres-js-concurrency.test.ts`

If helpful, I can also add a second regression that uses a more Studio-shaped catalog query pair, but I kept the committed test minimal and protocol-focused.