### PR TITLE
Fix pglite-socket maxConnections JSDoc default (1, not 100)

### DIFF
--- a/.changeset/fix-pglite-socket-maxconn-jsdoc.md
+++ b/.changeset/fix-pglite-socket-maxconn-jsdoc.md
@@ -1,0 +1,5 @@
+---
+'@electric-sql/pglite-socket': patch
+---
+
+Fix `PGLiteSocketServer` `maxConnections` JSDoc default — the constructor defaults to `1` (matching the CLI default and help text); only the JSDoc claimed `100`.

--- a/packages/pglite-socket/src/index.ts
+++ b/packages/pglite-socket/src/index.ts
@@ -530,7 +530,7 @@ export interface PGLiteSocketServerOptions {
   debug?: boolean
   /** Idle timeout in ms (0 to disable, default: 0) */
   idleTimeout?: number
-  /** Maximum concurrent connections (default: 100) */
+  /** Maximum concurrent connections (default: 1) */
   maxConnections?: number
 }
 


### PR DESCRIPTION
Tiny one: fixes a stale JSDoc in `pglite-socket`. The doc on `PGLiteSocketServerOptions.maxConnections` claims `(default: 100)`, but the constructor actually defaults to `1`. Three nearby spots agree the real default is `1`:

- `src/index.ts:572` — `this.maxConnections = options.maxConnections ?? 1`
- `src/scripts/server.ts:67` — CLI flag `default: '1'`
- `src/scripts/server.ts:94` — help text `--max-connections=N ... (default is no concurrency: 1)`

#902 later locked in the same wording across the README, so `1` is clearly the intended story — the JSDoc just needs to be brought up to speed, too. And both the docstring and the runtime default went in together in #873, so this is a same-PR typo rather than drift over time.

To reproduce:

```ts
const s = new PGLiteSocketServer({ db, path: '/tmp/foo' })
console.log(s.getStats().maxConnections) // → 1, not 100
```

Hope it saves the next person a head-scratch.