### PR TITLE
Skip redundant protocol parsing during raw streaming

### DIFF
--- a/.changeset/raw-stream-no-accumulation.md
+++ b/.changeset/raw-stream-no-accumulation.md
@@ -1,0 +1,8 @@
+---
+'@electric-sql/pglite': patch
+---
+
+Stop accumulating parsed protocol messages into the internal results array
+during `execProtocolRawStream()`. Raw-stream callers consume raw bytes via
+`onRawData` and never read the parsed results, so the accumulation grew
+unbounded until the next `execProtocol*` call reset it.

--- a/.changeset/raw-stream-skip-parse.md
+++ b/.changeset/raw-stream-skip-parse.md
@@ -1,0 +1,9 @@
+---
+'@electric-sql/pglite': patch
+---
+
+Skip the internal wire-protocol parse during `execProtocolRawStream()` when
+no notification listeners are registered. The parse runs synchronously in
+the WASM write callback and eagerly decodes every DataRow field, roughly
+doubling the latency of raw-stream queries; on the raw path it is
+load-bearing only for LISTEN/NOTIFY dispatch.

--- a/packages/pglite/src/pglite.ts
+++ b/packages/pglite/src/pglite.ts
@@ -689,14 +689,7 @@ export class PGlite
         console.error('error', e)
         throw e
       }
-      this.#protocolParser.parse(bytes, (msg) => {
-        const parsedMsg = this.#parse(msg)
-        // raw-stream callers never read #currentResults; accumulating here
-        // would grow unbounded until the next execProtocol* call resets it
-        if (parsedMsg && !this.#rawStreamMode) {
-          this.#currentResults.push(parsedMsg)
-        }
-      })
+      this.#handleProtocolWrite(bytes)
       if (this.#keepRawResponse) {
         const copied = bytes.slice()
         if (this.#currentOnRawData) {
@@ -1077,6 +1070,37 @@ export class PGlite
     }
 
     return result
+  }
+
+  // Parse outbound protocol bytes from the WASM write callback.
+  //
+  // On the parsed paths (query/exec/execProtocol*) every message is parsed and
+  // accumulated into #currentResults for the caller to read.
+  //
+  // On the raw-stream path the caller consumes raw bytes via onRawData and
+  // never reads #currentResults, so we never accumulate. The parse is then
+  // load-bearing only for LISTEN/NOTIFY dispatch — errors and notices are not
+  // surfaced on the raw path — so we skip it entirely when no listeners are
+  // registered. It eagerly decodes every DataRow field and can account for
+  // half the latency of a raw-stream query. The gate cannot change mid-query
+  // (execProtocolRawSync is synchronous), so the parser always sees a query's
+  // chunks all-or-nothing.
+  #handleProtocolWrite(bytes: Uint8Array) {
+    if (this.#rawStreamMode) {
+      if (
+        this.#notifyListeners.size !== 0 ||
+        this.#globalNotifyListeners.size !== 0
+      ) {
+        this.#protocolParser.parse(bytes, (msg) => this.#parse(msg))
+      }
+    } else {
+      this.#protocolParser.parse(bytes, (msg) => {
+        const parsedMsg = this.#parse(msg)
+        if (parsedMsg) {
+          this.#currentResults.push(parsedMsg)
+        }
+      })
+    }
   }
 
   #parse(msg: BackendMessage) {

--- a/packages/pglite/src/pglite.ts
+++ b/packages/pglite/src/pglite.ts
@@ -92,6 +92,9 @@ export class PGlite
   #currentThrowOnError: boolean = false
   #currentOnNotice: ((notice: NoticeMessage) => void) | undefined
   #currentOnRawData: ((data: Uint8Array) => void) | undefined
+  // true while execProtocolRawStream() is executing; raw-stream callers
+  // consume raw bytes via onRawData and never read #currentResults
+  #rawStreamMode: boolean = false
 
   // send data to wasm
   #pglite_socket_read: number = -1
@@ -688,7 +691,9 @@ export class PGlite
       }
       this.#protocolParser.parse(bytes, (msg) => {
         const parsedMsg = this.#parse(msg)
-        if (parsedMsg) {
+        // raw-stream callers never read #currentResults; accumulating here
+        // would grow unbounded until the next execProtocol* call resets it
+        if (parsedMsg && !this.#rawStreamMode) {
           this.#currentResults.push(parsedMsg)
         }
       })
@@ -993,7 +998,12 @@ export class PGlite
     { syncToFs = true, onRawData }: ExecProtocolOptionsStream,
   ) {
     this.#currentOnRawData = onRawData
-    this.execProtocolRawSync(message)
+    this.#rawStreamMode = true
+    try {
+      this.execProtocolRawSync(message)
+    } finally {
+      this.#rawStreamMode = false
+    }
     if (syncToFs) {
       await this.syncToFs()
     }


### PR DESCRIPTION
## Problem

The WASM write callback unconditionally runs the internal pg-protocol parser over every outbound chunk and pushes the parsed messages into `#currentResults` — including during `execProtocolRawStream()`, where the caller consumes raw bytes via `onRawData` and the parsed results are never read.

For raw-stream consumers this means:

- Every response is effectively parsed twice: once internally (and discarded), once by the consumer on the other side of the wire protocol.
- The parse runs synchronously inside the write callback, directly on the query's critical path. In our profiling it accounted for roughly half the end-to-end latency of a raw-stream query (eager string-decoding of every DataRow field).
- `#currentResults` grows unbounded until an unrelated `execProtocol*()` call happens to reset it, forcing raw-stream consumers to issue periodic no-op protocol calls just to release the memory.

## Change

Two commits, each with a changeset:

1. **Don't accumulate parsed results during raw streaming** — nothing reads `#currentResults` on that path.
2. **Skip the internal parse entirely during raw streaming when no notification listeners are registered.** On the raw path the parse is load-bearing only for LISTEN/NOTIFY dispatch — errors and notices are not surfaced there, consistent with the method's existing docstring ("bypasses PGlite's protocol wrappers… don't intend to use the above features"). With listeners registered, the parse still runs and notifications dispatch as before. The gate cannot change mid-query because `execProtocolRawSync` is synchronous, so the stateful parser always sees a query's chunks all-or-nothing.

Consumers of the parsed APIs (`query()`, `exec()`, `execProtocol*`) are unaffected — verified as a benchmark control.

## Numbers

Measured downstream through [prisma-pglite-bridge](https://github.com/drudolf/prisma-pglite-bridge) (Prisma → pg → wire protocol → `execProtocolRawStream`), `findMany` over 100 rows, n=1000 iterations × 5 repeats, same engine version A/B:

| | p50 | p95 | p99 |
|---|---|---|---|
| before | 2.31 ms | 2.96 ms | 5.91 ms |
| after | **1.05 ms** | **1.42 ms** | **2.13 ms** |

Commit 1 alone is memory hygiene (~no latency change); commit 2 is the latency win. Re-validated on this branch (PG 18.3) with the same profile. `pglite-socket` should benefit identically, since it serves the raw protocol.

## Validation

- `packages/pglite` test suite passes, including `exec-protocol.test.ts` and `test:node` (the only local failures were caused by my locally assembled `release/` artifacts lacking `pg_stat_statements.tar.gz`, which the published npm package excludes — unrelated to this change).
- `typecheck`, `eslint`, `prettier` clean.
- LISTEN/NOTIFY verified end-to-end: notifications still dispatch when listeners are registered while raw streaming is in use.

## Relation to existing work

Independent of and compatible with #903 — that work optimizes the parsed-results pipeline; this PR fixes the raw path's cost model, which #903 doesn't cover.