### PR TITLE
perf(pglite): reduce per-row allocation in parseResults

### DIFF
--- a/.changeset/optimize-parse-results.md
+++ b/.changeset/optimize-parse-results.md
@@ -1,0 +1,5 @@
+---
+"@electric-sql/pglite": patch
+---
+
+Reduce per-row allocation overhead in `parseResults()` by hoisting field metadata once per result set and building rows with indexed loops instead of `Object.fromEntries` / `.map()`.

--- a/packages/pglite/src/parse.ts
+++ b/packages/pglite/src/parse.ts
@@ -20,6 +20,8 @@ export function parseResults(
 ): Array<Results> {
   const resultSets: Results[] = []
   let currentResultSet: Results = { rows: [], fields: [] }
+  let fieldNames: string[] | undefined
+  let fieldTypes: number[] | undefined
   let affectedRows = 0
   const parsers = { ...defaultParsers, ...options?.parsers }
 
@@ -27,35 +29,41 @@ export function parseResults(
     switch (message.name) {
       case 'rowDescription': {
         const msg = message as RowDescriptionMessage
-        currentResultSet.fields = msg.fields.map((field) => ({
-          name: field.name,
-          dataTypeID: field.dataTypeID,
-        }))
+        const n = msg.fields.length
+        fieldNames = new Array(n)
+        fieldTypes = new Array(n)
+        currentResultSet.fields = new Array(n)
+        for (let i = 0; i < n; i++) {
+          const field = msg.fields[i]
+          fieldNames[i] = field.name
+          fieldTypes[i] = field.dataTypeID
+          currentResultSet.fields[i] = {
+            name: field.name,
+            dataTypeID: field.dataTypeID,
+          }
+        }
         break
       }
       case 'dataRow': {
-        if (!currentResultSet) break
+        if (!fieldNames || !fieldTypes) break
         const msg = message as DataRowMessage
+        const n = msg.fields.length
         if (options?.rowMode === 'array') {
-          currentResultSet.rows.push(
-            msg.fields.map((field, i) =>
-              parseType(field, currentResultSet!.fields[i].dataTypeID, parsers),
-            ),
-          )
+          const row = new Array<unknown>(n)
+          for (let i = 0; i < n; i++) {
+            row[i] = parseType(msg.fields[i], fieldTypes[i], parsers)
+          }
+          currentResultSet.rows.push(row)
         } else {
-          // rowMode === "object"
-          currentResultSet.rows.push(
-            Object.fromEntries(
-              msg.fields.map((field, i) => [
-                currentResultSet!.fields[i].name,
-                parseType(
-                  field,
-                  currentResultSet!.fields[i].dataTypeID,
-                  parsers,
-                ),
-              ]),
-            ),
-          )
+          const row: Record<string, unknown> = {}
+          for (let i = 0; i < n; i++) {
+            row[fieldNames[i]] = parseType(
+              msg.fields[i],
+              fieldTypes[i],
+              parsers,
+            )
+          }
+          currentResultSet.rows.push(row)
         }
         break
       }
@@ -70,6 +78,8 @@ export function parseResults(
         })
 
         currentResultSet = { rows: [], fields: [] }
+        fieldNames = undefined
+        fieldTypes = undefined
         break
       }
     }

