### PR TITLE
node-postgres compat: add rowCount and command

### DIFF
--- a/.changeset/hungry-donkeys-tell.md
+++ b/.changeset/hungry-donkeys-tell.md
@@ -1,0 +1,5 @@
+---
+'@electric-sql/pglite': patch
+---
+
+Expose the fields node-postgres derives from the CommandComplete command tag on `Results`: `command` (e.g. `SELECT`, `INSERT`, `CREATE`), and `rowCount` (the per-statement count from the tag). The tag was already received and parsed internally to compute `affectedRows`, but these values were not surfaced. Matching node-postgres' `command`/`rowCount` result fields lets pg-compatible adapters report them without re-parsing SQL.

--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -456,6 +456,12 @@ Result objects have the following properties:
 - `affectedRows?: number` <br />
   Count of the rows affected by the query. Note, this is _not_ the count of rows returned, it is the number or rows in the database changed by the query.
 
+- `command?: string` <br />
+  The command of the query that was run, taken from the command tag reported by Postgres, e.g. `SELECT`, `INSERT` or `CREATE`. Matches the `command` field of node-postgres query results.
+
+- `rowCount?: number` <br />
+  The number of rows reported by the command tag, e.g. the rows returned by a `SELECT` or changed by an `UPDATE`. Not set when the tag carries no count (e.g. `CREATE TABLE`). Unlike `affectedRows` this is per statement and not cumulative; it matches the `rowCount` field of node-postgres query results.
+
 - `fields: { name: string; dataTypeID: number }[]`<br />
   Field name and Postgres data type ID for each field returned.
 

--- a/packages/pglite-pgmq/tests/pgmq.test.ts
+++ b/packages/pglite-pgmq/tests/pgmq.test.ts
@@ -56,6 +56,8 @@ describe(`pgmq`, () => {
           },
         ],
         affectedRows: 0,
+        command: 'SELECT',
+        rowCount: 1,
       },
     ])
 
@@ -79,6 +81,8 @@ SELECT * from pgmq.send(
           },
         ],
         affectedRows: 0,
+        command: 'SELECT',
+        rowCount: 1,
       },
     ])
 

--- a/packages/pglite-pgvector/tests/pgvector.test.ts
+++ b/packages/pglite-pgvector/tests/pgvector.test.ts
@@ -64,6 +64,8 @@ describe(`pgvector`, () => {
           },
         ],
         affectedRows: 0,
+        command: 'SELECT',
+        rowCount: 3,
       },
     ])
   })

--- a/packages/pglite-postgis/tests/postgis.test.ts
+++ b/packages/pglite-postgis/tests/postgis.test.ts
@@ -98,6 +98,8 @@ WHERE ST_Within(c.location, s.geom);`)
           },
         ],
         affectedRows: 0,
+        command: 'SELECT',
+        rowCount: 1,
       },
     ])
 
@@ -133,6 +135,8 @@ WHERE ST_Within(c.location, s.geom);`)
           },
         ],
         affectedRows: 0,
+        command: 'SELECT',
+        rowCount: 1,
       },
     ])
 
@@ -172,6 +176,8 @@ WHERE ST_Within(c.location, s.geom);`)
           },
         ],
         affectedRows: 0,
+        command: 'SELECT',
+        rowCount: 1,
       },
     ])
   })
@@ -208,6 +214,8 @@ WHERE ST_Within(c.location, s.geom);`)
           },
         ],
         affectedRows: 0,
+        command: 'SELECT',
+        rowCount: 1,
       },
     ])
   })

--- a/packages/pglite/src/interface.ts
+++ b/packages/pglite/src/interface.ts
@@ -173,6 +173,16 @@ export type Row<T = { [key: string]: any }> = T
 export type Results<T = { [key: string]: any }> = {
   rows: Row<T>[]
   affectedRows?: number
+  /**
+   * The command of the query that was run, e.g. "SELECT", "INSERT", "CREATE".
+   */
+  command?: string
+  /**
+   * The number of rows reported by the command tag, e.g. the rows returned
+   * by a SELECT or changed by an UPDATE. Unlike `affectedRows` this is per statement
+   * and not cumulative across a multi-statement query.
+   */
+  rowCount?: number
   fields: { name: string; dataTypeID: number }[]
   blob?: Blob // Only set when a file is returned, such as from a COPY command
 }

