### PR TITLE
fix: reject operations on closed transaction handles

### DIFF
--- a/.changeset/quiet-taxis-close.md
+++ b/.changeset/quiet-taxis-close.md
@@ -1,0 +1,5 @@
+---
+'@electric-sql/pglite': patch
+---
+
+Reject operations performed through transaction handles after the transaction has closed.

--- a/packages/pglite/src/base.ts
+++ b/packages/pglite/src/base.ts
@@ -477,6 +477,7 @@ export abstract class BasePGlite
           sqlStrings: TemplateStringsArray,
           ...params: any[]
         ): Promise<Results<T>> => {
+          checkClosed()
           const { query, params: actualParams } = queryTemplate(
             sqlStrings,
             ...params,
@@ -519,6 +520,7 @@ export abstract class BasePGlite
         return result
       } catch (e) {
         if (!closed) {
+          closed = true
           await this.#runExec('ROLLBACK')
         }
         this.#inTransaction = false

--- a/packages/pglite/tests/basic.test.ts
+++ b/packages/pglite/tests/basic.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { expectToThrowAsync, testEsmCjsAndDTC } from './test-utils.ts'
 import { identifier } from '../dist/templating.js'
-import { PGlite } from '../dist/index.js'
+import { PGlite, type Transaction } from '../dist/index.js'
 
 await testEsmCjsAndDTC(async (importType) => {
   const { PGlite } =
@@ -498,6 +498,61 @@ await testEsmCjsAndDTC(async (importType) => {
         affectedRows: 0,
       })
     })
+
+    it('rejects sql on closed transaction handles', async () => {
+      await db.exec('CREATE TABLE closed_transaction_test (id INT PRIMARY KEY)')
+
+      let committedTx: Transaction | undefined
+      await db.transaction(async (tx) => {
+        committedTx = tx
+      })
+
+      expect(committedTx?.closed).toBe(true)
+      await expect(
+        committedTx!.sql`INSERT INTO closed_transaction_test VALUES (1)`,
+      ).rejects.toThrow('Transaction is closed')
+
+      let rolledBackTx: Transaction | undefined
+      await db.transaction(async (tx) => {
+        rolledBackTx = tx
+        await tx.rollback()
+      })
+
+      expect(rolledBackTx?.closed).toBe(true)
+      await expect(
+        rolledBackTx!.sql`INSERT INTO closed_transaction_test VALUES (2)`,
+      ).rejects.toThrow('Transaction is closed')
+
+      const result = await db.query('SELECT id FROM closed_transaction_test')
+      expect(result.rows).toEqual([])
+    })
+
+    it('closes the transaction handle when the callback rejects', async () => {
+      await db.exec('CREATE TABLE closed_transaction_test (id INT PRIMARY KEY)')
+
+      let failedTx: Transaction | undefined
+      await expect(
+        db.transaction(async (tx) => {
+          failedTx = tx
+          throw new Error('boom')
+        }),
+      ).rejects.toThrow('boom')
+
+      expect(failedTx?.closed).toBe(true)
+      await expect(
+        failedTx!.query('INSERT INTO closed_transaction_test VALUES (1)'),
+      ).rejects.toThrow('Transaction is closed')
+      await expect(
+        failedTx!.exec('INSERT INTO closed_transaction_test VALUES (2)'),
+      ).rejects.toThrow('Transaction is closed')
+      await expect(
+        failedTx!.sql`INSERT INTO closed_transaction_test VALUES (3)`,
+      ).rejects.toThrow('Transaction is closed')
+
+      const result = await db.query('SELECT id FROM closed_transaction_test')
+      expect(result.rows).toEqual([])
+    })
+
     it('merge delete', async () => {
       await db.exec(`
       CREATE TABLE employees (


### PR DESCRIPTION
## Background

Retained transaction handles can currently execute queries after their transaction has ended. `tx.sql` skips the closed-handle guard, and the automatic rollback path for a rejected callback leaves the handle marked open. Subsequent operations then run against the live auto-commit connection, allowing writes that callers expect to have been rolled back to persist.

## Related issue

Fixes #1049

## Changes

- Call `checkClosed()` before executing `tx.sql`.
- Mark the transaction handle closed before rolling back a rejected callback.
- Add ESM and CJS regression coverage for commit, explicit rollback, and callback rejection.
- Add a patch changeset for `@electric-sql/pglite`.

## Tests

- `pnpm --dir packages/pglite build`
- `pnpm --dir packages/pglite typecheck`
- `pnpm --dir packages/pglite stylecheck`
- `pnpm --dir packages/pglite test` (283 passed, 1 skipped)
