### PR TITLE
Fix initdb in sandboxed Node runtimes

### DIFF
--- a/.changeset/tough-rabbits-boot.md
+++ b/.changeset/tough-rabbits-boot.md
@@ -2,4 +2,4 @@
 '@electric-sql/pglite': patch
 ---
 
-Allow initdb to complete in Node-shaped sandbox runtimes that reject writes to `process.exitCode`.
+Allow initdb to complete in Node-shaped sandbox runtimes that reject writes to `process.exitCode`, preserve the host exit code, and release the Postgres module after close.

--- a/.changeset/tough-rabbits-boot.md
+++ b/.changeset/tough-rabbits-boot.md
@@ -1,0 +1,5 @@
+---
+'@electric-sql/pglite': patch
+---
+
+Allow initdb to complete in Node-shaped sandbox runtimes that reject writes to `process.exitCode`.

--- a/packages/pglite/src/initdb.ts
+++ b/packages/pglite/src/initdb.ts
@@ -74,7 +74,11 @@ function callWithWritableProcessExitCode<T>(callback: () => T): T {
     }
   }
 
-  return callback()
+  try {
+    return callback()
+  } finally {
+    processObject.exitCode = exitCode
+  }
 }
 
 async function execInitdb({

--- a/packages/pglite/src/initdb.ts
+++ b/packages/pglite/src/initdb.ts
@@ -44,6 +44,39 @@ function log(debug?: number, ...args: any[]) {
   }
 }
 
+function callWithWritableProcessExitCode<T>(callback: () => T): T {
+  const processObject = globalThis.process
+  if (!processObject) {
+    return callback()
+  }
+
+  let exitCode: typeof processObject.exitCode
+  try {
+    exitCode = processObject.exitCode
+    processObject.exitCode = exitCode
+  } catch {
+    // Emscripten's Node quit handler writes process.exitCode during a normal
+    // initdb exit. Some Node-shaped sandbox runtimes expose a setter that
+    // rejects that host operation, so give only the synchronous callMain a
+    // delegating process object with a writable exitCode.
+    const processShim = Object.create(processObject)
+    Object.defineProperty(processShim, 'exitCode', {
+      configurable: true,
+      enumerable: true,
+      value: exitCode,
+      writable: true,
+    })
+    globalThis.process = processShim
+    try {
+      return callback()
+    } finally {
+      globalThis.process = processObject
+    }
+  }
+
+  return callback()
+}
+
 async function execInitdb({
   pg,
   debug,
@@ -199,7 +232,7 @@ async function execInitdb({
   const initDbMod = await InitdbModFactory(emscriptenOpts)
 
   log(debug, 'calling initdb.main with', args)
-  const result = initDbMod.callMain(args)
+  const result = callWithWritableProcessExitCode(() => initDbMod.callMain(args))
 
   return {
     exitCode: result,

--- a/packages/pglite/src/pglite.ts
+++ b/packages/pglite/src/pglite.ts
@@ -826,14 +826,14 @@ export class PGlite
       // we need to do this explicitly
       // this sets process.exitCode to 0
       this.mod!._emscripten_force_exit(0)
-      // clear mod to release memory
-      this.mod = undefined
     } catch (e: any) {
       this.#log(e)
       if (e.status !== 0) {
         this.#log('Error when exiting', e.toString())
       }
     } finally {
+      // clear mod to release memory, including when force_exit throws ExitStatus
+      this.mod = undefined
       try {
         pglUtils.pgliteProc.exitCode = exitCode
       } catch {

--- a/packages/pglite/tests/fixtures/sandboxed-exit-code.js
+++ b/packages/pglite/tests/fixtures/sandboxed-exit-code.js
@@ -1,0 +1,63 @@
+const realProcess = globalThis.process
+const originalExitCode = realProcess.exitCode
+const mode = realProcess.argv[2]
+
+let setterCalls = 0
+let expectedProcess = realProcess
+let pg
+let result
+
+if (mode === 'sandboxed') {
+  const sandboxedProcess = Object.create(realProcess)
+  Object.defineProperty(sandboxedProcess, 'exitCode', {
+    get() {
+      return 0
+    },
+    set() {
+      setterCalls++
+      throw new Error('sandboxed process.exitCode setter called')
+    },
+    configurable: false,
+    enumerable: true,
+  })
+  globalThis.process = sandboxedProcess
+  expectedProcess = sandboxedProcess
+} else if (mode === 'node') {
+  realProcess.exitCode = 23
+} else {
+  throw new Error(`Unknown fixture mode: ${mode}`)
+}
+
+try {
+  const { PGlite } = await import('../../dist/index.js')
+  pg = await PGlite.create()
+  const queryResult = await pg.query('SELECT 1 AS one')
+
+  result = {
+    ok: true,
+    row: queryResult.rows[0]?.one,
+    exitCode: globalThis.process.exitCode,
+    processRestored: globalThis.process === expectedProcess,
+    setterCalls,
+  }
+} catch (error) {
+  result = {
+    ok: false,
+    processRestored: globalThis.process === expectedProcess,
+    setterCalls,
+    error: {
+      name: error instanceof Error ? error.name : typeof error,
+      message: error instanceof Error ? error.message : String(error),
+      stack: error instanceof Error ? error.stack : undefined,
+    },
+  }
+} finally {
+  globalThis.process = realProcess
+  if (pg) {
+    await pg.close()
+  }
+  realProcess.exitCode = originalExitCode
+}
+
+realProcess.stdout.write(JSON.stringify(result))
+realProcess.exit(0)

--- a/packages/pglite/tests/fixtures/sandboxed-exit-code.js
+++ b/packages/pglite/tests/fixtures/sandboxed-exit-code.js
@@ -22,8 +22,10 @@ if (mode === 'sandboxed') {
   })
   globalThis.process = sandboxedProcess
   expectedProcess = sandboxedProcess
-} else if (mode === 'node') {
-  realProcess.exitCode = 23
+} else if (mode === 'node' || mode === 'close') {
+  if (mode === 'node') {
+    realProcess.exitCode = 23
+  }
 } else {
   throw new Error(`Unknown fixture mode: ${mode}`)
 }
@@ -32,11 +34,18 @@ try {
   const { PGlite } = await import('../../dist/index.js')
   pg = await PGlite.create()
   const queryResult = await pg.query('SELECT 1 AS one')
+  const moduleLoaded = pg.ENV !== undefined
+
+  if (mode === 'close') {
+    await pg.close()
+  }
 
   result = {
     ok: true,
     row: queryResult.rows[0]?.one,
     exitCode: globalThis.process.exitCode,
+    moduleLoaded,
+    moduleCleared: mode === 'close' ? pg.ENV === undefined : undefined,
     processRestored: globalThis.process === expectedProcess,
     setterCalls,
   }
@@ -53,7 +62,7 @@ try {
   }
 } finally {
   globalThis.process = realProcess
-  if (pg) {
+  if (pg && !pg.closed) {
     await pg.close()
   }
   realProcess.exitCode = originalExitCode

--- a/packages/pglite/tests/sandboxed-exit-code.test.ts
+++ b/packages/pglite/tests/sandboxed-exit-code.test.ts
@@ -1,0 +1,102 @@
+import { spawn } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+interface FixtureResult {
+  ok: boolean
+  row?: number
+  exitCode?: number
+  processRestored: boolean
+  setterCalls: number
+  error?: {
+    name: string
+    message: string
+    stack?: string
+  }
+}
+
+const fixturePath = fileURLToPath(
+  new URL('./fixtures/sandboxed-exit-code.js', import.meta.url),
+)
+
+function runFixture(mode: 'sandboxed' | 'node'): Promise<FixtureResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [fixturePath, mode], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    let stdout = ''
+    let stderr = ''
+    let timedOut = false
+
+    child.stdout.setEncoding('utf8')
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk
+    })
+    child.stderr.setEncoding('utf8')
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk
+    })
+
+    const timeout = setTimeout(() => {
+      timedOut = true
+      child.kill('SIGKILL')
+    }, 20_000)
+
+    child.on('error', (error) => {
+      clearTimeout(timeout)
+      reject(error)
+    })
+    child.on('close', (code, signal) => {
+      clearTimeout(timeout)
+      if (timedOut) {
+        reject(new Error(`Fixture timed out; stderr: ${stderr}`))
+        return
+      }
+      if (code !== 0) {
+        reject(
+          new Error(
+            `Fixture exited with code ${code} and signal ${signal}; stderr: ${stderr}`,
+          ),
+        )
+        return
+      }
+
+      try {
+        resolve(JSON.parse(stdout))
+      } catch (error) {
+        reject(
+          new Error(
+            `Fixture returned invalid JSON: ${stdout}; stderr: ${stderr}`,
+            {
+              cause: error,
+            },
+          ),
+        )
+      }
+    })
+  })
+}
+
+describe('process.exitCode handling during initdb', () => {
+  it('boots when a Node-shaped process has a throwing exitCode setter', async () => {
+    const result = await runFixture('sandboxed')
+
+    expect(result.ok, JSON.stringify(result, null, 2)).toBe(true)
+    expect(result).toMatchObject({
+      row: 1,
+      processRestored: true,
+    })
+  })
+
+  it('preserves the normal Node exitCode behavior', async () => {
+    const result = await runFixture('node')
+
+    expect(result).toMatchObject({
+      ok: true,
+      row: 1,
+      exitCode: 0,
+      processRestored: true,
+      setterCalls: 0,
+    })
+  })
+})

