### PR TITLE
fix: bind formatQuery params by position, not textual order

### DIFF
--- a/.changeset/heavy-params-bind.md
+++ b/.changeset/heavy-params-bind.md
@@ -1,0 +1,5 @@
+---
+'@electric-sql/pglite': patch
+---
+
+Fix `formatQuery` (used by `live.query`/`live.incrementalQuery` to inline parameters) emitting `%NL` instead of the positional `%N$L` format specifier. A bare `%NL` is "min width N" and consumes `format()` arguments sequentially, so placeholders that are out of textual order silently bound the wrong values, and repeated placeholders failed with `too few arguments for format()`.

--- a/packages/pglite/src/utils.ts
+++ b/packages/pglite/src/utils.ts
@@ -50,9 +50,12 @@ export async function formatQuery(
 
   const dataTypeIDs = parseDescribeStatementResults(messages)
 
-  // replace $1, $2, etc with  %1L, %2L, etc
+  // replace $1, $2, etc with %1$L, %2$L, etc
+  // The `$` in `%n$L` is required for positional arguments; a bare `%nL` is
+  // "min width n" and makes format() consume arguments sequentially, binding
+  // the wrong values when placeholders are out of order or repeated.
   const subbedQuery = query.replace(/\$([0-9]+)/g, (_, num) => {
-    return '%' + num + 'L'
+    return '%' + num + '$L'
   })
 
   const ret = await tx.query<{

--- a/packages/pglite/tests/format.test.js
+++ b/packages/pglite/tests/format.test.js
@@ -52,6 +52,38 @@ describe('format', () => {
     expect(ret3).toBe("SELECT * FROM test3 WHERE value = 'test';")
   })
 
+  it('params out of textual order', async () => {
+    await pg.exec(`
+      CREATE TABLE test5 (
+        id SERIAL PRIMARY KEY,
+        value VARCHAR
+      );
+    `)
+    const ret5 = await formatQuery(
+      pg,
+      'SELECT * FROM test5 WHERE value = $2 AND id = $1;',
+      [1, 'test'],
+    )
+    expect(ret5).toBe("SELECT * FROM test5 WHERE value = 'test' AND id = '1';")
+  })
+
+  it('repeated param', async () => {
+    await pg.exec(`
+      CREATE TABLE test6 (
+        id SERIAL PRIMARY KEY,
+        value VARCHAR
+      );
+    `)
+    const ret6 = await formatQuery(
+      pg,
+      'SELECT * FROM test6 WHERE value = $1 OR value = $1;',
+      ['test'],
+    )
+    expect(ret6).toBe(
+      "SELECT * FROM test6 WHERE value = 'test' OR value = 'test';",
+    )
+  })
+
   it('json', async () => {
     await pg.exec(`
       CREATE TABLE test4 (


### PR DESCRIPTION
formatQuery rewrote $N placeholders as %NL, but format() reads a bare %NL as "min width N" and consumes arguments sequentially. Out-of-order placeholders therefore silently bound the wrong values (live.query and live.incrementalQuery inline params through this path), and a repeated placeholder failed with "too few arguments for format()". Emit the positional %N$L instead.

Fixes #1055