### PR TITLE
Fix/pglite socket ssl request

### DIFF
--- a/.changeset/fix-pglite-socket-ssl-request.md
+++ b/.changeset/fix-pglite-socket-ssl-request.md
@@ -1,0 +1,5 @@
+---
+'@electric-sql/pglite-socket': patch
+---
+
+Reply `N` to the PostgreSQL `SSLRequest` packet when SSL is not supported, preventing mis-parsing and hung connections from clients that probe TLS before `StartupMessage` (e.g. Navicat, libpq defaults).

--- a/.changeset/fix-pglite-socket-ssl-request.md
+++ b/.changeset/fix-pglite-socket-ssl-request.md
@@ -2,4 +2,4 @@
 '@electric-sql/pglite-socket': patch
 ---
 
-Reply `N` to the PostgreSQL `SSLRequest` packet when SSL is not supported, preventing mis-parsing and hung connections from clients that probe TLS before `StartupMessage` (e.g. Navicat, libpq defaults).
+Handle the `SSLRequest` startup packet per the PostgreSQL wire protocol: when SSL is not available, respond with `N` so the client may continue with a cleartext `StartupMessage`. See https://www.postgresql.org/docs/current/protocol-message-formats.html .

--- a/.changeset/fix-pglite-socket-ssl-request.md
+++ b/.changeset/fix-pglite-socket-ssl-request.md
@@ -2,4 +2,4 @@
 '@electric-sql/pglite-socket': patch
 ---
 
-Handle the `SSLRequest` startup packet per the PostgreSQL wire protocol: when SSL is not available, respond with `N` so the client may continue with a cleartext `StartupMessage`. See https://www.postgresql.org/docs/current/protocol-message-formats.html .
+Handle the `SSLRequest` startup packet per the PostgreSQL wire protocol: when SSL is not available, respond with `N` so the client may continue with a cleartext `StartupMessage`. Improves interoperability with JDBC clients such as DBeaver that probe TLS first without requiring manual SSL mode tweaks. See https://www.postgresql.org/docs/current/protocol-message-formats.html .

--- a/packages/pglite-socket/src/index.ts
+++ b/packages/pglite-socket/src/index.ts
@@ -3,6 +3,8 @@ import { type Server, type Socket, createServer } from 'net'
 
 // Connection queue timeout in milliseconds
 export const CONNECTION_QUEUE_TIMEOUT = 60000 // 60 seconds
