### PR TITLE
fix: serialize close with in-flight queries

### DIFF
--- a/.changeset/quiet-databases-close.md
+++ b/.changeset/quiet-databases-close.md
@@ -2,4 +2,6 @@
 '@electric-sql/pglite': patch
 ---
 
-Wait for in-flight queries and transactions to finish before closing PGlite.
+Prevent `close()` from hanging when called while a query or transaction is in
+flight. Work started before `close()` is allowed to finish, while later
+operations are rejected.

--- a/.changeset/quiet-databases-close.md
+++ b/.changeset/quiet-databases-close.md
@@ -1,0 +1,5 @@
+---
+'@electric-sql/pglite': patch
+---
+
+Wait for in-flight queries and transactions to finish before closing PGlite.

--- a/packages/pglite/src/pglite.ts
+++ b/packages/pglite/src/pglite.ts
@@ -89,6 +89,7 @@ export class PGlite
   #ready = false
   #closing = false
   #closed = false
+  #closePromise?: Promise<void>
   #relaxedDurability = false
 
   readonly waitReady: Promise<void>
@@ -784,62 +785,82 @@ export class PGlite
    * Close the database
    * @returns A promise that resolves when the database is closed
    */
-  async close() {
-    await this._checkReady()
-    this.#closing = true
+  close() {
+    if (!this.#closePromise) {
+      // Claim the lifecycle transition synchronously so operations started in
+      // the same tick cannot pass _checkReady() and queue behind close().
+      this.#closing = true
+      this.#closePromise = this.#close()
+    }
+    return this.#closePromise
+  }
 
-    // Close all extensions
-    for (const closeFn of this.#extensionsClose) {
-      await closeFn()
+  async #close() {
+    if (!this.#ready) {
+      await this.waitReady
     }
 
-    // Close the database
-    try {
-      this.mod!._pgl_setPGliteActive(0)
-      await this.execProtocol(serialize.end())
-      this.mod!._pgl_run_atexit_funcs()
-    } catch (e: any) {
-      const err = e as { name: string; status: number }
-      if (err.name === 'ExitStatus' && err.status === 0) {
-        // Database closed successfully
-        // An earlier build of PGlite would throw an error here when closing
-        // leaving this here for now. I believe it was a bug in Emscripten.
-      } else {
-        this.#log(`An error occured while closing the db`, e.toString())
-      }
-    } finally {
-      this.mod!.removeFunction(this.#pglite_socket_read)
-      this.mod!.removeFunction(this.#pglite_socket_write)
-    }
+    // Let operations that passed _checkReady() before close() was called
+    // enqueue on the mutexes. Operations started after close() are rejected
+    // synchronously by the #closing flag set above.
+    await Promise.resolve()
 
-    // Close the filesystem
-    await this.fs!.closeFs()
+    await this._runExclusiveTransaction(() =>
+      this._runExclusiveQuery(async () => {
+        // Close all extensions
+        for (const closeFn of this.#extensionsClose) {
+          await closeFn()
+        }
 
-    this.#closed = true
-    this.#closing = false
-    this.#ready = false
-    this.#running = false
+        // Close the database
+        try {
+          this.mod!._pgl_setPGliteActive(0)
+          await this.execProtocol(serialize.end())
+          this.mod!._pgl_run_atexit_funcs()
+        } catch (e: any) {
+          const err = e as { name: string; status: number }
+          if (err.name === 'ExitStatus' && err.status === 0) {
+            // Database closed successfully
+            // An earlier build of PGlite would throw an error here when closing
+            // leaving this here for now. I believe it was a bug in Emscripten.
+          } else {
+            this.#log(`An error occured while closing the db`, e.toString())
+          }
+        } finally {
+          this.mod!.removeFunction(this.#pglite_socket_read)
+          this.mod!.removeFunction(this.#pglite_socket_write)
+        }
 
-    const exitCode = pglUtils.pgliteProc.exitCode
-    try {
-      // exit the runtime. since we're using `noExitRuntime: true` on our module,
-      // we need to do this explicitly
-      // this sets process.exitCode to 0
-      this.mod!._emscripten_force_exit(0)
-      // clear mod to release memory
-      this.mod = undefined
-    } catch (e: any) {
-      this.#log(e)
-      if (e.status !== 0) {
-        this.#log('Error when exiting', e.toString())
-      }
-    } finally {
-      try {
-        pglUtils.pgliteProc.exitCode = exitCode
-      } catch {
-        // some envs do not allow setting the exitCode, swallow
-      }
-    }
+        // Close the filesystem
+        await this.fs!.closeFs()
+
+        this.#closed = true
+        this.#closing = false
+        this.#ready = false
+        this.#running = false
+
+        const exitCode = pglUtils.pgliteProc.exitCode
+        try {
+          // exit the runtime. since we're using `noExitRuntime: true` on our module,
+          // we need to do this explicitly
+          // this sets process.exitCode to 0
+          this.mod!._emscripten_force_exit(0)
+          // clear mod to release memory
+          this.mod = undefined
+        } catch (e: any) {
+          this.#log(e)
+          if (e.status !== 0) {
+            this.#log('Error when exiting', e.toString())
+          }
+        } finally {
+          try {
+            pglUtils.pgliteProc.exitCode = exitCode
+          } catch {
+            // some envs do not allow setting the exitCode, swallow
+          }
+        }
+      }),
+    )
   }
 
   /**

--- a/packages/pglite/src/pglite.ts
+++ b/packages/pglite/src/pglite.ts
@@ -787,9 +787,6 @@ export class PGlite
    */
   close() {
     if (!this.#closePromise) {
-      // Claim the lifecycle transition synchronously so operations started in
-      // the same tick cannot pass _checkReady() and queue behind close().
-      this.#closing = true
       this.#closePromise = this.#close()
     }
     return this.#closePromise
@@ -799,6 +796,9 @@ export class PGlite
     if (!this.#ready) {
       await this.waitReady
     }
+    // Claim the lifecycle transition synchronously once initialization is
+    // complete so later operations cannot queue behind close().
+    this.#closing = true
 
     // Let operations that passed _checkReady() before close() was called
     // enqueue on the mutexes. Operations started after close() are rejected
@@ -806,61 +806,63 @@ export class PGlite
     await Promise.resolve()
 
     await this._runExclusiveTransaction(() =>
-      this._runExclusiveQuery(async () => {
-        // Close all extensions
-        for (const closeFn of this.#extensionsClose) {
-          await closeFn()
-        }
-
-        // Close the database
-        try {
-          this.mod!._pgl_setPGliteActive(0)
-          await this.execProtocol(serialize.end())
-          this.mod!._pgl_run_atexit_funcs()
-        } catch (e: any) {
-          const err = e as { name: string; status: number }
-          if (err.name === 'ExitStatus' && err.status === 0) {
-            // Database closed successfully
-            // An earlier build of PGlite would throw an error here when closing
-            // leaving this here for now. I believe it was a bug in Emscripten.
-          } else {
-            this.#log(`An error occured while closing the db`, e.toString())
-          }
-        } finally {
-          this.mod!.removeFunction(this.#pglite_socket_read)
-          this.mod!.removeFunction(this.#pglite_socket_write)
-        }
-
-        // Close the filesystem
-        await this.fs!.closeFs()
-
-        this.#closed = true
-        this.#closing = false
-        this.#ready = false
-        this.#running = false
-
-        const exitCode = pglUtils.pgliteProc.exitCode
-        try {
-          // exit the runtime. since we're using `noExitRuntime: true` on our module,
-          // we need to do this explicitly
-          // this sets process.exitCode to 0
-          this.mod!._emscripten_force_exit(0)
-          // clear mod to release memory
-          this.mod = undefined
-        } catch (e: any) {
-          this.#log(e)
-          if (e.status !== 0) {
-            this.#log('Error when exiting', e.toString())
-          }
-        } finally {
-          try {
-            pglUtils.pgliteProc.exitCode = exitCode
-          } catch {
-            // some envs do not allow setting the exitCode, swallow
-          }
-        }
-      }),
+      this._runExclusiveQuery(() => this.#closeExclusive()),
     )
+  }
+
+  async #closeExclusive() {
+    // Close all extensions
+    for (const closeFn of this.#extensionsClose) {
+      await closeFn()
+    }
+
+    // Close the database
+    try {
+      this.mod!._pgl_setPGliteActive(0)
+      await this.execProtocol(serialize.end())
+      this.mod!._pgl_run_atexit_funcs()
+    } catch (e: any) {
+      const err = e as { name: string; status: number }
+      if (err.name === 'ExitStatus' && err.status === 0) {
+        // Database closed successfully
+        // An earlier build of PGlite would throw an error here when closing
+        // leaving this here for now. I believe it was a bug in Emscripten.
+      } else {
+        this.#log(`An error occured while closing the db`, e.toString())
+      }
+    } finally {
+      this.mod!.removeFunction(this.#pglite_socket_read)
+      this.mod!.removeFunction(this.#pglite_socket_write)
+    }
+
+    // Close the filesystem
+    await this.fs!.closeFs()
+
+    this.#closed = true
+    this.#closing = false
+    this.#ready = false
+    this.#running = false
+
+    const exitCode = pglUtils.pgliteProc.exitCode
+    try {
+      // exit the runtime. since we're using `noExitRuntime: true` on our module,
+      // we need to do this explicitly
+      // this sets process.exitCode to 0
+      this.mod!._emscripten_force_exit(0)
+      // clear mod to release memory
+      this.mod = undefined
+    } catch (e: any) {
+      this.#log(e)
+      if (e.status !== 0) {
+        this.#log('Error when exiting', e.toString())
+      }
+    } finally {
+      try {
+        pglUtils.pgliteProc.exitCode = exitCode
+      } catch {
+        // some envs do not allow setting the exitCode, swallow
+      }
+    }
   }
 
   /**
@@ -914,6 +916,12 @@ export class PGlite
       // Starting the database can take a while and it might not be ready yet
       // We'll wait for it to be ready before continuing
       await this.waitReady
+      if (this.#closing) {
+        throw new Error('PGlite is closing')
+      }
+      if (this.#closed) {
+        throw new Error('PGlite is closed')
+      }
     }
   }
 

--- a/packages/pglite/tests/targets/runtimes/node-close.test.js
+++ b/packages/pglite/tests/targets/runtimes/node-close.test.js
@@ -1,0 +1,63 @@
+import { spawn } from 'node:child_process'
+import { describe, expect, it } from 'vitest'
+
+const pgliteUrl = new URL('../../../dist/index.js', import.meta.url).href
+
+describe('close', () => {
+  it('waits for an in-flight query before shutting down', async () => {
+    const script = `
+      const { PGlite } = await import(process.argv[1])
+      const db = new PGlite()
+
+      await db.exec('CREATE TABLE t (workflow_name TEXT, run_id TEXT)')
+      await db.exec("INSERT INTO t VALUES ('agentic-loop', 'run-1')")
+
+      const query = db.query(
+        'DELETE FROM t WHERE workflow_name = $1 AND run_id = $2',
+        ['agentic-loop', 'run-1'],
+      )
+      const firstClose = db.close()
+      const secondClose = db.close()
+
+      await Promise.all([query, firstClose, secondClose])
+
+      const db2 = new PGlite()
+      await db2.waitReady
+      const close = db2.close()
+      const rejectedQuery = db2.query('SELECT 1').then(
+        () => false,
+        (error) => error.message === 'PGlite is closing',
+      )
+
+      if (!(await rejectedQuery)) {
+        throw new Error('query started after close was not rejected')
+      }
+      await close
+    `
+
+    const result = await new Promise((resolve) => {
+      const child = spawn(
+        process.execPath,
+        ['--input-type=module', '--eval', script, pgliteUrl],
+        { stdio: ['ignore', 'pipe', 'pipe'] },
+      )
+      let stderr = ''
+      child.stderr.setEncoding('utf8')
+      child.stderr.on('data', (chunk) => {
+        stderr += chunk
+      })
+
+      const timeout = setTimeout(() => {
+        child.kill('SIGKILL')
+        resolve({ code: null, stderr: 'PGlite close timed out' })
+      }, 5_000)
+
+      child.on('exit', (code) => {
+        clearTimeout(timeout)
+        resolve({ code, stderr })
+      })
+    })
+
+    expect(result).toEqual({ code: 0, stderr: '' })
+  }, 10_000)
+})

--- a/packages/pglite/tests/targets/runtimes/node-close.test.js
+++ b/packages/pglite/tests/targets/runtimes/node-close.test.js
@@ -3,9 +3,48 @@ import { describe, expect, it } from 'vitest'
 
 const pgliteUrl = new URL('../../../dist/index.js', import.meta.url).href
 
+async function expectChildToExitCleanly(script) {
+  const result = await new Promise((resolve) => {
+    const child = spawn(
+      process.execPath,
+      ['--input-type=module', '--eval', script, pgliteUrl],
+      { stdio: ['ignore', 'pipe', 'pipe'] },
+    )
+    let stderr = ''
+    let settled = false
+
+    const finish = (result) => {
+      if (settled) return
+      settled = true
+      clearTimeout(timeout)
+      resolve(result)
+    }
+
+    child.stderr.setEncoding('utf8')
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk
+      stderr = stderr.slice(-4_000)
+    })
+
+    const timeout = setTimeout(() => {
+      child.kill('SIGKILL')
+      finish({ code: null, stderr: 'PGlite close timed out' })
+    }, 5_000)
+
+    child.on('error', (error) => {
+      finish({ code: null, stderr: error.message })
+    })
+    child.on('exit', (code) => {
+      finish({ code, stderr })
+    })
+  })
+
+  expect(result).toEqual({ code: 0, stderr: '' })
+}
+
 describe('close', () => {
   it('waits for an in-flight query before shutting down', async () => {
-    const script = `
+    await expectChildToExitCleanly(`
       const { PGlite } = await import(process.argv[1])
       const db = new PGlite()
 
@@ -16,48 +55,56 @@ describe('close', () => {
         'DELETE FROM t WHERE workflow_name = $1 AND run_id = $2',
         ['agentic-loop', 'run-1'],
       )
-      const firstClose = db.close()
-      const secondClose = db.close()
+      const close = db.close()
 
-      await Promise.all([query, firstClose, secondClose])
+      await Promise.all([query, close])
+    `)
+  }, 10_000)
 
-      const db2 = new PGlite()
-      await db2.waitReady
-      const close = db2.close()
-      const rejectedQuery = db2.query('SELECT 1').then(
-        () => false,
-        (error) => error.message === 'PGlite is closing',
-      )
+  it('waits for an active transaction before shutting down', async () => {
+    await expectChildToExitCleanly(`
+      const { PGlite } = await import(process.argv[1])
+      const db = new PGlite()
 
-      if (!(await rejectedQuery)) {
-        throw new Error('query started after close was not rejected')
+      await db.exec('CREATE TABLE t (value INTEGER)')
+
+      let markTransactionStarted
+      const transactionStarted = new Promise((resolve) => {
+        markTransactionStarted = resolve
+      })
+      let resumeTransaction
+      const transactionGate = new Promise((resolve) => {
+        resumeTransaction = resolve
+      })
+      const events = []
+
+      const transaction = db.transaction(async (tx) => {
+        markTransactionStarted()
+        await transactionGate
+        await tx.query('INSERT INTO t VALUES (1)')
+        events.push('transaction')
+      })
+
+      await transactionStarted
+      const close = db.close().then(() => events.push('close'))
+      resumeTransaction()
+      await Promise.all([transaction, close])
+
+      if (events.join(',') !== 'transaction,close') {
+        throw new Error('close did not wait for the active transaction')
       }
-      await close
-    `
+    `)
+  }, 10_000)
 
-    const result = await new Promise((resolve) => {
-      const child = spawn(
-        process.execPath,
-        ['--input-type=module', '--eval', script, pgliteUrl],
-        { stdio: ['ignore', 'pipe', 'pipe'] },
-      )
-      let stderr = ''
-      child.stderr.setEncoding('utf8')
-      child.stderr.on('data', (chunk) => {
-        stderr += chunk
-      })
+  it('closes once during initialization and rejects later queries', async () => {
+    const { PGlite } = await import(pgliteUrl)
+    const db = new PGlite()
 
-      const timeout = setTimeout(() => {
-        child.kill('SIGKILL')
-        resolve({ code: null, stderr: 'PGlite close timed out' })
-      }, 5_000)
+    const firstClose = db.close()
+    expect(db.close()).toBe(firstClose)
+    await expect(db.query('SELECT 1')).rejects.toThrow('PGlite is closing')
 
-      child.on('exit', (code) => {
-        clearTimeout(timeout)
-        resolve({ code, stderr })
-      })
-    })
-
-    expect(result).toEqual({ code: 0, stderr: '' })
+    await firstClose
+    expect(db.closed).toBe(true)
   }, 10_000)
 })


### PR DESCRIPTION
## What changed

- share one close promise across repeated calls
- wait for previously-started transactions and queries before deactivating the WASM backend
- reject operations started after close begins, including while initialization is still completing
- keep lock coordination separate from the existing shutdown routine
- add bounded regression coverage for query, transaction, initialization, and repeated-close behavior
- add the required patch changeset

## Why

A query can pass `_checkReady()` and still be waiting between protocol phases when `close()` deactivates the backend. The query then enters `execProtocolRawSync()` against an inactive backend and can block the event loop permanently.

The close path now preserves call order: work invoked before `close()` drains under the existing transaction/query mutex order, while work invoked afterward sees `PGlite is closing`.

Fixes #1084.

## Related work

#1063 addresses a separate close race with detached filesystem syncs. Both changes affect shutdown ordering and may require conflict resolution if #1063 lands first; this PR specifically serializes `close()` with in-flight query and transaction work.

## Validation

Using the current-main Node 24 WASM artifact from #1087, from `packages/pglite`:

```sh
../../node_modules/.bin/tsup
../../node_modules/.bin/tsc --noEmit
../../node_modules/.bin/eslint ./src ./tests --report-unused-disable-directives --max-warnings 0
../../node_modules/.bin/prettier --check ./src ./tests
./node_modules/.bin/vitest run tests/targets/runtimes/node-close.test.js
./node_modules/.bin/vitest run tests/targets/runtimes/node-*.test.js
```

- focused close regressions: 3 passed
- Node runtime suite: 13 passed
