### PR TITLE
fix: reset protocol parser state after malformed messages

### DIFF
--- a/.changeset/calm-parsers-recover.md
+++ b/.changeset/calm-parsers-recover.md
@@ -1,0 +1,5 @@
+---
+'@electric-sql/pglite': patch
+---
+
+Reset retained protocol parser state after a malformed backend message so later queries can recover.

--- a/packages/pg-protocol/src/parser.ts
+++ b/packages/pg-protocol/src/parser.ts
@@ -99,12 +99,18 @@ export class Parser {
       const length = this.#bufferView.getUint32(offset + CODE_LENGTH, false)
       const fullMessageLength = CODE_LENGTH + length
       if (fullMessageLength + offset <= bufferFullLength && length > 0) {
-        const message = this.#handlePacket(
-          offset + HEADER_LENGTH,
-          code,
-          length,
-          this.#bufferView.buffer,
-        )
+        let message: BackendMessage
+        try {
+          message = this.#handlePacket(
+            offset + HEADER_LENGTH,
+            code,
+            length,
+            this.#bufferView.buffer,
+          )
+        } catch (error) {
+          this.#resetBuffer()
+          throw error
+        }
         callback(message)
         offset += fullMessageLength
       } else {
@@ -113,14 +119,18 @@ export class Parser {
     }
     if (offset === bufferFullLength) {
       // No more use for the buffer
-      this.#bufferView = new DataView(emptyBuffer)
-      this.#bufferRemainingLength = 0
-      this.#bufferOffset = 0
+      this.#resetBuffer()
     } else {
       // Adjust the cursors of remainingBuffer
       this.#bufferRemainingLength = bufferFullLength - offset
       this.#bufferOffset = offset
     }
+  }
+
+  #resetBuffer(): void {
+    this.#bufferView = new DataView(emptyBuffer)
+    this.#bufferRemainingLength = 0
+    this.#bufferOffset = 0
   }
 
   #mergeBuffer(buffer: ArrayBuffer): void {

--- a/packages/pg-protocol/test/inbound-parser.test.ts
+++ b/packages/pg-protocol/test/inbound-parser.test.ts
@@ -341,6 +341,23 @@ describe('PgPacketStream', () => {
         length: oneFieldBuf.byteLength - 1,
       })
     })
+
+    it('recovers after a malformed data row throws', () => {
+      const malformedDataRow = new Uint8Array(11)
+      const view = new DataView(malformedDataRow.buffer)
+      malformedDataRow[0] = 0x44
+      view.setUint32(1, 10, false)
+      view.setInt16(5, 2, false)
+      view.setInt32(7, 0x40000000, false)
+
+      const parser = new Parser()
+      expect(() => parser.parse(malformedDataRow, () => {})).toThrow(RangeError)
+
+      const messages: BackendMessage[] = []
+      parser.parse(readyForQueryBuffer, (message) => messages.push(message))
+
+      expect(messages).toEqual([expectedReadyForQueryMessage])
+    })
   })
 
   describe('notice message', () => {


### PR DESCRIPTION
## 작업 배경

Malformed backend packets can make protocol decoding throw while the parser still retains the failed buffer. Reusing that parser then prepends the stale bytes to later responses and prevents recovery.

## 티켓 및 링크

- Closes [#1052](https://github.com/electric-sql/pglite/issues/1052)

## 작업 내용

- Reset retained parser buffer state when internal packet decoding throws, then rethrow the original error.
- Keep consumer callback errors outside the reset path.
- Add a regression test that reuses the same parser successfully after a malformed `DataRow`.
- Add a patch changeset for `@electric-sql/pglite`.

## 테스트

- `pnpm --filter @electric-sql/pg-protocol exec vitest run` (81 passed)
- `pnpm --filter @electric-sql/pg-protocol typecheck`
- `pnpm --filter @electric-sql/pg-protocol stylecheck`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/electric-sql/codesmith/pglite/pr/1072"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788325483&installation_model_id=8736&pr_number=1072&repository=electric-sql%2Fpglite&return_to=https%3A%2F%2Fgithub.com%2Felectric-sql%2Fpglite%2Fpull%2F1072&signature=075c88455b26e68ae572f658acd12bf63ca841f9fbbd054528549e4f20c21e6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->