### PR TITLE
docs: add mapColumns examples

### DIFF
--- a/docs/docs/sync.md
+++ b/docs/docs/sync.md
@@ -126,8 +126,26 @@ It takes the following options as an object:
 - `schema: string`<br>
   The name of the Postgres schema that the table to sync into is part of, defaults to `"public"`.
 
-- `mapColumns: MapColumns`<br>
-  An object indicating the mapping of the shape column values to your local table. This can be either a simple object of `localColumnName: shapeColumnName` mapping, or a function that takes a replication message and returns a mapping of `localColumnName: newValue`.
+- `mapColumns?: MapColumns`<br>
+  Optional mapping from shape columns to columns in the local table. Pass an object whose keys are local column names and whose values are shape column names:
+
+  ```ts
+  mapColumns: {
+    id: 'todo_id',
+    task: 'description',
+    done: 'completed',
+  }
+  ```
+
+  Or pass a callback that receives the full Electric `ChangeMessage` and returns an object keyed by local column names:
+
+  ```ts
+  mapColumns: (message) => ({
+    id: message.value.todo_id,
+    task: message.value.description,
+    done: message.value.completed,
+  })
+  ```
 
 - `primaryKey: string[]`<br>
   An array of column names that form the primary key of the table you are syncing into. Used for updates and deletes.


### PR DESCRIPTION
## 작업 배경

Issue #475 asks for concrete documentation of both supported `mapColumns` forms, especially the callback that receives an Electric `ChangeMessage`.

## 티켓 및 링크

- [GH-475](https://github.com/electric-sql/pglite/issues/475) — Closes #475

## 작업 내용

- Mark `mapColumns` as optional, matching the current `SyncShapeToTableOptions` API.
- Add an object-form example that maps local table columns to shape columns.
- Add a callback-form example that reads `ChangeMessage.value` and returns values keyed by local column names.

## 테스트

- `pnpm --dir docs stylecheck`
- `pnpm --dir docs typecheck`
- VitePress Markdown renderer structural check for the option list and both TypeScript code blocks
- `git diff --check`
- `pnpm --dir docs build` — blocked before page rendering because this fresh worktree does not contain the generated `packages/pglite/dist/index.js` workspace artifact
