### PR TITLE
fix: detect Node via process.type to keep Electron main process working

### DIFF
--- a/.changeset/electron-main-process-in-node.md
+++ b/.changeset/electron-main-process-in-node.md
@@ -1,0 +1,5 @@
+---
+'@electric-sql/pglite': patch
+---
+
+Detect the Node environment via `process.type` instead of `process.versions.electron`. The previous Electron guard (#951) also treated the Electron main and utility processes as non-Node, which broke PGlite's filesystem code path there. `process.type` only excludes Electron's web contexts (renderer, web worker, service worker), so PGlite keeps using the Node.js path in the Electron main and utility processes. Follow-up to #951 / #813.

--- a/packages/pglite-utils/src/utils.ts
+++ b/packages/pglite-utils/src/utils.ts
@@ -1,8 +1,19 @@
+// Electron exposes a Node-like `process` (with `process.versions.node`) in its
+// renderer/worker/service-worker contexts, which made `IN_NODE` true there and
+// crashed PGlite on the Node.js fs path (#813). The earlier `!process.versions
+// .electron` guard fixed the renderer but also disabled the Node path in the
+// Electron *main* and *utility* processes, which ARE real Node environments that
+// need it (`process.versions.electron` is set in every Electron process). Key
+// off `process.type` instead: it is 'renderer'/'worker'/'service-worker' only in
+// Electron's web contexts, and 'browser' (main) / 'utility' / undefined (plain
+// Node) wherever a Node fs is actually available.
 export const IN_NODE =
   typeof process === 'object' &&
   typeof process.versions === 'object' &&
   typeof process.versions.node === 'string' &&
-  !process.versions.electron
+  !['renderer', 'worker', 'service-worker'].includes(
+    (process as { type?: string }).type ?? '',
+  )
 
 export const WASM_PREFIX = '/pglite'
 

--- a/packages/pglite-utils/src/utils.ts
+++ b/packages/pglite-utils/src/utils.ts
@@ -1,19 +1,16 @@
-// Electron exposes a Node-like `process` (with `process.versions.node`) in its
-// renderer/worker/service-worker contexts, which made `IN_NODE` true there and
-// crashed PGlite on the Node.js fs path (#813). The earlier `!process.versions
-// .electron` guard fixed the renderer but also disabled the Node path in the
-// Electron *main* and *utility* processes, which ARE real Node environments that
-// need it (`process.versions.electron` is set in every Electron process). Key
-// off `process.type` instead: it is 'renderer'/'worker'/'service-worker' only in
-// Electron's web contexts, and 'browser' (main) / 'utility' / undefined (plain
-// Node) wherever a Node fs is actually available.
+// Electron exposes a Node-like `process` in its renderer/worker/service-worker
+// contexts, which must use the browser fs path. Its main and utility processes
+// are real Node environments (#813).
+function isElectronWebContext(): boolean {
+  const type = (process as { type?: string }).type
+  return type === 'renderer' || type === 'worker' || type === 'service-worker'
+}
+
 export const IN_NODE =
   typeof process === 'object' &&
   typeof process.versions === 'object' &&
   typeof process.versions.node === 'string' &&
-  !['renderer', 'worker', 'service-worker'].includes(
-    (process as { type?: string }).type ?? '',
-  )
+  !isElectronWebContext()
 
 export const WASM_PREFIX = '/pglite'
 


### PR DESCRIPTION
Follow-up to #951 (thanks for merging that one!) and #813.

#951 fixed the Electron renderer crash by adding `!process.versions.electron` to `IN_NODE`. While verifying it I noticed that guard also flips `IN_NODE` to `false` in the Electron **main** and **utility** processes, because `process.versions.electron` is set in *every* Electron process, not just the renderer. Those are real Node environments, so PGlite then takes the browser path and loses the Node.js `fs` code path it needs. Running PGlite in the main process for filesystem-backed storage (keeping DB access out of the renderer) is a common pattern, so this is a regression.

This keys the check off `process.type` instead, which cleanly separates Electron's web contexts from its Node ones:

| Environment | `process.type` | `!process.versions.electron` (#951) | `process.type` exclusion (this PR) |
| --- | --- | --- | --- |
| Plain Node | `undefined` | Node ✅ | Node ✅ |
| Node `worker_threads` | `undefined` | Node ✅ | Node ✅ |
| Electron **main** | `browser` | browser ❌ | Node ✅ |
| Electron **utility** | `utility` | browser ❌ | Node ✅ |
| Electron renderer | `renderer` | browser ✅ | browser ✅ |
| Electron renderer web worker | `worker` | browser ✅ | browser ✅ |
| Electron renderer service worker | `service-worker` | browser ✅ | browser ✅ |
| Browser (no `process`) | n/a | browser ✅ | browser ✅ |

So it still fixes the original renderer crash from #813, and additionally keeps the Node path working in the Electron main and utility processes.

`process.type` is Electron specific and not in `@types/node`, hence the small structural cast.

Checks run locally: `typecheck`, `lint`, and `build` pass for `@electric-sql/pglite-utils`. Changeset included (patch to `@electric-sql/pglite`).