--- a/packages/pglite/src/parse.ts
+++ b/packages/pglite/src/parse.ts
@@ -61,13 +61,39 @@ export function parseResults(
       }
       case 'commandComplete': {
         const msg = message as CommandCompleteMessage
-        affectedRows += retrieveRowCount(msg)
 
-        resultSets.push({
+        // A command tag that carries a row count ends in it ("SELECT 2",
+        // "UPDATE 3", "INSERT 0 5"); all other tags end in a word
+        // ("CREATE TABLE").
+        const parts = msg.text.split(' ')
+        const command = parts[0]
+        const rowCount = parseInt(parts[parts.length - 1], 10)
+
+        switch (command) {
+          case 'INSERT':
+          case 'UPDATE':
+          case 'DELETE':
+          case 'COPY':
+          case 'MERGE':
+            affectedRows += rowCount
+            break
+        }
+
+        const result = {
           ...currentResultSet,
+          command,
           affectedRows,
-          ...(blob ? { blob } : {}),
-        })
+        }
+
+        if (!Number.isNaN(rowCount)) {
+          result.rowCount = rowCount
+        }
+
+        if (blob) {
+          result.blob = blob
+        }
+
+        resultSets.push(result)
 
         currentResultSet = { rows: [], fields: [] }
         break
@@ -84,21 +110,6 @@ export function parseResults(
   }
 
   return resultSets
-}
-
-function retrieveRowCount(msg: CommandCompleteMessage): number {
-  const parts = msg.text.split(' ')
-  switch (parts[0]) {
-    case 'INSERT':
-      return parseInt(parts[2], 10)
-    case 'UPDATE':
-    case 'DELETE':
-    case 'COPY':
-    case 'MERGE':
-      return parseInt(parts[1], 10)
-    default:
-      return 0
-  }
 }
 
 /** Get the dataTypeIDs from a list of messages, if it's available. */

--- a/packages/pglite/tests/array-types.test.ts
+++ b/packages/pglite/tests/array-types.test.ts
@@ -77,6 +77,8 @@ describe('array types', () => {
         },
       ],
       affectedRows: 0,
+      command: 'SELECT',
+      rowCount: 1,
     })
   })
 

--- a/packages/pglite/tests/basic.test.ts
+++ b/packages/pglite/tests/basic.test.ts
@@ -49,11 +49,15 @@ await testEsmCjsAndDTC(async (importType) => {
       expect(multiStatementResult).toEqual([
         {
           affectedRows: 1,
+          command: 'INSERT',
+          rowCount: 1,
           rows: [],
           fields: [],
         },
         {
           affectedRows: 2,
+          command: 'UPDATE',
+          rowCount: 1,
           rows: [],
           fields: [],
         },
@@ -64,6 +68,8 @@ await testEsmCjsAndDTC(async (importType) => {
             { name: 'name', dataTypeID: 25 },
           ],
           affectedRows: 2,
+          command: 'SELECT',
+          rowCount: 1,
         },
       ])
     })
@@ -98,6 +104,8 @@ await testEsmCjsAndDTC(async (importType) => {
           },
         ],
         affectedRows: 0,
+        command: 'SELECT',
+        rowCount: 1,
       })
 
       const updateResult = await db.query("UPDATE test SET name = 'test2';")
@@ -105,6 +113,8 @@ await testEsmCjsAndDTC(async (importType) => {
         rows: [],
         fields: [],
         affectedRows: 1,
+        command: 'UPDATE',
+        rowCount: 1,
       })
     })
 
@@ -137,6 +147,8 @@ await testEsmCjsAndDTC(async (importType) => {
           },
         ],
         affectedRows: 0,
+        command: 'SELECT',
+        rowCount: 1,
       })
 
       const updateResult =
@@ -145,6 +157,8 @@ await testEsmCjsAndDTC(async (importType) => {
         rows: [],
         fields: [],
         affectedRows: 1,
+        command: 'UPDATE',
+        rowCount: 1,
       })
     })
 
@@ -343,6 +357,8 @@ await testEsmCjsAndDTC(async (importType) => {
           },
         ],
         affectedRows: 0,
+        command: 'SELECT',
+        rowCount: 1,
       })
     })
 
@@ -376,6 +392,8 @@ await testEsmCjsAndDTC(async (importType) => {
           },
         ],
         affectedRows: 0,
+        command: 'SELECT',
+        rowCount: 1,
       })
     })
 
@@ -428,6 +446,8 @@ await testEsmCjsAndDTC(async (importType) => {
           },
         ],
         affectedRows: 0,
+        command: 'SELECT',
+        rowCount: 1,
       })
     })
 
@@ -472,6 +492,8 @@ await testEsmCjsAndDTC(async (importType) => {
             },
           ],
           affectedRows: 0,
+          command: 'SELECT',
+          rowCount: 2,
         })
         await tx.rollback()
       })
@@ -496,6 +518,8 @@ await testEsmCjsAndDTC(async (importType) => {
           },
         ],
         affectedRows: 0,
+        command: 'SELECT',
+        rowCount: 1,
       })
     })
     it('merge delete', async () => {
@@ -594,6 +618,8 @@ await testEsmCjsAndDTC(async (importType) => {
           },
         ],
         affectedRows: 0,
+        command: 'SELECT',
+        rowCount: 2,
       })
     })
 
@@ -634,6 +660,8 @@ await testEsmCjsAndDTC(async (importType) => {
           { name: 'last_name', dataTypeID: 25 },
         ],
         affectedRows: 0,
+        command: 'SELECT',
+        rowCount: 1,
       })
     })
     it('timezone', async () => {
@@ -821,6 +849,8 @@ await testEsmCjsAndDTC(async (importType) => {
           },
         ],
         affectedRows: 0,
+        command: 'SELECT',
+        rowCount: 1,
       })
     })
   })

