### PR TITLE
Update Postgres source links to newer repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ And follow the instructions to create an appropriate changeset. Please ensure an
 
 ## Acknowledgments
 
-PGlite builds on the work of [Stas Kelvich](https://github.com/kelvich) of [Neon](https://neon.tech) in this [Postgres fork](https://github.com/electric-sql/postgres-wasm).
+PGlite builds on the work of [Stas Kelvich](https://github.com/kelvich) of [Neon](https://neon.tech) in this [Postgres fork](https://github.com/electric-sql/postgres-pglite).
 
 ## Sponsors
 
@@ -193,4 +193,4 @@ Big shoutout to everybody supporting us!
 
 PGlite is dual-licensed under the terms of the [Apache License 2.0](https://github.com/electric-sql/pglite/blob/main/LICENSE) and the [PostgreSQL License](https://github.com/electric-sql/pglite/blob/main/POSTGRES-LICENSE), you can choose which you prefer.
 
-Changes to the [Postgres source](https://github.com/electric-sql/postgres-wasm) are licensed under the PostgreSQL License.
+Changes to the [Postgres source](https://github.com/electric-sql/postgres-pglite) are licensed under the PostgreSQL License.

--- a/packages/pglite/README.md
+++ b/packages/pglite/README.md
@@ -180,10 +180,10 @@ And follow the instructions to create an appropriate changeset. Please ensure an
 
 ## Acknowledgments
 
-PGlite builds on the work of [Stas Kelvich](https://github.com/kelvich) of [Neon](https://neon.tech) in this [Postgres fork](https://github.com/electric-sql/postgres-wasm).
+PGlite builds on the work of [Stas Kelvich](https://github.com/kelvich) of [Neon](https://neon.tech) in this [Postgres fork](https://github.com/electric-sql/postgres-pglite).
 
 ## License
 
 PGlite is dual-licensed under the terms of the [Apache License 2.0](https://github.com/electric-sql/pglite/blob/main/LICENSE) and the [PostgreSQL License](https://github.com/electric-sql/pglite/blob/main/POSTGRES-LICENSE), you can choose which you prefer.
 
-Changes to the [Postgres source](https://github.com/electric-sql/postgres-wasm) are licensed under the PostgreSQL License.
+Changes to the [Postgres source](https://github.com/electric-sql/postgres-pglite) are licensed under the PostgreSQL License.


### PR DESCRIPTION
This updates a few remaining links I noticed while browsing to point to the newer Postgres source repo used to build PGlite.