### PR TITLE
Clarify pglite-server TCP and Unix socket connection examples

### DIFF
--- a/packages/pglite-socket/README.md
+++ b/packages/pglite-socket/README.md
@@ -218,15 +218,17 @@ pglite-server --path=/tmp/.s.PGSQL.5432 --run "npm run dev" --include-database-u
 
 ### Connecting to the server
 
-Once the server is running, you can connect to it using any PostgreSQL client:
+Once the server is running, you can connect to it using any PostgreSQL client. The connection options depend on whether you started the server with the default TCP listener or with a Unix socket.
 
-#### Using psql
+#### Connecting over TCP
+
+By default, `pglite-server` listens on `127.0.0.1:5432`. You can connect to the default TCP server with `psql`:
 
 ```bash
 PGSSLMODE=disable psql -h localhost -p 5432 -d postgres
 ```
 
-#### Using Node.js clients
+Or with Node.js clients:
 
 ```javascript
 // Using node-postgres
@@ -234,7 +236,7 @@ import pg from 'pg'
 const client = new pg.Client({
   host: 'localhost',
   port: 5432,
-  database: 'postgres'
+  database: 'postgres',
 })
 await client.connect()
 
@@ -243,10 +245,42 @@ import postgres from 'postgres'
 const sql = postgres({
   host: 'localhost',
   port: 5432,
-  database: 'postgres'
+  database: 'postgres',
 })
+```
 
-// Using environment variable (when using --include-database-url)
+#### Connecting over Unix sockets
+
+If you started the server with `--path`, connect using the socket directory instead of `localhost` and `port`:
+
+```bash
+PGSSLMODE=disable psql "postgresql://postgres:postgres@/postgres?host=/tmp"
+```
+
+For Node.js clients, use the socket path configuration for your client:
+
+```javascript
+// Using node-postgres
+import pg from 'pg'
+const client = new pg.Client({
+  host: '/tmp',
+  database: 'postgres',
+  user: 'postgres',
+  password: 'postgres',
+})
+await client.connect()
+
+// Using postgres.js
+import postgres from 'postgres'
+const sql = postgres({
+  path: '/tmp/.s.PGSQL.5432',
+  database: 'postgres',
+})
+```
+
+When using `--run` with `--include-database-url`, you can use the generated `DATABASE_URL`:
+
+```javascript
 const sql = postgres(process.env.DATABASE_URL)
 ```
 

--- a/packages/pglite-socket/README.md
+++ b/packages/pglite-socket/README.md
@@ -278,11 +278,10 @@ const sql = postgres({
 })
 ```
 
-When using `--run` with `--include-database-url`, you can use the generated `DATABASE_URL`:
-
-```javascript
-const sql = postgres(process.env.DATABASE_URL)
-```
+When using `--run` with `--include-database-url`, the generated `DATABASE_URL`
+uses the libpq-style `?host=/tmp` Unix socket form. This works with clients that
+understand that connection string format, such as `psql`. For `postgres.js`, use
+the `path` option shown above instead of passing the generated URL directly.
 
 ### Limitations and Tips
 


### PR DESCRIPTION
## Summary

Clarifies the `pglite-server` connection examples by separating the default TCP listener from Unix socket connections.

The README introduces Unix socket support with `--path` and shows the generated socket-style `DATABASE_URL`, but the following `psql` and Node.js examples use `localhost:5432`, which applies to the default TCP listener. Since `--path` takes precedence over host/port, reading those examples sequentially can make it look like `localhost:5432` should connect to the Unix socket server.

This keeps both setup paths documented and adds explicit Unix socket examples for `psql`, `node-postgres`, and `postgres.js`.

## Validation

- Ran `pnpm -C packages/pglite-socket build`
- Ran `pnpm exec prettier --check packages/pglite-socket/README.md`
- Verified locally by starting `pglite-server` with `--path`, creating a sentinel table through the generated Unix socket connection string, and checking that the TCP-style `localhost:5432` example did not reach that server while the socket-style URL did.
