### PR TITLE
fix: parse dates with years before 100 correctly

### DIFF
--- a/.changeset/fix-date-year-before-100.md
+++ b/.changeset/fix-date-year-before-100.md
@@ -1,0 +1,5 @@
+---
+'@electric-sql/pglite': patch
+---
+
+Fix `date` / `timestamp` / `timestamptz` values with a year before 100 being parsed as 19xx/20xx. PostgreSQL emits such years as e.g. `0050-06-15 12:30:00+00`, which is not strict ISO 8601, so `new Date()` fell back to its legacy parser and mapped the year into the 1900s (or returned `Invalid Date`). For example `0050` became `1950` and `0001` became `2015`. The text is now normalized to ISO 8601 before parsing; years 100 and above are unaffected.

--- a/packages/pglite/src/types.ts
+++ b/packages/pglite/src/types.ts
@@ -153,7 +153,13 @@ export const types = {
         throw new Error('Invalid input for date type')
       }
     },
-    parse: (x: string | number) => new Date(x),
+    parse: (x: string | number) => {
+      if (typeof x === 'string') {
+        const iso = x.replace(' ', 'T')
+        return new Date(iso === x ? x : iso.replace(/([+-]\d{2})$/, '$1:00'))
+      }
+      return new Date(x)
+    },
   },
   bytea: {
     to: BYTEA,

--- a/packages/pglite/tests/types.test.ts
+++ b/packages/pglite/tests/types.test.ts
@@ -66,6 +66,12 @@ describe('parse', () => {
     ).toEqual(new Date('2021-01-01T12:00:00.000Z').getUTCMilliseconds())
   })
 
+  it('timestamptz 1184 before year 100', () => {
+    expect(types.parseType('0050-06-15 12:30:00+00', 1184)).toEqual(
+      new Date('0050-06-15T12:30:00.000Z'),
+    )
+  })
+
   it('bytea 17', () => {
     expect(types.parseType('\\x010203', 17)).toEqual(Uint8Array.from([1, 2, 3]))
   })


### PR DESCRIPTION
## Problem

The `date` / `timestamp` / `timestamptz` parser in `packages/pglite/src/types.ts` is `parse: (x) => new Date(x)`. PostgreSQL emits a year below 100 as e.g. `0050-06-15 12:30:00+00`, which is not strict ISO 8601 (space separator, two-digit offset), so `new Date` falls back to its legacy parser, which maps the year into the 1900s or returns garbage:

```js
const db = new PGlite()
;(await db.query(`select '0050-06-15 12:30:00+00'::timestamptz as v`)).rows[0].v  // 1950-06-15  (should be 0050)
;(await db.query(`select '0099-06-15 12:30:00+00'::timestamptz as v`)).rows[0].v  // 1999-06-15  (should be 0099)
;(await db.query(`select '0001-06-15 12:30:00+00'::timestamptz as v`)).rows[0].v  // 2015-01-06  (garbage)
```

Any `date` / `timestamp` / `timestamptz` with a year of 1 to 99 is silently corrupted (off by ~1900 years, or `Invalid Date`).

## Fix

Normalize the text to ISO 8601 before `new Date`: replace the date/time space with `T`, and expand a two-digit timezone offset `+HH` to `+HH:00`. The ISO parser then handles years below 100 correctly. Years 100 and above produce identical output to before.

## Test

Added `timestamptz 1184 before year 100` to `packages/pglite/tests/types.test.ts`. Verified via `parseType` that years 1–99 now parse to the correct year, and that years ≥ 100 and the `date` (1082) / `timestamp` (1114) cases are unchanged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/electric-sql/codesmith/pglite/pr/1074"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788480985&installation_model_id=8736&pr_number=1074&repository=electric-sql%2Fpglite&return_to=https%3A%2F%2Fgithub.com%2Felectric-sql%2Fpglite%2Fpull%2F1074&signature=9ca7fd3473ec661e1ca4a4d768d320002ce5b0255ac971666a5c850acb6ab4c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->