### PR TITLE
fix: rethrow non-longjmp exceptions in execProtocolRawSync protocol loop

### DIFF
--- a/.changeset/exec-protocol-raw-sync-spin.md
+++ b/.changeset/exec-protocol-raw-sync-spin.md
@@ -1,0 +1,5 @@
+---
+'@electric-sql/pglite': patch
+---
+
+Fix `execProtocolRawSync` spinning forever at 100% CPU when the WASM backend terminates mid-message (e.g. `exit(1)` after hitting EOF during a `COPY ... FROM STDIN`). Non-longjmp exceptions from the protocol loop are now rethrown instead of silently swallowed, so the call rejects with the backend error and subsequent calls fail fast instead of hanging (#1058).

--- a/packages/pglite/src/pglite.ts
+++ b/packages/pglite/src/pglite.ts
@@ -950,6 +950,12 @@ export class PGlite
             // that we call whenever the exception longjmp is executed
             // like this we also just need to setjmp only once, in a similar fashion to the original code.
             mod._PostgresMainLongJmp()
+          } else {
+            // anything else (e.g. an ExitStatus from the backend terminating,
+            // or a WASM RuntimeError) means the backend is gone — swallowing
+            // the exception here would leave the loop spinning forever, as
+            // no more input is consumed. Rethrow so the caller sees the error.
+            throw e
           }
           // even if there is an exception caused by one of the batched queries,
           // we need to continue processing the rest without throwing.
@@ -958,8 +964,13 @@ export class PGlite
         }
       }
     } finally {
-      mod._PostgresSendReadyForQueryIfNecessary()
-      mod._pgl_pq_flush()
+      try {
+        mod._PostgresSendReadyForQueryIfNecessary()
+        mod._pgl_pq_flush()
+      } catch {
+        // if the backend terminated, the runtime may already be dead;
+        // don't let these calls mask the original error thrown above
+      }
     }
 
     this.#outputData = []

--- a/packages/pglite/tests/backend-death.test.ts
+++ b/packages/pglite/tests/backend-death.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { PGlite } from '../dist/index.js'
+
+// Regression test for https://github.com/electric-sql/pglite/issues/1058
+//
+// When the WASM backend terminates while `execProtocolRawSync` is processing
+// a message (e.g. `exit(1)` after hitting EOF during a `COPY ... FROM STDIN`),
+// the protocol loop used to swallow the non-longjmp exception and spin forever,
+// synchronously, at 100% CPU. The call never settled and the process had to be
+// killed from outside.
+describe('backend terminates mid-message', () => {
+  let db: PGlite
+
+  beforeAll(async () => {
+    db = await PGlite.create()
+    await db.exec('CREATE TABLE backend_death_t(a int)')
+  })
+
+  afterAll(async () => {
+    if (!db.closed) {
+      await db.close()
+    }
+  })
+
+  it('should reject instead of spinning when the backend exits', async () => {
+    // The backend hits EOF during COPY FROM STDIN and exits with status 1
+    await expect(db.exec('COPY backend_death_t FROM STDIN')).rejects.toThrow(
+      /terminated|exit/i,
+    )
+  })
+
+  it('should reject promptly for queries issued after the backend died', async () => {
+    await expect(
+      db.query('SELECT 1 FROM backend_death_t'),
+    ).rejects.toThrow(/terminated|exit/i)
+  })
+
+  it('should still be able to close the database', async () => {
+    await expect(db.close()).resolves.toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Description

Fixes #1058.

When the WASM backend terminates while `execProtocolRawSync` is processing a message (e.g. `exit(1)` after hitting EOF during a `COPY ... FROM STDIN` issued via `exec()`), the protocol loop spins forever, synchronously, at 100% CPU. The call never settles, so no timer, `Promise.race`, or `AbortSignal` can interrupt it — the process has to be killed from outside.

### Root cause

After the backend exits, `_PostgresMainLoopOnce()` throws `ExitStatus`. That is not the longjmp sentinel, so it was silently swallowed; the dead backend consumes no input, so `#readOffset` never advances and `_pq_buffer_remaining_data()` never drains — the `while` condition is permanently true, producing a tight call → throw → swallow loop.

### Changes

- Rethrow anything that is not the longjmp sentinel (`ExitStatus`, WASM `RuntimeError`, …) — the backend is gone; looping cannot help
- Guard the `finally`'s own WASM calls (`_PostgresSendReadyForQueryIfNecessary` / `_pgl_pq_flush`) so they cannot mask the original error against a dead runtime

### Behavior after the fix (verified against the repro from #1058)

- the killing `exec()` rejects with `ExitStatus { status: 1 }`
- follow-up queries reject immediately with the same error instead of spinning
- `close()` resolves and the event loop stays alive throughout

### Regression test

New `tests/backend-death.test.ts`:

1. `COPY ... FROM STDIN` rejects instead of hanging
2. queries after the backend died reject promptly
3. `close()` still resolves

Against unfixed code the test process hangs synchronously — it even defeats vitest's own test timeout, so the baseline run has to be killed externally. With this patch all tests pass.

Also adds a changeset for `@electric-sql/pglite`.

Fixes #1058