### PR TITLE
fix(pglite-sync): accept liveSse shape option

### DIFF
--- a/.changeset/smooth-waves-live-sse.md
+++ b/.changeset/smooth-waves-live-sse.md
@@ -1,0 +1,5 @@
+---
+"@electric-sql/pglite-sync": patch
+---
+
+Allow `liveSse` in sync shape options and map it to Electric's current SSE option.

--- a/packages/pglite-sync/src/index.ts
+++ b/packages/pglite-sync/src/index.ts
@@ -29,6 +29,7 @@ import {
   applyMessagesToTableWithCopy,
   applyMessagesToTableWithJson,
 } from './apply'
+import { normalizeShapeStreamOptions } from './shapeStreamOptions'
 
 export * from './types'
 
@@ -154,10 +155,13 @@ async function createPlugin(
         shapes: Object.fromEntries(
           Object.entries(shapes).map(([key, shapeOptions]) => {
             const shapeMetadata = subState?.shape_metadata[key]
+            const shapeStreamOptions = normalizeShapeStreamOptions(
+              shapeOptions.shape,
+            )
             return [
               key,
               {
-                ...shapeOptions.shape,
+                ...shapeStreamOptions,
                 ...(shapeMetadata
                   ? {
                       offset: shapeMetadata.offset,

--- a/packages/pglite-sync/src/shapeStreamOptions.ts
+++ b/packages/pglite-sync/src/shapeStreamOptions.ts
@@ -1,0 +1,23 @@
+import type { ShapeStreamOptions } from '@electric-sql/client'
+
+export type PGliteSyncShapeStreamOptions<T = never> = ShapeStreamOptions<T> & {
+  liveSse?: boolean
+}
+
+export function normalizeShapeStreamOptions<T = never>(
+  shape: PGliteSyncShapeStreamOptions<T>,
+): ShapeStreamOptions<T> {
+  const { liveSse, ...shapeStreamOptions } = shape
+
+  if (
+    liveSse !== undefined &&
+    shapeStreamOptions.experimentalLiveSse === undefined
+  ) {
+    return {
+      ...shapeStreamOptions,
+      experimentalLiveSse: liveSse,
+    }
+  }
+
+  return shapeStreamOptions
+}

--- a/packages/pglite-sync/src/types.ts
+++ b/packages/pglite-sync/src/types.ts
@@ -1,11 +1,11 @@
 import type {
-  ShapeStreamOptions,
   ShapeStreamInterface,
   Row,
   ChangeMessage,
   FetchError,
 } from '@electric-sql/client'
 import { Transaction } from '@electric-sql/pglite'
+import type { PGliteSyncShapeStreamOptions } from './shapeStreamOptions'
 
 export type Lsn = bigint
 
@@ -16,7 +16,7 @@ export type SubscriptionKey = string
 export type InitialInsertMethod = 'insert' | 'csv' | 'json' | 'useCopy'
 
 export interface ShapeToTableOptions {
-  shape: ShapeStreamOptions
+  shape: PGliteSyncShapeStreamOptions
   table: string
   schema?: string
   mapColumns?: MapColumns
@@ -40,7 +40,7 @@ export interface SyncShapesToTablesResult {
 }
 
 export interface SyncShapeToTableOptions {
-  shape: ShapeStreamOptions
+  shape: PGliteSyncShapeStreamOptions
   table: string
   schema?: string
   mapColumns?: MapColumns

--- a/packages/pglite-sync/test/shapeStreamOptions.test.ts
+++ b/packages/pglite-sync/test/shapeStreamOptions.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import {
+  normalizeShapeStreamOptions,
+  type PGliteSyncShapeStreamOptions,
+} from '../src/shapeStreamOptions'
+
+describe('normalizeShapeStreamOptions', () => {
+  it('maps liveSse to the Electric client SSE option', () => {
+    const shape: PGliteSyncShapeStreamOptions = {
+      url: 'http://localhost:3000/v1/shape',
+      liveSse: true,
+    }
+
+    const normalized = normalizeShapeStreamOptions(shape)
+
+    expect(normalized).toEqual({
+      url: 'http://localhost:3000/v1/shape',
+      experimentalLiveSse: true,
+    })
+    expect('liveSse' in normalized).toBe(false)
+  })
+
+  it('preserves explicit experimentalLiveSse when both options are provided', () => {
+    const normalized = normalizeShapeStreamOptions({
+      url: 'http://localhost:3000/v1/shape',
+      liveSse: true,
+      experimentalLiveSse: false,
+    })
+
+    expect(normalized).toEqual({
+      url: 'http://localhost:3000/v1/shape',
+      experimentalLiveSse: false,
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #861.

`@electric-sql/pglite-sync` now accepts the documented `liveSse` shape option and maps it to the current Electric client `experimentalLiveSse` option before creating the multi-shape stream. Existing explicit `experimentalLiveSse` values continue to take precedence.

## Changes

- Add a small pglite-sync shape option normalizer for `liveSse`.
- Use the normalized options when constructing sync shape streams.
- Add focused regression coverage for `liveSse` mapping and precedence.
- Add the required changeset.

## Testing

- `pnpm install --frozen-lockfile`
- `pnpm --filter @electric-sql/pglite-sync test -- --run test/shapeStreamOptions.test.ts`
- `pnpm --filter @electric-sql/pglite-sync lint`
- `git diff --check`

Verification gap: `pnpm --filter @electric-sql/pglite-sync build`, `pnpm --filter @electric-sql/pglite-sync typecheck`, and the existing `test/sync.test.ts` path could not complete in this local checkout because the generated `@electric-sql/pglite` package artifacts/types were not present.

Note: I used Codex while preparing this change, reviewed the final diff, and ran the checks listed above locally.