--- a/packages/pglite/tests/sandboxed-exit-code.test.ts
+++ b/packages/pglite/tests/sandboxed-exit-code.test.ts
@@ -6,6 +6,8 @@ interface FixtureResult {
   ok: boolean
   row?: number
   exitCode?: number
+  moduleLoaded?: boolean
+  moduleCleared?: boolean
   processRestored: boolean
   setterCalls: number
   error?: {
@@ -19,7 +21,9 @@ const fixturePath = fileURLToPath(
   new URL('./fixtures/sandboxed-exit-code.js', import.meta.url),
 )
 
-function runFixture(mode: 'sandboxed' | 'node'): Promise<FixtureResult> {
+function runFixture(
+  mode: 'sandboxed' | 'node' | 'close',
+): Promise<FixtureResult> {
   return new Promise((resolve, reject) => {
     const child = spawn(process.execPath, [fixturePath, mode], {
       stdio: ['ignore', 'pipe', 'pipe'],
@@ -77,7 +81,7 @@ function runFixture(mode: 'sandboxed' | 'node'): Promise<FixtureResult> {
   })
 }
 
-describe('process.exitCode handling during initdb', () => {
+describe('process exit handling', () => {
   it('boots when a Node-shaped process has a throwing exitCode setter', async () => {
     const result = await runFixture('sandboxed')
 
@@ -94,9 +98,21 @@ describe('process.exitCode handling during initdb', () => {
     expect(result).toMatchObject({
       ok: true,
       row: 1,
-      exitCode: 0,
+      exitCode: 23,
       processRestored: true,
       setterCalls: 0,
+    })
+  })
+
+  it('releases the Postgres module after the expected force exit', async () => {
+    const result = await runFixture('close')
+
+    expect(result).toMatchObject({
+      ok: true,
+      row: 1,
+      moduleLoaded: true,
+      moduleCleared: true,
+      processRestored: true,
     })
   })
 })


### PR DESCRIPTION
## 작업 배경

Node 형태의 `process`를 노출하지만 `exitCode` setter가 쓰기를 거부하는 sandbox runtime에서 정상적인 initdb 종료가 Emscripten `quit_`의 `process.exitCode` 쓰기로 실패했습니다.

## 티켓 및 링크

- [GH-1082](https://github.com/electric-sql/pglite/issues/1082) (Fixes #1082)

## 작업 내용

- setter가 던질 때만 동기 `initdb.callMain()` 동안 writable `exitCode`를 가진 delegating process shim을 사용하고, 호출 후 원래 process를 복원합니다.
- 정상 Node initdb가 기존 host `process.exitCode`를 덮어쓰지 않도록 호출 후 값을 복원합니다.
- `_emscripten_force_exit(0)`의 예상 `ExitStatus(0)` throw 이후에도 Postgres module 참조를 해제합니다.
- sandbox setter, 정상 Node exit code 보존, close 후 module 해제를 bounded child process로 회귀 검증합니다.
- `@electric-sql/pglite` patch changeset을 추가합니다.

## 테스트

- `pnpm --dir packages/pglite build`
- `pnpm --dir packages/pglite exec vitest run tests/sandboxed-exit-code.test.ts --reporter=verbose` (3 passed)
- `pnpm --dir packages/pglite test` (297 passed, 1 skipped)
- `pnpm --dir packages/pglite typecheck`
- `pnpm --dir packages/pglite stylecheck`
- `git diff --check`
