### PR TITLE
fix: restore a saved undefined process.exitCode as an explicit 0

### DIFF
--- a/.changeset/restore-exit-code-explicit-zero.md
+++ b/.changeset/restore-exit-code-explicit-zero.md
@@ -1,0 +1,14 @@
+---
+'@electric-sql/pglite': patch
+---
+
+Restore a saved `process.exitCode` as an explicit `0` when it was `undefined`.
+
+PGlite saves and restores `process.exitCode` around engine calls that may run
+`proc_exit(XX)`. On a clean host the saved value is `undefined`, and under bun
+`process.exitCode = undefined` is a no-op that leaves the current value in
+place — so the restore silently failed and the engine's `proc_exit(99)` boot
+sentinel survived, force-exiting an otherwise successful host process with code
+99. `close()` previously masked this by calling `_emscripten_force_exit(0)`,
+which set an explicit `0`; preserving the host exit code across `close()`
+removed that incidental reset and exposed the bug on every lane.

--- a/packages/pglite/src/pglite.ts
+++ b/packages/pglite/src/pglite.ts
@@ -40,6 +40,21 @@ import {
 
 import { pglUtils } from '@electric-sql/pglite-utils'
 
+/**
+ * Restore a `process.exitCode` captured before an engine call that may run
+ * `proc_exit(XX)`.
+ *
+ * A saved `undefined` must be restored as an explicit `0`: under bun,
+ * `process.exitCode = undefined` is a no-op that leaves the current value in
+ * place, so restoring `undefined` over the engine's `proc_exit(99)` boot
+ * sentinel does nothing and bun force-exits an otherwise successful host
+ * process with code 99. Assigning `0` is equivalent for exit status on every
+ * runtime.
+ */
+function restoreExitCode(previous: string | number | undefined): void {
+  pglUtils.pgliteProc.exitCode = previous ?? 0
+}
+
 class CurrentQuery {
   results: BackendMessage[] = []
   throwOnError: boolean = false
@@ -620,7 +635,7 @@ export class PGlite
       }
     }
 
-    pglUtils.pgliteProc.exitCode = prevExitCode
+    restoreExitCode(prevExitCode)
   }
 
   #handlePostgresqlConf(
@@ -839,7 +854,7 @@ export class PGlite
         this.#log('Error when exiting', e.toString())
       }
     } finally {
-      pglUtils.pgliteProc.exitCode = prevExitCode
+      restoreExitCode(prevExitCode)
     }
   }
 
@@ -961,7 +976,7 @@ export class PGlite
     } finally {
       mod._PostgresSendReadyForQueryIfNecessary()
       mod._pgl_pq_flush()
-      pglUtils.pgliteProc.exitCode = prevExitCode
+      restoreExitCode(prevExitCode)
     }
 
     this.#outputData = []

--- a/packages/pglite/tests/basic.test.ts
+++ b/packages/pglite/tests/basic.test.ts
@@ -812,6 +812,20 @@ await testEsmCjsAndDTC(async (importType) => {
       }
     })
 
+    it('does not leave the wasm boot exit code on process.exitCode', async () => {
+      // Postgres' single-user boot signals success with proc_exit(99). The
+      // saved host exitCode is usually `undefined`, and under bun assigning
+      // `undefined` to process.exitCode is a no-op, so a restore of the saved
+      // value must write an explicit 0 — otherwise the sentinel survives and
+      // bun force-exits an otherwise successful process with code 99.
+      const before = process.exitCode
+      const pg = await PGlite.create()
+      await pg.exec('SELECT 1')
+      await pg.close()
+      expect([before, 0]).toContain(process.exitCode)
+      expect(process.exitCode).not.toEqual(99)
+    })
+
     it("arrays with NULL elements should return null, not string 'NULL'", async () => {
       const pg = await PGlite.create()
 


### PR DESCRIPTION
PGlite saves and restores `process.exitCode` around engine calls that may run `proc_exit(XX)` (`#init()`, `close()`, `execProtocolRaw`). On a clean host the saved value is `undefined`, and under bun assigning `undefined` to `process.exitCode` does not clear the current value — depending on the current value it is either a silent no-op or throws `TypeError: exitCode must be an integer`. The restore therefore fails, and the engine's `proc_exit(99)` boot sentinel survives to process exit: a fully successful bun process exits with code 99.

Until 0.5.4 this was masked by an accident: `close()`'s `_emscripten_force_exit(0)` set an explicit `0` on the way out. #1059 (correctly) made `close()` restore the previously saved value instead — which removed the incidental reset and exposed the bug for every bun consumer of the 0.5.5 release. Repro, run with bun against `@electric-sql/pglite@0.5.5`:

```ts
import { PGlite } from '@electric-sql/pglite'
const pg = await PGlite.create()
await pg.exec('SELECT 1')
await pg.close()
// prints nothing wrong — but the process exits 99
```

This also fails any downstream `bun test` suite that touches PGlite: every test passes and the runner still exits 99.

The fix routes all three restore sites through one helper that restores a saved `undefined` as an explicit `0`, which is equivalent for exit status on every runtime. The added regression test asserts the boot sentinel never remains on `process.exitCode`; under bun the whole suite additionally force-exits 99 without the fix, so the lane goes red either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