--- a/packages/pglite/tests/targets/deno/basic.test.deno.js
+++ b/packages/pglite/tests/targets/deno/basic.test.deno.js
@@ -26,11 +26,15 @@ Deno.test({
     assertEquals(multiStatementResult, [
       {
         affectedRows: 1,
+        command: 'INSERT',
+        rowCount: 1,
         rows: [],
         fields: [],
       },
       {
         affectedRows: 2,
+        command: 'UPDATE',
+        rowCount: 1,
         rows: [],
         fields: [],
       },
@@ -41,6 +45,8 @@ Deno.test({
           { name: 'name', dataTypeID: 25 },
         ],
         affectedRows: 2,
+        command: 'SELECT',
+        rowCount: 1,
       },
     ])
   },

--- a/packages/pglite/tests/targets/deno/basic.test.deno.js
+++ b/packages/pglite/tests/targets/deno/basic.test.deno.js
@@ -86,6 +86,8 @@ Deno.test({
         },
       ],
       affectedRows: 0,
+      command: 'SELECT',
+      rowCount: 1,
     })
 
     const updateResult = await db.query("UPDATE test SET name = 'test2';")
@@ -93,6 +95,8 @@ Deno.test({
       rows: [],
       fields: [],
       affectedRows: 1,
+      command: 'UPDATE',
+      rowCount: 1,
     })
   },
 })
@@ -238,6 +242,8 @@ Deno.test({
         },
       ],
       affectedRows: 0,
+      command: 'SELECT',
+      rowCount: 1,
     })
 
     // standardize timestamp comparison to UTC milliseconds to ensure predictable test runs on machines in different timezones.
@@ -282,6 +288,8 @@ Deno.test({
         },
       ],
       affectedRows: 0,
+      command: 'SELECT',
+      rowCount: 1,
     })
   },
 })
@@ -340,6 +348,8 @@ Deno.test({
           },
         ],
         affectedRows: 0,
+        command: 'SELECT',
+        rowCount: 2,
       })
       await tx.rollback()
     })
@@ -364,6 +374,8 @@ Deno.test({
         },
       ],
       affectedRows: 0,
+      command: 'SELECT',
+      rowCount: 1,
     })
   },
 })
@@ -422,6 +434,8 @@ Deno.test({
         },
       ],
       affectedRows: 0,
+      command: 'SELECT',
+      rowCount: 2,
     })
   },
 })

--- a/packages/pglite/tests/targets/deno/fs.test.deno.js
+++ b/packages/pglite/tests/targets/deno/fs.test.deno.js
@@ -67,6 +67,8 @@ Deno.test({
           { name: 'name', dataTypeID: 25 },
         ],
         affectedRows: 0,
+        command: 'SELECT',
+        rowCount: 1,
       },
     ])
 

--- a/packages/pglite/tests/targets/deno/fs.test.deno.js
+++ b/packages/pglite/tests/targets/deno/fs.test.deno.js
@@ -23,11 +23,15 @@ Deno.test({
     assertEquals(multiStatementResult, [
       {
         affectedRows: 1,
+        command: 'INSERT',
+        rowCount: 1,
         rows: [],
         fields: [],
       },
       {
         affectedRows: 2,
+        command: 'UPDATE',
+        rowCount: 1,
         rows: [],
         fields: [],
       },
@@ -38,6 +42,8 @@ Deno.test({
           { name: 'name', dataTypeID: 25 },
         ],
         affectedRows: 2,
+        command: 'SELECT',
+        rowCount: 1,
       },
     ])
 

--- a/packages/pglite/tests/targets/deno/pgvector.test.deno.js
+++ b/packages/pglite/tests/targets/deno/pgvector.test.deno.js
@@ -68,6 +68,8 @@ Deno.test({
           },
         ],
         affectedRows: 0,
+        command: 'SELECT',
+        rowCount: 3,
       },
     ])
   },


### PR DESCRIPTION
Some clients rely on the `rowCount` and `command` fields usually exposed by `node-postgres` (see [TypeORM](https://github.com/typeorm/typeorm/blob/281bfba42a5813b106bcf5ba79bc7f7251bd1e73/src/driver/postgres/PostgresQueryRunner.ts#L304-L320)). Currently `command` / `rowCount` is empty and misbehaves in TypeORM for example (`.affected` not being populated by TypeORM; see link above).

`node-postgres` for reference [here](https://github.com/brianc/node-postgres/blob/c5e8c9a57bff6d9160ec5dbd5c4f4c1e4c460711/packages/pg/lib/result.js#L28-L48).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/electric-sql/codesmith/pglite/pr/1067"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787557306&installation_model_id=8736&pr_number=1067&repository=electric-sql%2Fpglite&return_to=https%3A%2F%2Fgithub.com%2Felectric-sql%2Fpglite%2Fpull%2F1067&signature=8bbb604fe416faa3b1cf19c40036ecb2f06dbfe7fa4e753e6313f6ef5fde73cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->