### PR TITLE
fix(live): resolve variable shadowing in unsubscribe callback filtering

### DIFF
--- a/packages/pglite/src/live/index.ts
+++ b/packages/pglite/src/live/index.ts
@@ -240,7 +240,7 @@ const setup = async (pg: PGliteInterface, _emscriptenOpts: any) => {
       // If there are no callbacks, unsubscribe from the notify triggers
       const unsubscribe = async (callback?: (results: Results<T>) => void) => {
         if (callback) {
-          callbacks = callbacks.filter((callback) => callback !== callback)
+          callbacks = callbacks.filter((cb) => cb !== callback)
         } else {
           callbacks = []
         }
@@ -503,7 +503,7 @@ const setup = async (pg: PGliteInterface, _emscriptenOpts: any) => {
         callback?: (changes: Array<Change<T>>) => void,
       ) => {
         if (callback) {
-          callbacks = callbacks.filter((callback) => callback !== callback)
+          callbacks = callbacks.filter((cb) => cb !== callback)
         } else {
           callbacks = []
         }
@@ -663,7 +663,7 @@ const setup = async (pg: PGliteInterface, _emscriptenOpts: any) => {
 
       const unsubscribe = async (callback?: (results: Results<T>) => void) => {
         if (callback) {
-          callbacks = callbacks.filter((callback) => callback !== callback)
+          callbacks = callbacks.filter((cb) => cb !== callback)
         } else {
           callbacks = []
         }


### PR DESCRIPTION
Hi team,

I found a bug in the live query unsubscribe logic where trying to remove a specific listener actually drops *all* subscribed callbacks.

### The Bug
In packages/pglite/src/live/index.ts, the inner variable in the ilter function shadows the outer callback parameter:
`	ypescript
callbacks = callbacks.filter((callback) => callback !== callback)
`
Because of the shadowing, it checks if the callback is not equal to itself, which always evaluates to alse. As a result, the ilter() returns an empty array, and all live query listeners are wiped out whenever a single unsubscription occurs.

### The Fix
I simply renamed the inner variable to cb in the three places this occurs:
`	ypescript
callbacks = callbacks.filter((cb) => cb !== callback)
`

This ensures the filter correctly identifies and removes only the intended listener while preserving the others. Let me know if you need any adjustments!
