### PR TITLE
fix: preserve host process.exitCode when closing PGlite

### DIFF
--- a/.changeset/preserve-exit-code-on-close.md
+++ b/.changeset/preserve-exit-code-on-close.md
@@ -1,0 +1,5 @@
+---
+'@electric-sql/pglite': patch
+---
+
+Preserve the host `process.exitCode` when closing a PGlite instance. `close()` calls `_emscripten_force_exit(0)`, whose Emscripten runtime sets `process.exitCode = 0`, clobbering any exit code the host process had already set. This mirrors the existing save/restore guards in `#init()` and `execProtocolRaw()`, so closing a database no longer silently resets the host process's exit code.

--- a/packages/pglite/src/pglite.ts
+++ b/packages/pglite/src/pglite.ts
@@ -820,6 +820,10 @@ export class PGlite
     this.#ready = false
     this.#running = false
 
+    // PGlite modifies process.exitCode when it does exit(XX)
+    // we need to restore the previous value
+    const prevExitCode = pglUtils.pgliteProc.exitCode
+
     try {
       // exit the runtime. since we're using `noExitRuntime: true` on our module,
       // we need to do this explicitly
@@ -829,6 +833,8 @@ export class PGlite
       if (e.status !== 0) {
         this.#log('Error when exiting', e.toString())
       }
+    } finally {
+      pglUtils.pgliteProc.exitCode = prevExitCode
     }
   }
 

--- a/packages/pglite/tests/basic.test.ts
+++ b/packages/pglite/tests/basic.test.ts
@@ -717,6 +717,18 @@ await testEsmCjsAndDTC(async (importType) => {
       expect(process.exitCode).toEqual(origExitCode)
     })
 
+    it('restores process.exitCode on close', async () => {
+      const origExitCode = process.exitCode
+      process.exitCode = 42
+
+      try {
+        await db.close()
+        expect(process.exitCode).toEqual(42)
+      } finally {
+        process.exitCode = origExitCode
+      }
+    })
+
     it("arrays with NULL elements should return null, not string 'NULL'", async () => {
       const pg = await PGlite.create()
 


### PR DESCRIPTION
Closing a PGlite instance resets the host process's `process.exitCode` to `0`. This wipes out whatever the host had already set.

The cause is `close()` calling `_emscripten_force_exit(0)`. Emscripten implements exit as `quit_ = (e, r) => { throw process.exitCode = e, r }`, so it writes `process.exitCode = 0` on the host Node process. The `#init()` and `execProtocolRaw()` paths already save and restore `process.exitCode` around their Emscripten calls, but `close()` was missing the same guard.

This adds that guard. It reuses the existing `pglUtils.pgliteProc.exitCode` save and restore pattern in a `finally`, like `execProtocolRaw()`. It also adds a test next to the existing `restores process.exitCode` one, plus a changeset.