### PR TITLE
Fix execProtocolRawSync spin after backend exit

### DIFF
--- a/.changeset/calm-wasps-exit.md
+++ b/.changeset/calm-wasps-exit.md
@@ -1,0 +1,5 @@
+---
+'@electric-sql/pglite': patch
+---
+
+Prevent `execProtocolRawSync` from spinning indefinitely when the Postgres WASM backend exits or crashes by rethrowing exceptions outside the database error longjmp path.

--- a/packages/pglite/src/pglite.ts
+++ b/packages/pglite/src/pglite.ts
@@ -955,7 +955,13 @@ export class PGlite
             // that we call whenever the exception longjmp is executed
             // like this we also just need to setjmp only once, in a similar fashion to the original code.
             mod._PostgresMainLongJmp()
-          } else {
+          } else if (
+            e.name === 'ExitStatus' ||
+            e instanceof WebAssembly.RuntimeError
+          ) {
+            // Emscripten throws these when the backend exits or crashes.
+            // Other exceptions are left with their previous handling because
+            // extensions can throw after the protocol message was processed.
             throw e
           }
           // even if there is an exception caused by one of the batched queries,

--- a/packages/pglite/src/pglite.ts
+++ b/packages/pglite/src/pglite.ts
@@ -930,6 +930,10 @@ export class PGlite
     }
 
     const prevExitCode = pglUtils.pgliteProc.exitCode
+    let protocolError: unknown
+    let cleanupError: unknown
+    let hasProtocolError = false
+    let hasCleanupError = false
 
     // execute the message
     try {
@@ -951,6 +955,8 @@ export class PGlite
             // that we call whenever the exception longjmp is executed
             // like this we also just need to setjmp only once, in a similar fashion to the original code.
             mod._PostgresMainLongJmp()
+          } else {
+            throw e
           }
           // even if there is an exception caused by one of the batched queries,
           // we need to continue processing the rest without throwing.
@@ -958,10 +964,26 @@ export class PGlite
           // and returned to the caller for handling
         }
       }
+    } catch (e) {
+      protocolError = e
+      hasProtocolError = true
     } finally {
-      mod._PostgresSendReadyForQueryIfNecessary()
-      mod._pgl_pq_flush()
-      pglUtils.pgliteProc.exitCode = prevExitCode
+      try {
+        mod._PostgresSendReadyForQueryIfNecessary()
+        mod._pgl_pq_flush()
+      } catch (e) {
+        cleanupError = e
+        hasCleanupError = true
+      } finally {
+        pglUtils.pgliteProc.exitCode = prevExitCode
+      }
+    }
+
+    if (hasProtocolError) {
+      throw protocolError
+    }
+    if (hasCleanupError) {
+      throw cleanupError
     }
 
     this.#outputData = []

