### PR TITLE
Fix COPY FROM STDIN over pglite-socket

### DIFF
--- a/.changeset/socket-copy-from-stdin.md
+++ b/.changeset/socket-copy-from-stdin.md
@@ -1,0 +1,8 @@
+---
+'@electric-sql/pglite-socket': patch
+---
+
+Fix COPY ... FROM STDIN over the socket server. The CopyData/CopyDone
+messages that follow the query are now buffered and submitted to PGlite
+together with the query as a single protocol call, instead of as separate
+calls that desynchronized the connection and poisoned subsequent connects.

--- a/packages/pglite-socket/src/index.ts
+++ b/packages/pglite-socket/src/index.ts
@@ -8,6 +8,12 @@ export const SSL_REQUEST_LENGTH = 8
 export const CANCEL_REQUEST_CODE = 80877102
 export const CANCEL_REQUEST_LENGTH = 16
 
+// Postgres wire-protocol message tags (the first byte of each message)
+const MSG_QUERY = 0x51 // 'Q' — simple-protocol Query (frontend)
+const MSG_COPY_DONE = 0x63 // 'c' — CopyDone (frontend)
+const MSG_COPY_FAIL = 0x66 // 'f' — CopyFail (frontend)
+const MSG_COPY_IN_RESPONSE = 0x47 // 'G' — CopyInResponse (backend)
+
 /**
  * Represents a queued query waiting for PGlite access
  */