+export const SSL_REQUEST_CODE = 80877103
+export const SSL_REQUEST_LENGTH = 8
 
 /**
  * Represents a queued query waiting for PGlite access
@@ -325,6 +327,25 @@ export class PGLiteSocketHandler extends EventTarget {
     return this.socket !== null
   }
 
+  private handleSslRequest(): boolean {
+    if (this.messageBuffer.length < SSL_REQUEST_LENGTH) {
+      return false
+    }
+
+    const len = this.messageBuffer.readInt32BE(0)
+    const code = this.messageBuffer.readInt32BE(4)
+
+    if (len === SSL_REQUEST_LENGTH && code === SSL_REQUEST_CODE) {
+      if (this.socket?.writable) {
+        this.socket.write(Buffer.from('N'))
+      }
+      this.messageBuffer = this.messageBuffer.slice(SSL_REQUEST_LENGTH)
+      return true
+    }
+
+    return false
+  }
+
   private async handleData(data: Buffer): Promise<number> {
     if (!this.socket || !this.active) {
       this.log(`handleData: no active socket, ignoring data`)
@@ -343,21 +364,8 @@ export class PGLiteSocketHandler extends EventTarget {
       let totalProcessed = 0
 
       while (this.messageBuffer.length > 0) {
-        // SSLRequest: first Int32 is length (8); second Int32 is fixed 80877103.
-        // This and other frontend/backend message layouts are specified in PostgreSQL docs:
-        // https://www.postgresql.org/docs/current/protocol-message-formats.html
-        // Rules: server must reply 'S' or 'N' before the client sends StartupMessage.
-        // pglite-socket has no TLS/SSL, so always 'N' (decline SSL).
-        if (this.messageBuffer.length >= 8) {
-          const len = this.messageBuffer.readInt32BE(0)
-          const code = this.messageBuffer.readInt32BE(4)
-          if (len === 8 && code === 80877103) {
-            if (this.socket?.writable) {
-              this.socket.write(Buffer.from('N'))
-            }
-            this.messageBuffer = this.messageBuffer.slice(8)
-            continue
-          }
+        if (this.handleSslRequest()) {
+          continue
         }
 
         // Determine message length

--- a/packages/pglite-socket/src/index.ts
+++ b/packages/pglite-socket/src/index.ts
@@ -343,11 +343,13 @@ export class PGLiteSocketHandler extends EventTarget {
       let totalProcessed = 0
 
       while (this.messageBuffer.length > 0) {
-        // SSLRequest: length 8, second int 80877103 (PostgreSQL protocol). Many
-        // clients send this before StartupMessage. Server must reply 'N' when SSL
-        // is not supported (pglite-socket has no TLS). Without handling it here,
-        // the packet is mis-parsed as a typed frontend message and the connection
-        // stalls (e.g. Navicat “test connection” never completing).
+        // SSLRequest: Int32 length 8 then Int32(80877103). Documented alongside
+        // other protocol message layouts in PostgreSQL docs (see
+        // https://www.postgresql.org/docs/current/protocol-message-formats.html ).
+        // The backend must send 'S' or 'N' before the client sends StartupMessage;
+        // pglite-socket has no TLS, so we reply 'N'. Without this branch the
+        // eight bytes are mis-parsed as a typed frontend message and the reader
+        // waits indefinitely for a complete packet.
         if (this.messageBuffer.length >= 8) {
           const len = this.messageBuffer.readInt32BE(0)
           const code = this.messageBuffer.readInt32BE(4)

--- a/packages/pglite-socket/src/index.ts
+++ b/packages/pglite-socket/src/index.ts
@@ -343,21 +343,15 @@ export class PGLiteSocketHandler extends EventTarget {
       let totalProcessed = 0
 
       while (this.messageBuffer.length > 0) {
-        // SSLRequest: Int32 length 8 then Int32(80877103). Documented alongside
-        // other protocol message layouts in PostgreSQL docs (see
-        // https://www.postgresql.org/docs/current/protocol-message-formats.html ).
-        // The backend must send 'S' or 'N' before the client sends StartupMessage;
-        // pglite-socket has no TLS, so we reply 'N'. JDBC stacks used by tools
-        // such as DBeaver typically send SSLRequest first; answering 'N' completes
-        // that negotiation so StartupMessage follows over cleartext without asking
-        // users to manually disable SSL mode. Without this branch the eight bytes
-        // are mis-parsed as a typed frontend message and the reader waits
-        // indefinitely for a complete packet.
+        // SSLRequest: first Int32 is length (8); second Int32 is fixed 80877103.
+        // This and other frontend/backend message layouts are specified in PostgreSQL docs:
+        // https://www.postgresql.org/docs/current/protocol-message-formats.html
+        // Rules: server must reply 'S' or 'N' before the client sends StartupMessage.
+        // pglite-socket has no TLS/SSL, so always 'N' (decline SSL).
         if (this.messageBuffer.length >= 8) {
           const len = this.messageBuffer.readInt32BE(0)
           const code = this.messageBuffer.readInt32BE(4)
           if (len === 8 && code === 80877103) {
-            this.log('handleData: SSLRequest, replying N (SSL not supported)')
             if (this.socket?.writable) {
               this.socket.write(Buffer.from('N'))
             }

--- a/packages/pglite-socket/src/index.ts
+++ b/packages/pglite-socket/src/index.ts
@@ -343,6 +343,24 @@ export class PGLiteSocketHandler extends EventTarget {
       let totalProcessed = 0
 
       while (this.messageBuffer.length > 0) {
+        // SSLRequest: length 8, second int 80877103 (PostgreSQL protocol). Many
+        // clients send this before StartupMessage. Server must reply 'N' when SSL
+        // is not supported (pglite-socket has no TLS). Without handling it here,
+        // the packet is mis-parsed as a typed frontend message and the connection
+        // stalls (e.g. Navicat “test connection” never completing).
+        if (this.messageBuffer.length >= 8) {
+          const len = this.messageBuffer.readInt32BE(0)
+          const code = this.messageBuffer.readInt32BE(4)
+          if (len === 8 && code === 80877103) {
+            this.log('handleData: SSLRequest, replying N (SSL not supported)')
+            if (this.socket?.writable) {
+              this.socket.write(Buffer.from('N'))
+            }
+            this.messageBuffer = this.messageBuffer.slice(8)
+            continue
+          }
+        }
+
         // Determine message length
         let messageLength = 0
         let isComplete = false

--- a/packages/pglite-socket/src/index.ts
+++ b/packages/pglite-socket/src/index.ts
@@ -347,9 +347,12 @@ export class PGLiteSocketHandler extends EventTarget {
         // other protocol message layouts in PostgreSQL docs (see
         // https://www.postgresql.org/docs/current/protocol-message-formats.html ).
         // The backend must send 'S' or 'N' before the client sends StartupMessage;
-        // pglite-socket has no TLS, so we reply 'N'. Without this branch the
-        // eight bytes are mis-parsed as a typed frontend message and the reader
-        // waits indefinitely for a complete packet.
+        // pglite-socket has no TLS, so we reply 'N'. JDBC stacks used by tools
+        // such as DBeaver typically send SSLRequest first; answering 'N' completes
+        // that negotiation so StartupMessage follows over cleartext without asking
+        // users to manually disable SSL mode. Without this branch the eight bytes
+        // are mis-parsed as a typed frontend message and the reader waits
+        // indefinitely for a complete packet.
         if (this.messageBuffer.length >= 8) {
           const len = this.messageBuffer.readInt32BE(0)
           const code = this.messageBuffer.readInt32BE(4)

--- a/packages/pglite-socket/tests/ssl-request.test.ts
+++ b/packages/pglite-socket/tests/ssl-request.test.ts
@@ -1,8 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { PGLiteSocketHandler } from '../src'
+import {
+  PGLiteSocketHandler,
+  SSL_REQUEST_CODE,
+  SSL_REQUEST_LENGTH,
+} from '../src'
 
 /** Second Int32 of SSLRequest — https://www.postgresql.org/docs/current/protocol-message-formats.html */
