### PR TITLE
docs: explain LISTEN channel identifier quoting

### DIFF
--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -294,13 +294,13 @@ Returns an unsubscribe function to unsubscribe from the channel.
 ##### Example
 
 ```ts
-const unsub = await pg.listen('test', (payload) => {
+const unsub = await pg.listen('"name-with-hyphen"', (payload) => {
   console.log('Received:', payload)
 })
-await pg.query("NOTIFY test, 'Hello, world!'")
+await pg.query(`NOTIFY "name-with-hyphen", 'Hello, world!'`)
 ```
 
-Channel names are case sensitive if double-quoted (`pg.listen('"TeST"')`). Otherwise channel name will be lower cased (`pg.listen('TeStiNG')` == `pg.listen('testing')`).
+Channel names follow PostgreSQL identifier rules. Unquoted identifiers are folded to lowercase, so `pg.listen('TeStiNG')` listens on the same channel as `pg.listen('testing')`. Double-quoted identifiers preserve case and allow special characters such as hyphens, spaces, and `&`. Include the double quotes in the string passed to `listen()`, as shown above, and use the matching quoted identifier in the `NOTIFY` statement.
 
 ### unlisten
 

--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -289,18 +289,19 @@ Close the database, ensuring it is shut down cleanly.
 
 Subscribe to a [pg_notify](https://www.postgresql.org/docs/current/sql-notify.html) channel. The callback will receive the payload from the notification.
 
-Returns an unsubscribe function to unsubscribe from the channel.
+Returns an unsubscribe function to unsubscribe from the channel. When an identifier requires double quotes, keep the quoted string and pass it directly to `unlisten()` for cleanup, as shown below.
 
 ##### Example
 
 ```ts
-const unsub = await pg.listen('"name-with-hyphen"', (payload) => {
+await pg.listen('"name-with-hyphen"', (payload) => {
   console.log('Received:', payload)
 })
 await pg.query(`NOTIFY "name-with-hyphen", 'Hello, world!'`)
+await pg.unlisten('"name-with-hyphen"')
 ```
 
-Channel names follow PostgreSQL identifier rules. Unquoted identifiers are folded to lowercase, so `pg.listen('TeStiNG')` listens on the same channel as `pg.listen('testing')`. Double-quoted identifiers preserve case and allow special characters such as hyphens, spaces, and `&`. Include the double quotes in the string passed to `listen()`, as shown above, and use the matching quoted identifier in the `NOTIFY` statement.
+Channel names follow PostgreSQL identifier rules. Unquoted identifiers are folded to lowercase, so `pg.listen('TeStiNG')` listens on the same channel as `pg.listen('testing')`. Double-quoted identifiers preserve case and allow special characters such as hyphens, spaces, and `&`. Include the double quotes in the strings passed to `listen()` and `unlisten()`, as shown above, and use the matching quoted identifier in the `NOTIFY` statement.
 
 ### unlisten
 

--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -289,7 +289,7 @@ Close the database, ensuring it is shut down cleanly.
 
 Subscribe to a [pg_notify](https://www.postgresql.org/docs/current/sql-notify.html) channel. The callback will receive the payload from the notification.
 
-Returns an unsubscribe function to unsubscribe from the channel. When an identifier requires double quotes, keep the quoted string and pass it directly to `unlisten()` for cleanup, as shown below.
+`listen()` returns an unsubscribe function for ordinary unquoted channel names. Quoted identifiers are supported for subscribing and receiving notifications, but cleanup is not reliable in either `PGlite` or `PGliteWorker`; do not use the returned function or `unlisten()` for quoted names. Use an unquoted identifier when per-channel cleanup is required. The quoted example below is suitable only when the listener can remain active for the lifetime of the PGlite instance.
 
 ##### Example
 
@@ -298,10 +298,9 @@ await pg.listen('"name-with-hyphen"', (payload) => {
   console.log('Received:', payload)
 })
 await pg.query(`NOTIFY "name-with-hyphen", 'Hello, world!'`)
-await pg.unlisten('"name-with-hyphen"')
 ```
 
-Channel names follow PostgreSQL identifier rules. Unquoted identifiers are folded to lowercase, so `pg.listen('TeStiNG')` listens on the same channel as `pg.listen('testing')`. Double-quoted identifiers preserve case and allow special characters such as hyphens, spaces, and `&`. Include the double quotes in the strings passed to `listen()` and `unlisten()`, as shown above, and use the matching quoted identifier in the `NOTIFY` statement.
+Channel names follow PostgreSQL identifier rules. Unquoted identifiers are folded to lowercase, so `pg.listen('TeStiNG')` listens on the same channel as `pg.listen('testing')`. Double-quoted identifiers preserve case and allow special characters such as hyphens, spaces, and `&`. Include the double quotes in the string passed to `listen()`, as shown above, and use the matching quoted identifier in the `NOTIFY` statement.
 
 ### unlisten
 


### PR DESCRIPTION
## 작업 배경

PGlite already supports PostgreSQL identifier quoting for `LISTEN` channel names, but the API documentation did not make it clear that names containing hyphens or other special characters must be passed as quoted identifiers.

## 티켓 및 링크

- [GH-747](https://github.com/electric-sql/pglite/issues/747) — Closes #747
- Related identifier case handling: [#642](https://github.com/electric-sql/pglite/issues/642)

## 작업 내용

- Replace the basic `listen()` example with a copy-pastable quoted channel name containing a hyphen and a matching `NOTIFY` statement.
- Explain PostgreSQL's lowercase folding for unquoted identifiers and the case-preserving, special-character behavior of double-quoted identifiers.
- Clarify that quoted identifiers can subscribe and receive notifications, but per-channel cleanup is not reliable in either `PGlite` or `PGliteWorker`; use an unquoted identifier when cleanup is required.
- Keep the change documentation-only; no API behavior, source, tests, or changeset are changed.

## 테스트

- `pnpm --dir docs stylecheck`
- `pnpm --dir docs typecheck`
- VitePress Markdown renderer structural check for the quoted `LISTEN`/`NOTIFY` example, the absence of quoted `unlisten()` guidance, and the cleanup limitation
- `git diff --check`
- `pnpm --dir docs build` — blocked before page rendering because this fresh worktree does not contain the generated `packages/pglite/dist/index.js` workspace artifact; a direct `@electric-sql/pglite` import fails at the same missing entry point
