### PR TITLE
Fix useLiveQuery with typed PGlite providers

### DIFF
--- a/.changeset/typed-providers-query.md
+++ b/.changeset/typed-providers-query.md
@@ -1,0 +1,5 @@
+---
+'@electric-sql/pglite-react': patch
+---
+
+Make live query hooks use databases supplied by typed PGlite providers.

--- a/packages/pglite-react/src/provider.tsx
+++ b/packages/pglite-react/src/provider.tsx
@@ -16,11 +16,12 @@ interface PGliteProviderSet<T extends PGliteWithLive> {
   usePGlite: UsePGlite<T>
 }
 
-/**
- * Create a typed set of {@link PGliteProvider} and {@link usePGlite}.
- */
-function makePGliteProvider<T extends PGliteWithLive>(): PGliteProviderSet<T> {
-  const ctx = createContext<T | undefined>(undefined)
+const defaultContext = createContext<PGliteWithLive | undefined>(undefined)
+
+function makePGliteProviderSet<T extends PGliteWithLive>(
+  ctx: React.Context<T | undefined>,
+  bridgeDefaultContext: boolean,
+): PGliteProviderSet<T> {
   return {
     usePGlite: ((db?: T) => {
       const dbProvided = useContext(ctx)
@@ -36,11 +37,28 @@ function makePGliteProvider<T extends PGliteWithLive>(): PGliteProviderSet<T> {
       return dbProvided
     }) as UsePGlite<T>,
     PGliteProvider: ({ children, db }: Props<T>) => {
-      return <ctx.Provider value={db}>{children}</ctx.Provider>
+      const provider = <ctx.Provider value={db}>{children}</ctx.Provider>
+
+      return bridgeDefaultContext ? (
+        <defaultContext.Provider value={db}>{provider}</defaultContext.Provider>
+      ) : (
+        provider
+      )
     },
   }
 }
 
-const { PGliteProvider, usePGlite } = makePGliteProvider<PGliteWithLive>()
+/**
+ * Create a typed set of {@link PGliteProvider} and {@link usePGlite}.
+ */
+function makePGliteProvider<T extends PGliteWithLive>(): PGliteProviderSet<T> {
+  const ctx = createContext<T | undefined>(undefined)
+  return makePGliteProviderSet(ctx, true)
+}
+
+const { PGliteProvider, usePGlite } = makePGliteProviderSet(
+  defaultContext,
+  false,
+)
 
 export { makePGliteProvider, PGliteProvider, usePGlite }

--- a/packages/pglite-react/test/provider.test.tsx
+++ b/packages/pglite-react/test/provider.test.tsx
@@ -1,10 +1,15 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { renderHook } from '@testing-library/react'
 import { waitFor } from '@testing-library/dom'
 import React from 'react'
 import { PGlite } from '@electric-sql/pglite'
 import { live, PGliteWithLive } from '@electric-sql/pglite/live'
-import { makePGliteProvider, PGliteProvider, usePGlite } from '../src'
+import {
+  makePGliteProvider,
+  PGliteProvider,
+  useLiveQuery,
+  usePGlite,
+} from '../src'
 
 describe('provider', () => {
   it('can receive PGlite', async () => {
@@ -39,5 +44,44 @@ describe('provider', () => {
     const { result } = renderHook(() => usePGliteTyped(), { wrapper })
 
     await waitFor(() => expect(result.current).toBe(db))
+  })
+
+  it('makes useLiveQuery available under a typed provider', async () => {
+    const initialResults = {
+      rows: [{ value: 1 }],
+      fields: [{ name: 'value', dataTypeID: 23 }],
+    }
+    const query = vi.fn(
+      (
+        _query: string,
+        _params: unknown[] | undefined | null,
+        callback: (results: typeof initialResults) => void,
+      ) => {
+        callback(initialResults)
+        return Promise.resolve({
+          initialResults,
+          subscribe: vi.fn(),
+          unsubscribe: vi.fn(async () => undefined),
+          refresh: vi.fn(async () => undefined),
+        })
+      },
+    )
+    const db = { live: { query } } as unknown as PGliteWithLive
+    const { PGliteProvider: PGliteProviderTyped } =
+      makePGliteProvider<PGliteWithLive>()
+    const wrapper = ({ children }: { children: React.ReactNode }) => {
+      return <PGliteProviderTyped db={db}>{children}</PGliteProviderTyped>
+    }
+
+    const { result } = renderHook(() => useLiveQuery('SELECT 1 AS value'), {
+      wrapper,
+    })
+
+    await waitFor(() => expect(result.current?.rows).toEqual([{ value: 1 }]))
+    expect(query).toHaveBeenCalledWith(
+      'SELECT 1 AS value',
+      undefined,
+      expect.any(Function),
+    )
   })
 })


### PR DESCRIPTION
## 작업 배경

`makePGliteProvider` creates a typed React context, while `useLiveQuery` reads from the module's default provider context. As a result, live-query hooks throw the missing-provider error even when rendered under a typed provider.

## 티켓 및 링크

- [GH-543](https://github.com/electric-sql/pglite/issues/543)
- Fixes #543

## 작업 내용

- Bridge databases supplied by generated typed providers into the module-default context used by live-query hooks.
- Keep each generated provider's typed context isolated for its paired `usePGlite` hook.
- Add a focused runtime regression and a patch changeset for `@electric-sql/pglite-react`.

## 테스트

- `pnpm --dir packages/pglite-react exec vitest run` (18 passed, 0 type errors)
- `pnpm --dir packages/pglite-react typecheck`
- `pnpm --dir packages/pglite-react stylecheck`
- `git diff --check`