@@ -188,6 +194,7 @@ export class PGLiteSocketHandler extends EventTarget {
   private debug: boolean
   private readonly id: number
   private messageBuffer: Buffer = Buffer.alloc(0)
+  private copyState: { messages: Buffer[] } | null = null
   private idleTimer?: NodeJS.Timeout
   private idleTimeout: number
   private lastActivityTime: number = Date.now()
@@ -320,6 +327,7 @@ export class PGLiteSocketHandler extends EventTarget {
     this.socket = null
     this.active = false
     this.messageBuffer = Buffer.alloc(0)
+    this.copyState = null
 
     this.log(`detach: handler cleaned up`)
     return this
@@ -427,7 +435,7 @@ export class PGLiteSocketHandler extends EventTarget {
         }
 
         // Extract and process complete message
-        const message = this.messageBuffer.slice(0, messageLength)
+        let message = this.messageBuffer.slice(0, messageLength)
         this.messageBuffer = this.messageBuffer.slice(messageLength)
 
         this.log(`handleData: processing message of ${message.length} bytes`)
@@ -438,6 +446,43 @@ export class PGLiteSocketHandler extends EventTarget {
           break
         }
 
+        // COPY ... FROM STDIN is a stateful sub-protocol: the CopyData
+        // ('d') / CopyDone ('c') / CopyFail ('f') messages that follow the
+        // query must reach PGlite in the same execProtocolRawStream call
+        // as the query itself — PGlite cannot resume a copy started in a
+        // previous call. Buffer the whole sequence and submit it as one
+        // message, then drop the leading CopyInResponse from the response
+        // since a synthesized one was already sent when the copy started.
+        let stripCopyInResponse = false
+        if (this.copyState) {
+          this.copyState.messages.push(message)
+          const tag = message[0]
+          if (tag !== MSG_COPY_DONE && tag !== MSG_COPY_FAIL) {
+            continue
+          }
+          message = Buffer.concat(this.copyState.messages)
+          this.copyState = null
+          stripCopyInResponse = true
+          this.log(
+            `handleData: submitting buffered COPY sequence of ${message.length} bytes`,
+          )
+        } else {
+          const copyFormat = this.sniffCopyFromStdin(message)
+          if (copyFormat !== null) {
+            // The client waits for a CopyInResponse before sending
+            // CopyData, but the query can only run once the full sequence
+            // has been buffered — synthesize the CopyInResponse here.
+            this.log(`handleData: COPY FROM STDIN detected, buffering sequence`)
+            this.copyState = { messages: [message] }
+            this.socket.write(this.makeCopyInResponse(copyFormat))
+            continue
+          }
+        }
+        // Response bytes held back until the CopyInResponse is dropped
+        let pendingResponse: Buffer | null = stripCopyInResponse
+          ? Buffer.alloc(0)
+          : null
+
         let socketWriteError: any = undefined
         // Queue the query for execution
         // This allows multiple connections to queue queries simultaneously
@@ -445,6 +490,22 @@ export class PGLiteSocketHandler extends EventTarget {
           this.id,
           new Uint8Array(message),
           (data) => {
+            if (pendingResponse !== null) {
+              pendingResponse = Buffer.concat([
+                pendingResponse,
+                Buffer.from(data),
+              ])
+              if (pendingResponse.length < 5) return
+              const firstLength = 1 + pendingResponse.readInt32BE(1)
+              if (pendingResponse.length < firstLength) return
+              data =
+                pendingResponse[0] === MSG_COPY_IN_RESPONSE
+                  ? pendingResponse.subarray(firstLength)
+                  : pendingResponse
+              pendingResponse = null
+              if (data.length === 0) return
+            }
+
             this.log(`handleData: received ${data.length} bytes from PGlite`)
 
             // Print the outgoing data to the console
@@ -490,6 +551,40 @@ export class PGLiteSocketHandler extends EventTarget {
       this.log(`handleData: error processing data:`, err)
       throw err
     }
+  }
+
+  // Matches a simple-protocol query whose first statement is COPY ... FROM
+  // STDIN, allowing leading whitespace and comments. Anchored to the start
+  // of the query so that COPY mentioned inside a string literal or comment
+  // of another statement cannot match.
+  private static COPY_FROM_STDIN_RE =
+    /^(?:\s+|--[^\n]*\n?|\/\*[\s\S]*?\*\/)*COPY\b[\s\S]+\bFROM\b\s+STDIN\b/i
+  private static COPY_BINARY_RE = /\bBINARY\b|\bFORMAT\s+'?binary'?/i
+
+  /**
+   * Detect a simple-protocol query ('Q') that starts a COPY FROM STDIN.
+   * Returns the copy format (0 = text/csv, 1 = binary), or null when the
+   * message does not start a copy-in sequence.
+   */
+  private sniffCopyFromStdin(message: Buffer): number | null {
+    if (message.length < 6 || message[0] !== MSG_QUERY) return null
+    const sql = message.toString('utf8', 5, message.length - 1)
+    if (!PGLiteSocketHandler.COPY_FROM_STDIN_RE.test(sql)) return null
+    return PGLiteSocketHandler.COPY_BINARY_RE.test(sql) ? 1 : 0
+  }
+
+  /**
+   * Build a CopyInResponse ('G') message: overall format byte plus a zero
+   * column count. Clients use it as the signal to start streaming CopyData
+   * and do not need the per-column details for copy-in.
+   */
+  private makeCopyInResponse(format: number): Buffer {
+    const buf = Buffer.alloc(8)
+    buf.writeUInt8(MSG_COPY_IN_RESPONSE, 0)
+    buf.writeInt32BE(7, 1)
+    buf.writeUInt8(format, 5)
+    buf.writeInt16BE(0, 6)
+    return buf
   }
 
   private handleError(err: Error): void {

--- a/packages/pglite-socket/src/index.ts
+++ b/packages/pglite-socket/src/index.ts
@@ -4,6 +4,12 @@ import { type Server, type Socket, createServer } from 'net'
 // Connection queue timeout in milliseconds
 export const CONNECTION_QUEUE_TIMEOUT = 60000 // 60 seconds
 
+// Postgres wire-protocol message tags (the first byte of each message)
+const MSG_QUERY = 0x51 // 'Q' — simple-protocol Query (frontend)
+const MSG_COPY_DONE = 0x63 // 'c' — CopyDone (frontend)
+const MSG_COPY_FAIL = 0x66 // 'f' — CopyFail (frontend)
+const MSG_COPY_IN_RESPONSE = 0x47 // 'G' — CopyInResponse (backend)
+
 /**
  * Represents a queued query waiting for PGlite access
  */
@@ -184,6 +190,7 @@ export class PGLiteSocketHandler extends EventTarget {
   private debug: boolean
   private readonly id: number
   private messageBuffer: Buffer = Buffer.alloc(0)
+  private copyState: { messages: Buffer[] } | null = null
   private idleTimer?: NodeJS.Timeout
   private idleTimeout: number
   private lastActivityTime: number = Date.now()
@@ -316,6 +323,7 @@ export class PGLiteSocketHandler extends EventTarget {
     this.socket = null
     this.active = false
     this.messageBuffer = Buffer.alloc(0)
+    this.copyState = null
 
     this.log(`detach: handler cleaned up`)
     return this
@@ -376,7 +384,7 @@ export class PGLiteSocketHandler extends EventTarget {
         }
 
         // Extract and process complete message
-        const message = this.messageBuffer.slice(0, messageLength)
+        let message = this.messageBuffer.slice(0, messageLength)
         this.messageBuffer = this.messageBuffer.slice(messageLength)
 
         this.log(`handleData: processing message of ${message.length} bytes`)
@@ -387,6 +395,43 @@ export class PGLiteSocketHandler extends EventTarget {
           break
         }
 
+        // COPY ... FROM STDIN is a stateful sub-protocol: the CopyData
+        // ('d') / CopyDone ('c') / CopyFail ('f') messages that follow the
+        // query must reach PGlite in the same execProtocolRawStream call
+        // as the query itself — PGlite cannot resume a copy started in a
+        // previous call. Buffer the whole sequence and submit it as one
+        // message, then drop the leading CopyInResponse from the response
+        // since a synthesized one was already sent when the copy started.
+        let stripCopyInResponse = false
+        if (this.copyState) {
+          this.copyState.messages.push(message)
+          const tag = message[0]
+          if (tag !== MSG_COPY_DONE && tag !== MSG_COPY_FAIL) {
+            continue
+          }
+          message = Buffer.concat(this.copyState.messages)
+          this.copyState = null
+          stripCopyInResponse = true
+          this.log(
+            `handleData: submitting buffered COPY sequence of ${message.length} bytes`,
+          )
+        } else {
+          const copyFormat = this.sniffCopyFromStdin(message)
+          if (copyFormat !== null) {
+            // The client waits for a CopyInResponse before sending
+            // CopyData, but the query can only run once the full sequence
+            // has been buffered — synthesize the CopyInResponse here.
+            this.log(`handleData: COPY FROM STDIN detected, buffering sequence`)
+            this.copyState = { messages: [message] }
+            this.socket.write(this.makeCopyInResponse(copyFormat))
+            continue
+          }
+        }
+        // Response bytes held back until the CopyInResponse is dropped
+        let pendingResponse: Buffer | null = stripCopyInResponse
+          ? Buffer.alloc(0)
+          : null
+
         let socketWriteError: any = undefined
         // Queue the query for execution
         // This allows multiple connections to queue queries simultaneously
@@ -394,6 +439,22 @@ export class PGLiteSocketHandler extends EventTarget {
           this.id,
           new Uint8Array(message),
           (data) => {
+            if (pendingResponse !== null) {
+              pendingResponse = Buffer.concat([
+                pendingResponse,
+                Buffer.from(data),
+              ])
+              if (pendingResponse.length < 5) return
+              const firstLength = 1 + pendingResponse.readInt32BE(1)
+              if (pendingResponse.length < firstLength) return
+              data =
+                pendingResponse[0] === MSG_COPY_IN_RESPONSE
+                  ? pendingResponse.subarray(firstLength)
+                  : pendingResponse
+              pendingResponse = null
+              if (data.length === 0) return
+            }
+
             this.log(`handleData: received ${data.length} bytes from PGlite`)
 
             // Print the outgoing data to the console
@@ -439,6 +500,40 @@ export class PGLiteSocketHandler extends EventTarget {
       this.log(`handleData: error processing data:`, err)
       throw err
     }
+  }
+
+  // Matches a simple-protocol query whose first statement is COPY ... FROM
+  // STDIN, allowing leading whitespace and comments. Anchored to the start
+  // of the query so that COPY mentioned inside a string literal or comment
+  // of another statement cannot match.
+  private static COPY_FROM_STDIN_RE =
+    /^(?:\s+|--[^\n]*\n?|\/\*[\s\S]*?\*\/)*COPY\b[\s\S]+\bFROM\b\s+STDIN\b/i
+  private static COPY_BINARY_RE = /\bBINARY\b|\bFORMAT\s+'?binary'?/i
+
+  /**
+   * Detect a simple-protocol query ('Q') that starts a COPY FROM STDIN.
+   * Returns the copy format (0 = text/csv, 1 = binary), or null when the
+   * message does not start a copy-in sequence.
+   */
+  private sniffCopyFromStdin(message: Buffer): number | null {
+    if (message.length < 6 || message[0] !== MSG_QUERY) return null
+    const sql = message.toString('utf8', 5, message.length - 1)
+    if (!PGLiteSocketHandler.COPY_FROM_STDIN_RE.test(sql)) return null
+    return PGLiteSocketHandler.COPY_BINARY_RE.test(sql) ? 1 : 0
+  }
+
+  /**
+   * Build a CopyInResponse ('G') message: overall format byte plus a zero
+   * column count. Clients use it as the signal to start streaming CopyData
+   * and do not need the per-column details for copy-in.
+   */
+  private makeCopyInResponse(format: number): Buffer {
+    const buf = Buffer.alloc(8)
+    buf.writeUInt8(MSG_COPY_IN_RESPONSE, 0)
+    buf.writeInt32BE(7, 1)
+    buf.writeUInt8(format, 5)
+    buf.writeInt16BE(0, 6)
+    return buf
   }
 
   private handleError(err: Error): void {

--- a/packages/pglite-socket/tests/copy-from-stdin.test.ts
+++ b/packages/pglite-socket/tests/copy-from-stdin.test.ts
@@ -1,0 +1,251 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { PGlite } from '@electric-sql/pglite'
+import { PGLiteSocketServer } from '../src'
+import { Socket, createConnection } from 'net'
+
+const TEST_PORT = 5436
+
+function startupMessage(): Buffer {
+  const params = Buffer.from('user\0postgres\0database\0postgres\0\0', 'utf8')
+  const buf = Buffer.alloc(8 + params.length)
+  buf.writeInt32BE(8 + params.length, 0)
+  buf.writeInt32BE(196608, 4)
+  params.copy(buf, 8)
+  return buf
+}
+
+function message(tag: string, payload: Buffer): Buffer {
+  const buf = Buffer.alloc(5 + payload.length)
+  buf.write(tag, 0, 'ascii')
+  buf.writeInt32BE(4 + payload.length, 1)
+  payload.copy(buf, 5)
+  return buf
+}
+
+const query = (sql: string) => message('Q', Buffer.from(sql + '\0', 'utf8'))
+const copyData = (data: string) => message('d', Buffer.from(data, 'utf8'))
+const copyDone = () => message('c', Buffer.alloc(0))
+const copyFail = (reason: string) =>
+  message('f', Buffer.from(reason + '\0', 'utf8'))
+
+/**
+ * Minimal wire-protocol client: writes raw messages and waits for a
+ * response message with a given tag, discarding everything before it.
+ */
+class WireClient {
+  socket: Socket
+  private buffer = Buffer.alloc(0)
+  private waiters = new Set<() => void>()
+
+  constructor(port: number) {
+    this.socket = createConnection({ host: '127.0.0.1', port })
+    this.socket.on('data', (data) => {
+      this.buffer = Buffer.concat([this.buffer, data])
+      for (const waiter of this.waiters) waiter()
+    })
+  }
+
+  connected(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.socket.on('connect', () => resolve())
+      this.socket.on('error', reject)
+    })
+  }
+
+  async waitFor(tag: string, timeout = 15000): Promise<Buffer> {
+    const want = tag.charCodeAt(0)
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.waiters.delete(scan)
+        reject(new Error(`timeout waiting for '${tag}'`))
+      }, timeout)
+      const scan = () => {
+        let offset = 0
+        while (this.buffer.length - offset >= 5) {
+          const msgTag = this.buffer[offset]
+          const length = 1 + this.buffer.readInt32BE(offset + 1)
+          if (this.buffer.length - offset < length) break
+          if (msgTag === want) {
+            const payload = Buffer.from(
+              this.buffer.subarray(offset + 5, offset + length),
+            )
+            this.buffer = this.buffer.subarray(offset + length)
+            this.waiters.delete(scan)
+            clearTimeout(timer)
+            resolve(payload)
+            return
+          }
+          offset += length
+        }
+        this.buffer = this.buffer.subarray(offset)
+      }
+      this.waiters.add(scan)
+      scan()
+    })
+  }
+
+  end() {
+    this.socket.end()
+  }
+}
+
+async function connect(port: number): Promise<WireClient> {
+  const client = new WireClient(port)
+  await client.connected()
+  client.socket.write(startupMessage())
+  await client.waitFor('Z')
+  return client
+}
+
+describe('COPY FROM STDIN over pglite-socket', () => {
+  let db: PGlite
+  let server: PGLiteSocketServer
+
+  beforeAll(async () => {
+    db = await PGlite.create()
+    server = new PGLiteSocketServer({
+      db,
+      port: TEST_PORT,
+      host: '127.0.0.1',
+    })
+    await server.start()
+  })
+
+  afterAll(async () => {
+    await server.stop()
+    await db.close()
+  })
+
+  async function waitForDisconnect() {
+    while (server.getStats().activeConnections > 0) {
+      await new Promise((resolve) => setTimeout(resolve, 10))
+    }
+  }
+
+  it('copies rows and leaves the connection and server healthy', async () => {
+    const client = await connect(TEST_PORT)
+
+    client.socket.write(query('CREATE TABLE copy_test (id int, name text)'))
+    await client.waitFor('Z')
+
+    client.socket.write(query('COPY copy_test FROM STDIN'))
+    const copyIn = await client.waitFor('G')
+    expect(copyIn.readUInt8(0)).toBe(0) // text format
+
+    client.socket.write(copyData('1\talice\n'))
+    client.socket.write(copyData('2\tbob\n'))
+    client.socket.write(copyDone())
+    const complete = await client.waitFor('C')
+    expect(complete.toString('utf8')).toContain('COPY 2')
+    await client.waitFor('Z')
+
+    // Same connection still works after the COPY
+    client.socket.write(query('SELECT count(*) FROM copy_test'))
+    const row = await client.waitFor('D')
+    expect(row.toString('utf8')).toContain('2')
+    await client.waitFor('Z')
+    client.end()
+    await waitForDisconnect()
+
+    // A fresh connection must not be poisoned by the earlier COPY
+    const client2 = new WireClient(TEST_PORT)
+    await client2.connected()
+    client2.socket.write(startupMessage())
+    const auth = await client2.waitFor('R')
+    expect(auth.readInt32BE(0)).toBe(0) // AuthenticationOk
+    await client2.waitFor('Z')
+    client2.end()
+    await waitForDisconnect()
+  })
+
+  it('reports errors for a failing COPY without desyncing', async () => {
+    const client = await connect(TEST_PORT)
+
+    client.socket.write(query('COPY missing_table FROM STDIN'))
+    await client.waitFor('G')
+    client.socket.write(copyData('1\n'))
+    client.socket.write(copyDone())
+    const err = await client.waitFor('E')
+    expect(err.toString('utf8')).toContain('missing_table')
+    await client.waitFor('Z')
+
+    // Same connection still works after the failed COPY
+    client.socket.write(query('SELECT 1'))
+    await client.waitFor('D')
+    await client.waitFor('Z')
+    client.end()
+    await waitForDisconnect()
+  })
+
+  it('aborts cleanly on CopyFail', async () => {
+    const client = await connect(TEST_PORT)
+
+    client.socket.write(query('CREATE TABLE copy_fail_test (id int)'))
+    await client.waitFor('Z')
+
+    client.socket.write(query('COPY copy_fail_test FROM STDIN'))
+    await client.waitFor('G')
+    client.socket.write(copyData('1\n'))
+    client.socket.write(copyFail('client changed its mind'))
+    const err = await client.waitFor('E')
+    expect(err.toString('utf8')).toContain('COPY from stdin failed')
+    await client.waitFor('Z')
+
+    // Same connection still works after the aborted COPY
+    client.socket.write(query('SELECT count(*) FROM copy_fail_test'))
+    const row = await client.waitFor('D')
+    expect(row.toString('utf8')).toContain('0')
+    await client.waitFor('Z')
+    client.end()
+    await waitForDisconnect()
+  })
+
+  it('does not treat COPY FROM STDIN inside a string literal as a copy', async () => {
+    const client = await connect(TEST_PORT)
+
+    // If the sniffer false-positived here, the handler would buffer waiting
+    // for CopyData and this query would never produce a DataRow.
+    client.socket.write(query(`SELECT 'COPY t FROM STDIN' AS s`))
+    const row = await client.waitFor('D')
+    expect(row.toString('utf8')).toContain('COPY t FROM STDIN')
+    await client.waitFor('Z')
+    client.end()
+    await waitForDisconnect()
+  })
+
+  it('detects COPY FROM STDIN behind leading comments', async () => {
+    const client = await connect(TEST_PORT)
+
+    client.socket.write(query('CREATE TABLE copy_comment_test (id int)'))
+    await client.waitFor('Z')
+
+    client.socket.write(
+      query('-- bulk load\n/* fixture */ COPY copy_comment_test FROM STDIN'),
+    )
+    await client.waitFor('G')
+    client.socket.write(copyData('7\n'))
+    client.socket.write(copyDone())
+    const complete = await client.waitFor('C')
+    expect(complete.toString('utf8')).toContain('COPY 1')
+    await client.waitFor('Z')
+    client.end()
+    await waitForDisconnect()
+  })
+
+  it('does not buffer COPY TO STDOUT', async () => {
+    const client = await connect(TEST_PORT)
+
+    client.socket.write(query('CREATE TABLE copy_out_test (id int)'))
+    await client.waitFor('Z')
+    client.socket.write(query('INSERT INTO copy_out_test VALUES (42)'))
+    await client.waitFor('Z')
+
+    client.socket.write(query('COPY copy_out_test TO STDOUT'))
+    await client.waitFor('H') // CopyOutResponse
+    const data = await client.waitFor('d')
+    expect(data.toString('utf8')).toContain('42')
+    await client.waitFor('Z')
+    client.end()
+    await waitForDisconnect()
+  })
+})


### PR DESCRIPTION
COPY ... FROM STDIN is a stateful sub-protocol: the CopyData ('d') / CopyDone ('c') / CopyFail ('f') messages that follow the query must reach PGlite in the same execProtocolRawStream call as the query itself — PGlite cannot resume a copy started in a previous call. The handler previously dispatched every wire message as its own call, which desynchronized the connection mid-COPY and left buffered response bytes that corrupted the next client's startup handshake.

The handler now detects COPY ... FROM STDIN in simple-protocol queries, synthesizes the CopyInResponse the client is waiting for, buffers the copy sub-protocol messages, and submits the whole sequence as one call, stripping the duplicate CopyInResponse from PGlite's response.

Known limitations, called out in the PR: the COPY payload is buffered in memory, extended-protocol COPY is not detected, and errors from the COPY statement itself are reported after the data has been sent.