--- a/packages/pglite/src/pglite.ts
+++ b/packages/pglite/src/pglite.ts
@@ -957,9 +957,10 @@ export class PGlite
             mod._PostgresMainLongJmp()
           } else if (
             e.name === 'ExitStatus' ||
-            e instanceof WebAssembly.RuntimeError
+            (e instanceof WebAssembly.RuntimeError &&
+              this.#readOffset < message.length)
           ) {
-            // Emscripten throws these when the backend exits or crashes.
+            // Emscripten throws these when the backend exits mid-message.
             // Other exceptions are left with their previous handling because
             // extensions can throw after the protocol message was processed.
             throw e

--- a/packages/pglite/tests/exec-protocol-backend-exit.test.ts
+++ b/packages/pglite/tests/exec-protocol-backend-exit.test.ts
@@ -14,6 +14,7 @@ type ReproMode =
   | 'no-transaction'
   | 'transaction'
   | 'runtime-error'
+  | 'runtime-error-after-message'
   | 'runtime-error-with-cleanup-error'
 
 interface ReproResult {
@@ -144,6 +145,16 @@ describe('execProtocolRawSync backend exits', () => {
         name: 'RuntimeError',
         message: 'synthetic runtime failure',
       },
+      processExitCode: 42,
+    })
+    expectChildExited(result)
+  })
+
+  it('preserves recoverable RuntimeError after processing the message', async () => {
+    const result = await runBackendExitRepro('runtime-error-after-message')
+
+    expect(result).toMatchObject({
+      outcome: 'resolved',
       processExitCode: 42,
     })
     expectChildExited(result)

--- a/packages/pglite/tests/exec-protocol-backend-exit.test.ts
+++ b/packages/pglite/tests/exec-protocol-backend-exit.test.ts
@@ -3,7 +3,9 @@ import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 
 const RESULT_PREFIX = 'PGLITE_BACKEND_EXIT_RESULT:'
-const CHILD_TIMEOUT_MS = 2000
+const READY_PREFIX = 'PGLITE_BACKEND_EXIT_READY'
+const CHILD_STARTUP_TIMEOUT_MS = 15_000
+const CHILD_BACKEND_OPERATION_TIMEOUT_MS = 2000
 const fixturePath = fileURLToPath(
   new URL('./fixtures/exec-protocol-backend-exit.js', import.meta.url),
 )
@@ -26,29 +28,45 @@ interface ReproResult {
   childExitCode: number
 }
 
-function runBackendExitRepro(mode: ReproMode): Promise<ReproResult> {
+function runBackendExitRepro(
+  mode: ReproMode,
+  startupDelayMs = 0,
+): Promise<ReproResult> {
   return new Promise((resolve, reject) => {
-    const child = spawn(process.execPath, [fixturePath, mode], {
-      stdio: ['ignore', 'pipe', 'pipe'],
-    })
+    const child = spawn(
+      process.execPath,
+      [fixturePath, mode, startupDelayMs.toString()],
+      {
+        stdio: ['ignore', 'pipe', 'pipe'],
+      },
+    )
     const childPid = child.pid
     let stdout = ''
     let stderr = ''
     let timedOut = false
+    let timeoutPhase = 'startup'
+    let timeoutMs = CHILD_STARTUP_TIMEOUT_MS
+
+    const killOnTimeout = () => {
+      timedOut = true
+      child.kill('SIGKILL')
+    }
+    let timeout = setTimeout(killOnTimeout, timeoutMs)
 
     child.stdout.setEncoding('utf8')
     child.stdout.on('data', (chunk) => {
       stdout += chunk
+      if (timeoutPhase === 'startup' && stdout.includes(`${READY_PREFIX}\n`)) {
+        clearTimeout(timeout)
+        timeoutPhase = 'backend operation'
+        timeoutMs = CHILD_BACKEND_OPERATION_TIMEOUT_MS
+        timeout = setTimeout(killOnTimeout, timeoutMs)
+      }
     })
     child.stderr.setEncoding('utf8')
     child.stderr.on('data', (chunk) => {
       stderr += chunk
     })
-
-    const timeout = setTimeout(() => {
-      timedOut = true
-      child.kill('SIGKILL')
-    }, CHILD_TIMEOUT_MS)
 
     child.once('error', (error) => {
       clearTimeout(timeout)
@@ -61,7 +79,7 @@ function runBackendExitRepro(mode: ReproMode): Promise<ReproResult> {
       if (timedOut) {
         reject(
           new Error(
-            `Child ${childPid} timed out after ${CHILD_TIMEOUT_MS}ms and exited with signal ${signal}`,
+            `Child ${childPid} timed out during ${timeoutPhase} after ${timeoutMs}ms and exited with signal ${signal}`,
           ),
         )
         return
@@ -133,6 +151,20 @@ describe('execProtocolRawSync backend exits', () => {
 
   it('preserves RuntimeError when cleanup also throws', async () => {
     const result = await runBackendExitRepro('runtime-error-with-cleanup-error')
+
+    expect(result).toMatchObject({
+      outcome: 'rejected',
+      error: {
+        name: 'RuntimeError',
+        message: 'synthetic runtime failure',
+      },
+      processExitCode: 42,
+    })
+    expectChildExited(result)
+  })
+
+  it('allows slow child initialization before timing the backend operation', async () => {
+    const result = await runBackendExitRepro('runtime-error', 2500)
 
     expect(result).toMatchObject({
       outcome: 'rejected',

--- a/packages/pglite/tests/exec-protocol-backend-exit.test.ts
+++ b/packages/pglite/tests/exec-protocol-backend-exit.test.ts
@@ -1,0 +1,147 @@
+import { spawn } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const RESULT_PREFIX = 'PGLITE_BACKEND_EXIT_RESULT:'
+const CHILD_TIMEOUT_MS = 2000
+const fixturePath = fileURLToPath(
+  new URL('./fixtures/exec-protocol-backend-exit.js', import.meta.url),
+)
+
+type ReproMode =
+  | 'no-transaction'
+  | 'transaction'
+  | 'runtime-error'
+  | 'runtime-error-with-cleanup-error'
+
+interface ReproResult {
+  outcome: 'resolved' | 'rejected' | 'fixture-error'
+  error?: {
+    name?: string
+    message: string
+    status?: number
+  }
+  processExitCode?: number
+  childPid: number
+  childExitCode: number
+}
+
+function runBackendExitRepro(mode: ReproMode): Promise<ReproResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [fixturePath, mode], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    const childPid = child.pid
+    let stdout = ''
+    let stderr = ''
+    let timedOut = false
+
+    child.stdout.setEncoding('utf8')
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk
+    })
+    child.stderr.setEncoding('utf8')
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk
+    })
+
+    const timeout = setTimeout(() => {
+      timedOut = true
+      child.kill('SIGKILL')
+    }, CHILD_TIMEOUT_MS)
+
+    child.once('error', (error) => {
+      clearTimeout(timeout)
+      reject(error)
+    })
+
+    child.once('exit', (code, signal) => {
+      clearTimeout(timeout)
+
+      if (timedOut) {
+        reject(
+          new Error(
+            `Child ${childPid} timed out after ${CHILD_TIMEOUT_MS}ms and exited with signal ${signal}`,
+          ),
+        )
+        return
+      }
+
+      if (code !== 0) {
+        reject(
+          new Error(
+            `Child ${childPid} exited with code ${code}: ${stderr || stdout}`,
+          ),
+        )
+        return
+      }
+
+      const resultLine = stdout
+        .split('\n')
+        .find((line) => line.startsWith(RESULT_PREFIX))
+
+      if (!resultLine || childPid === undefined) {
+        reject(new Error(`Child did not report a result: ${stderr || stdout}`))
+        return
+      }
+
+      resolve({
+        ...JSON.parse(resultLine.slice(RESULT_PREFIX.length)),
+        childPid,
+        childExitCode: code,
+      })
+    })
+  })
+}
+
+function expectChildExited(result: ReproResult) {
+  expect(result.childExitCode).toBe(0)
+  expect(() => process.kill(result.childPid, 0)).toThrow()
+}
+
+describe('execProtocolRawSync backend exits', () => {
+  it.each(['no-transaction', 'transaction'] as const)(
+    'rethrows ExitStatus with %s',
+    async (mode) => {
+      const result = await runBackendExitRepro(mode)
+
+      expect(result).toMatchObject({
+        outcome: 'rejected',
+        error: {
+          name: 'ExitStatus',
+          status: 1,
+        },
+        processExitCode: 42,
+      })
+      expectChildExited(result)
+    },
+  )
+
+  it('rethrows RuntimeError', async () => {
+    const result = await runBackendExitRepro('runtime-error')
+
+    expect(result).toMatchObject({
+      outcome: 'rejected',
+      error: {
+        name: 'RuntimeError',
+        message: 'synthetic runtime failure',
+      },
+      processExitCode: 42,
+    })
+    expectChildExited(result)
+  })
+
+  it('preserves RuntimeError when cleanup also throws', async () => {
+    const result = await runBackendExitRepro('runtime-error-with-cleanup-error')
+
+    expect(result).toMatchObject({
+      outcome: 'rejected',
+      error: {
+        name: 'RuntimeError',
+        message: 'synthetic runtime failure',
+      },
+      processExitCode: 42,
+    })
+    expectChildExited(result)
+  })
+})

--- a/packages/pglite/tests/fixtures/exec-protocol-backend-exit.js
+++ b/packages/pglite/tests/fixtures/exec-protocol-backend-exit.js
@@ -46,7 +46,16 @@ try {
   await new Promise((resolve) => setTimeout(resolve, startupDelayMs))
   const db = await PGlite.create()
 
-  if (mode.startsWith('runtime-error')) {
+  if (mode === 'runtime-error-after-message') {
+    await db.exec('CREATE TABLE t(a int)')
+    const postgresMainLoopOnce = db.Module._PostgresMainLoopOnce
+    db.Module._PostgresMainLoopOnce = () => {
+      postgresMainLoopOnce()
+      throw new WebAssembly.RuntimeError(
+        'synthetic runtime failure after message',
+      )
+    }
+  } else if (mode.startsWith('runtime-error')) {
     db.Module._PostgresMainLoopOnce = () => {
       if (mode === 'runtime-error-with-cleanup-error') {
         process.exitCode = 1
@@ -68,7 +77,9 @@ try {
   await reportReady()
 
   try {
-    if (mode.startsWith('runtime-error')) {
+    if (mode === 'runtime-error-after-message') {
+      await db.exec('SELECT 1')
+    } else if (mode.startsWith('runtime-error')) {
       db.execProtocolRawSync(Uint8Array.of('Q'.charCodeAt(0)))
     } else {
       await db.exec('COPY t FROM STDIN')
@@ -79,7 +90,7 @@ try {
         outcome: 'resolved',
         processExitCode: process.exitCode,
       },
-      2,
+      mode === 'runtime-error-after-message' ? 0 : 2,
     )
   } catch (error) {
     await reportResultAndExit({

--- a/packages/pglite/tests/fixtures/exec-protocol-backend-exit.js
+++ b/packages/pglite/tests/fixtures/exec-protocol-backend-exit.js
@@ -1,6 +1,7 @@
 import { PGlite } from '../../dist/index.js'
 
 const RESULT_PREFIX = 'PGLITE_BACKEND_EXIT_RESULT:'
+const READY_PREFIX = 'PGLITE_BACKEND_EXIT_READY'
 const ORIGINAL_EXIT_CODE = 42
 
 function serializeError(error) {
@@ -25,10 +26,24 @@ function reportResultAndExit(result, exitCode = 0) {
   })
 }
 
+function reportReady() {
+  return new Promise((resolve, reject) => {
+    process.stdout.write(`${READY_PREFIX}\n`, (error) => {
+      if (error) {
+        reject(error)
+      } else {
+        resolve()
+      }
+    })
+  })
+}
+
 const mode = process.argv[2]
+const startupDelayMs = Number(process.argv[3] ?? 0)
 process.exitCode = ORIGINAL_EXIT_CODE
 
 try {
+  await new Promise((resolve) => setTimeout(resolve, startupDelayMs))
   const db = await PGlite.create()
 
   if (mode.startsWith('runtime-error')) {
@@ -49,6 +64,8 @@ try {
       await db.exec('BEGIN')
     }
   }
+
+  await reportReady()
 
   try {
     if (mode.startsWith('runtime-error')) {

--- a/packages/pglite/tests/fixtures/exec-protocol-backend-exit.js
+++ b/packages/pglite/tests/fixtures/exec-protocol-backend-exit.js
@@ -1,0 +1,83 @@
+import { PGlite } from '../../dist/index.js'
+
+const RESULT_PREFIX = 'PGLITE_BACKEND_EXIT_RESULT:'
+const ORIGINAL_EXIT_CODE = 42
+
+function serializeError(error) {
+  return {
+    name:
+      typeof error === 'object' && error !== null
+        ? error.constructor?.name
+        : typeof error,
+    message: error instanceof Error ? error.message : String(error),
+    status:
+      typeof error === 'object' && error !== null && 'status' in error
+        ? error.status
+        : undefined,
+  }
+}
+
+function reportResultAndExit(result, exitCode = 0) {
+  return new Promise(() => {
+    process.stdout.write(`${RESULT_PREFIX}${JSON.stringify(result)}\n`, () =>
+      process.exit(exitCode),
+    )
+  })
+}
+
+const mode = process.argv[2]
+process.exitCode = ORIGINAL_EXIT_CODE
+
+try {
+  const db = await PGlite.create()
+
+  if (mode.startsWith('runtime-error')) {
+    db.Module._PostgresMainLoopOnce = () => {
+      if (mode === 'runtime-error-with-cleanup-error') {
+        process.exitCode = 1
+      }
+      throw new WebAssembly.RuntimeError('synthetic runtime failure')
+    }
+    if (mode === 'runtime-error-with-cleanup-error') {
+      db.Module._PostgresSendReadyForQueryIfNecessary = () => {
+        throw new Error('synthetic cleanup failure')
+      }
+    }
+  } else {
+    await db.exec('CREATE TABLE t(a int)')
+    if (mode === 'transaction') {
+      await db.exec('BEGIN')
+    }
+  }
+
+  try {
+    if (mode.startsWith('runtime-error')) {
+      db.execProtocolRawSync(Uint8Array.of('Q'.charCodeAt(0)))
+    } else {
+      await db.exec('COPY t FROM STDIN')
+    }
+
+    await reportResultAndExit(
+      {
+        outcome: 'resolved',
+        processExitCode: process.exitCode,
+      },
+      2,
+    )
+  } catch (error) {
+    await reportResultAndExit({
+      outcome: 'rejected',
+      error: serializeError(error),
+      processExitCode: process.exitCode,
+    })
+  }
+} catch (error) {
+  await reportResultAndExit(
+    {
+      outcome: 'fixture-error',
+      error: serializeError(error),
+      processExitCode: process.exitCode,
+    },
+    3,
+  )
+}


### PR DESCRIPTION
## 작업 배경

`execProtocolRawSync` swallowed exceptions from the Postgres WASM main loop unless they matched the database error longjmp sentinel. When the backend exited or crashed mid-message, the input offsets stopped advancing and the synchronous loop retried forever at 100% CPU.

## 티켓 및 링크

- [GH-1058](https://github.com/electric-sql/pglite/issues/1058)

## 작업 내용

- Rethrow `ExitStatus`, `RuntimeError`, and other exceptions outside the known longjmp recovery path.
- Preserve the original protocol error when cleanup also fails, while always restoring the host `process.exitCode`.
- Add bounded child-process regressions for backend exit with and without an open transaction, synthetic runtime failure, cleanup failure, and child cleanup.
- Add a patch changeset for `@electric-sql/pglite`.

## 테스트

- `pnpm --dir packages/pglite exec vitest run tests/exec-protocol-backend-exit.test.ts tests/exec-protocol.test.ts --reporter=verbose`
- `pnpm --dir packages/pglite exec vitest run tests/basic.test.ts --testNamePattern='restores process.exitCode' --reporter=verbose`
- `pnpm --dir packages/pglite typecheck`
- `pnpm --dir packages/pglite stylecheck`
