### PR TITLE
Fix PGlite.create options without a data directory

### DIFF
--- a/.changeset/fresh-options-create.md
+++ b/.changeset/fresh-options-create.md
@@ -1,0 +1,5 @@
+---
+'@electric-sql/pglite': patch
+---
+
+Apply the second options argument when calling `PGlite.create(undefined, options)`.

--- a/packages/pglite/src/pglite.ts
+++ b/packages/pglite/src/pglite.ts
@@ -260,7 +260,7 @@ export class PGlite
             dataDir: dataDirOrPGliteOptions,
             ...(options ?? {}),
           }
-        : (dataDirOrPGliteOptions ?? {})
+        : (dataDirOrPGliteOptions ?? options ?? {})
 
     const pg = new PGlite(resolvedOpts)
     await pg.waitReady

--- a/packages/pglite/tests/instantiation.test.ts
+++ b/packages/pglite/tests/instantiation.test.ts
@@ -4,6 +4,12 @@ import { PGlite } from '../dist/index.js'
 describe('instantiation', () => {
   testInstatiationMethod('constructor')
   testInstatiationMethod('static `create` factory')
+
+  it('should apply options when the data dir is undefined', async () => {
+    const pg = await PGlite.create(undefined, { debug: 1 })
+
+    expect(pg.debug).toBe(1)
+  })
 })
 
 function testInstatiationMethod(


### PR DESCRIPTION
## 작업 배경

The `PGlite.create` overload permits passing `undefined` as the data directory and providing options as the second argument. The implementation previously discarded those options and silently used the defaults.

## 티켓 및 링크

- Closes [#773](https://github.com/electric-sql/pglite/issues/773)

## 작업 내용

- Fall back to the second options argument when the data directory is `undefined`.
- Add a regression test using the public `debug` option.
- Add a patch changeset for `@electric-sql/pglite`.

## 테스트

- `pnpm --dir packages/pglite exec vitest run tests/instantiation.test.ts --reporter=dot`
- `pnpm --dir packages/pglite typecheck`
- `pnpm --dir packages/pglite stylecheck`
