### PR TITLE
Fix serializing a Date on an untyped text parameter

### DIFF
--- a/.changeset/serialize-date-text-param.md
+++ b/.changeset/serialize-date-text-param.md
@@ -1,0 +1,5 @@
+---
+'@electric-sql/pglite': patch
+---
+
+fix serializing a Date passed to an untyped (text) parameter

--- a/packages/pglite/src/types.ts
+++ b/packages/pglite/src/types.ts
@@ -75,11 +75,13 @@ export const types = {
   string: {
     to: TEXT,
     from: [TEXT, VARCHAR, BPCHAR],
-    serialize: (x: string | number) => {
+    serialize: (x: string | number | Date) => {
       if (typeof x === 'string') {
         return x
       } else if (typeof x === 'number') {
         return x.toString()
+      } else if (x instanceof Date) {
+        return x.toISOString()
       } else {
         throw new Error('Invalid input for string type')
       }

--- a/packages/pglite/tests/types.test.ts
+++ b/packages/pglite/tests/types.test.ts
@@ -85,6 +85,12 @@ describe('serialize', () => {
     expect(types.serializers[25](1)).toEqual('1')
   })
 
+  it('string from date', () => {
+    expect(types.serializers[25](new Date('2021-01-01T00:00:00.000Z'))).toEqual(
+      '2021-01-01T00:00:00.000Z',
+    )
+  })
+
   it('not string', () => {
     expect(() => types.serializers[25](true)).toThrow()
   })


### PR DESCRIPTION
Fixes #1021.

## What broke

Passing a JS `Date` to a placeholder with no concrete type, like a bare `select $1`, throws `Invalid input for string type` before the query runs. A cast (`select $1::timestamp`) or a column context works, and so does passing a pre-serialized ISO string, so the failure is specific to the absence of type context.

```js
const db = new PGlite()
await db.query('select $1 as result', [new Date('2024-01-15T12:34:56Z')])
// throws: Invalid input for string type
```

## Root cause

When a parameter has no concrete type, Postgres infers it as `text`, so the bound value goes through the `text`/`string` serializer in `packages/pglite/src/types.ts`. That serializer only accepts `string` and `number` and throws on everything else, including a `Date`. The wire-protocol drivers (`pg`, `postgres`) don't hit this because they stringify the `Date` to an ISO-8601 string on the client before it reaches the server, and Postgres accepts that for a text parameter.

## Fix

Coerce a `Date` to its ISO-8601 string in the `string` serializer. That is the same representation the `date` serializer already produces and the same string the wire drivers send for an untyped parameter. Non-coercible values still throw as before.

## Test

Added a `string from date` case to `tests/types.test.ts`, next to the existing `string from number` case. It fails on `main` with `Invalid input for string type` and passes with this change.