-const PG_PROTOCOL_SSL_REQUEST_CODE = 80877103
 
 function createNetSocketStub() {
   const eventHandlers: Record<string, Array<(data?: unknown) => void>> = {}
@@ -63,9 +66,9 @@ describe('PGLiteSocketHandler PostgreSQL SSLRequest (protocol-message-formats)',
   it("consumes SSLRequest (8 bytes) and writes 'N' without queueing PGlite protocol", async () => {
     await handler.attach(socketStub)
 
-    const sslRequest = Buffer.alloc(8)
-    sslRequest.writeInt32BE(8, 0)
-    sslRequest.writeInt32BE(PG_PROTOCOL_SSL_REQUEST_CODE, 4)
+    const sslRequest = Buffer.alloc(SSL_REQUEST_LENGTH)
+    sslRequest.writeInt32BE(SSL_REQUEST_LENGTH, 0)
+    sslRequest.writeInt32BE(SSL_REQUEST_CODE, 4)
     socketStub.emit('data', sslRequest)
 
     await flushEventLoop()

--- a/packages/pglite-socket/tests/ssl-request.test.ts
+++ b/packages/pglite-socket/tests/ssl-request.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { PGLiteSocketHandler } from '../src'
+
+/** Second int32 in PostgreSQL SSLRequest packet */
+const PG_PROTOCOL_SSL_REQUEST_CODE = 80877103
+
+function createNetSocketStub() {
+  const eventHandlers: Record<string, Array<(data?: unknown) => void>> = {}
+  const socket = {
+    writable: true,
+    remoteAddress: '127.0.0.1',
+    remotePort: 12345,
+    setNoDelay: vi.fn(),
+    write: vi.fn(),
+    removeAllListeners: vi.fn(),
+    end: vi.fn(),
+    destroy: vi.fn(),
+    on: vi.fn((event: string, callback: (data?: unknown) => void) => {
+      if (!eventHandlers[event]) eventHandlers[event] = []
+      eventHandlers[event].push(callback)
+      return socket
+    }),
+    emit(event: string, data?: unknown) {
+      eventHandlers[event]?.forEach((h) => h(data))
+    },
+  }
+  return socket as any
+}
+
+function createQueryQueueStub() {
+  return {
+    enqueue: vi.fn().mockResolvedValue(0),
+    clearQueueForHandler: vi.fn(),
+    clearTransactionIfNeeded: vi.fn().mockResolvedValue(undefined),
+    getQueueLength: vi.fn().mockReturnValue(0),
+  }
+}
+
+async function flushEventLoop(): Promise<void> {
+  await new Promise<void>((r) => setImmediate(r))
+  await new Promise<void>((r) => setImmediate(r))
+}
+
+describe('PGLiteSocketHandler SSL negotiation', () => {
+  let handler: PGLiteSocketHandler
+  let socketStub: ReturnType<typeof createNetSocketStub>
+  let queryQueueStub: ReturnType<typeof createQueryQueueStub>
+
+  beforeEach(() => {
+    queryQueueStub = createQueryQueueStub()
+    handler = new PGLiteSocketHandler({
+      queryQueue: queryQueueStub as any,
+    })
+    socketStub = createNetSocketStub()
+  })
+
+  afterEach(async () => {
+    if (handler?.isAttached) {
+      await handler.detach(true)
+    }
+  })
+
+  it("consumes SSLRequest (8 bytes) and writes 'N' without queueing PGlite protocol", async () => {
+    await handler.attach(socketStub)
+
+    const sslRequest = Buffer.alloc(8)
+    sslRequest.writeInt32BE(8, 0)
+    sslRequest.writeInt32BE(PG_PROTOCOL_SSL_REQUEST_CODE, 4)
+    socketStub.emit('data', sslRequest)
+
+    await flushEventLoop()
+
+    expect(socketStub.write).toHaveBeenCalledWith(Buffer.from('N'))
+    expect(queryQueueStub.enqueue).not.toHaveBeenCalled()
+  })
+})

--- a/packages/pglite-socket/tests/ssl-request.test.ts
+++ b/packages/pglite-socket/tests/ssl-request.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { PGLiteSocketHandler } from '../src'
 
-/** Second int32 in PostgreSQL SSLRequest packet */
+/** Second Int32 of SSLRequest — https://www.postgresql.org/docs/current/protocol-message-formats.html */
 const PG_PROTOCOL_SSL_REQUEST_CODE = 80877103
 
 function createNetSocketStub() {
@@ -41,7 +41,7 @@ async function flushEventLoop(): Promise<void> {
   await new Promise<void>((r) => setImmediate(r))
 }
 
-describe('PGLiteSocketHandler SSL negotiation', () => {
+describe('PGLiteSocketHandler PostgreSQL SSLRequest (protocol-message-formats)', () => {
   let handler: PGLiteSocketHandler
   let socketStub: ReturnType<typeof createNetSocketStub>
   let queryQueueStub: ReturnType<typeof createQueryQueueStub>


### PR DESCRIPTION
#989 
Handle the `SSLRequest` startup packet per the PostgreSQL wire protocol: when SSL is not available, respond with `N` so the client may continue with a cleartext `StartupMessage`. Improves interoperability with JDBC clients such as DBeaver that probe TLS first without requiring manual SSL mode tweaks. See https://www.postgresql.org/docs/current/protocol-message-formats.html .