--- a/packages/pglite/tests/parse.test.ts
+++ b/packages/pglite/tests/parse.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from 'vitest'
+import {
+  RowDescriptionMessage,
+  DataRowMessage,
+  CommandCompleteMessage,
+} from '@electric-sql/pg-protocol/messages'
+import { parseResults, parseDescribeStatementResults } from '../src/parse'
+import { ParameterDescriptionMessage } from '@electric-sql/pg-protocol/messages'
+
+function rowDescription(
+  fields: Array<{ name: string; dataTypeID: number }>,
+): RowDescriptionMessage {
+  const msg = new RowDescriptionMessage(0, fields.length)
+  msg.fields = fields.map((field) => ({
+    name: field.name,
+    tableID: 0,
+    columnID: 0,
+    dataTypeID: field.dataTypeID,
+    dataTypeSize: 0,
+    dataTypeModifier: 0,
+    format: 0,
+  }))
+  return msg
+}
+
+function dataRow(values: (string | null)[]): DataRowMessage {
+  return new DataRowMessage(0, values)
+}
+
+function commandComplete(text: string): CommandCompleteMessage {
+  return new CommandCompleteMessage(0, text)
+}
+
+describe('parseResults', () => {
+  it('parses object-mode rows with typed values', () => {
+    const messages = [
+      rowDescription([
+        { name: 'id', dataTypeID: 23 },
+        { name: 'name', dataTypeID: 25 },
+      ]),
+      dataRow(['1', 'alice']),
+      dataRow(['2', 'bob']),
+      commandComplete('SELECT 2'),
+    ]
+
+    const [result] = parseResults(messages, {})
+
+    expect(result.fields).toEqual([
+      { name: 'id', dataTypeID: 23 },
+      { name: 'name', dataTypeID: 25 },
+    ])
+    expect(result.rows).toEqual([
+      { id: 1, name: 'alice' },
+      { id: 2, name: 'bob' },
+    ])
+    expect(result.affectedRows).toBe(0)
+  })
+
+  it('parses array-mode rows', () => {
+    const messages = [
+      rowDescription([
+        { name: 'id', dataTypeID: 23 },
+        { name: 'active', dataTypeID: 16 },
+      ]),
+      dataRow(['42', 't']),
+      commandComplete('SELECT 1'),
+    ]
+
+    const [result] = parseResults(messages, {}, { rowMode: 'array' })
+
+    expect(result.rows).toEqual([[42, true]])
+  })
+
+  it('accumulates affected rows across multiple result sets', () => {
+    const messages = [
+      rowDescription([{ name: 'id', dataTypeID: 23 }]),
+      dataRow(['1']),
+      commandComplete('SELECT 1'),
+      rowDescription([{ name: 'id', dataTypeID: 23 }]),
+      dataRow(['2']),
+      commandComplete('SELECT 1'),
+    ]
+
+    const results = parseResults(messages, {})
+
+    expect(results).toHaveLength(2)
+    expect(results[0].rows).toEqual([{ id: 1 }])
+    expect(results[1].rows).toEqual([{ id: 2 }])
+    expect(results[0].affectedRows).toBe(0)
+    expect(results[1].affectedRows).toBe(0)
+  })
+
+  it('tracks INSERT/UPDATE/DELETE row counts', () => {
+    const insert = parseResults([commandComplete('INSERT 0 3')], {})[0]
+      .affectedRows
+    const update = parseResults([commandComplete('UPDATE 5')], {})[0]
+      .affectedRows
+    const del = parseResults([commandComplete('DELETE 2')], {})[0].affectedRows
+
+    expect(insert).toBe(3)
+    expect(update).toBe(5)
+    expect(del).toBe(2)
+  })
+
+  it('returns empty result set when no commandComplete is present', () => {
+    const [result] = parseResults([], {})
+
+    expect(result).toEqual({
+      affectedRows: 0,
+      rows: [],
+      fields: [],
+    })
+  })
+
+  it('applies custom parsers from options', () => {
+    const messages = [
+      rowDescription([{ name: 'value', dataTypeID: 25 }]),
+      dataRow(['hello']),
+      commandComplete('SELECT 1'),
+    ]
+
+    const [result] = parseResults(
+      messages,
+      {},
+      {
+        parsers: {
+          25: (value) => `parsed:${value}`,
+        },
+      },
+    )
+
+    expect(result.rows).toEqual([{ value: 'parsed:hello' }])
+  })
+
+  it('attaches blob when provided', () => {
+    const blob = new Blob(['test'])
+    const [result] = parseResults(
+      [commandComplete('SELECT 0')],
+      {},
+      undefined,
+      blob,
+    )
+
+    expect(result.blob).toBe(blob)
+  })
+})
+
+describe('parseDescribeStatementResults', () => {
+  it('returns parameter type OIDs when present', () => {
+    const msg = new ParameterDescriptionMessage(0, 2)
+    msg.dataTypeIDs = [23, 25]
+
+    expect(parseDescribeStatementResults([msg])).toEqual([23, 25])
+  })
+
+  it('returns empty array when parameter description is missing', () => {
+    expect(parseDescribeStatementResults([])).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary

Optimizes the hottest JS-side path in PGlite — converting PostgreSQL wire-protocol `DataRow` messages into JavaScript objects/arrays in `parseResults()`.

**Problem:** Every row previously allocated intermediate structures:
- **Object mode (default):** `Object.fromEntries(msg.fields.map(...))` — builds a `[key, value][]` array per row, then iterates it again
- **Array mode:** `msg.fields.map(...)` — callback-based allocation per row

Field names and type OIDs were also re-read from `currentResultSet.fields[i]` on every row even though they're constant for the entire result set.

**Fix:**
1. Hoist `fieldNames[]` and `fieldTypes[]` once per result set on `rowDescription`
2. Build object-mode rows with a tight indexed `for` loop (no `Object.fromEntries`)
3. Preallocate array-mode rows with `new Array(n)` and fill by index
4. Reset hoisted metadata on `commandComplete`

This is a behavior-preserving micro-optimization — a natural follow-up to #495, focused on large result-set workloads (#630). Does not overlap with maintainer drafts #973 (parse redesign) or #903 (streaming parse).

## Test plan

- [x] New unit tests in `packages/pglite/tests/parse.test.ts` (9 cases: object/array modes, multi-result sets, INSERT/UPDATE/DELETE counts, custom parsers, blob attachment, describe helper)
- [x] `pnpm vitest tests/parse.test.ts` — 9 passed
- [x] `pnpm test:basic` — 278 passed (57 files)
- [x] `pnpm stylecheck && pnpm typecheck` — clean
- [x] Changeset added for `@electric-sql/pglite` patch
